### PR TITLE
feat(feedback): add About page and in-app feedback modal

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { Flag, Mail } from "lucide-react";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
+import type { FeedbackType } from "@/components/FeedbackDialog";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return { title: "About" };
+}
+
+export default async function AboutPage() {
+  const t = await getTranslations("About");
+
+  const faqItems = [
+    { q: t("faq1Q"), a: t("faq1A") },
+    { q: t("faq2Q"), a: t("faq2A") },
+    { q: t("faq3Q"), a: t("faq3A") },
+    { q: t("faq4Q"), a: t("faq4A") },
+  ];
+
+  const feedbackLinks: {
+    label: string;
+    type: FeedbackType;
+    icon: React.ReactNode;
+  }[] = [
+    { label: t("feedbackReport"), type: "data_issue", icon: <Flag size={13} /> },
+    { label: t("feedbackSuggest"), type: "missing_lens", icon: <Flag size={13} /> },
+    { label: t("feedbackGeneral"), type: "general", icon: <Mail size={13} /> },
+  ];
+
+  return (
+    <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-12 flex flex-col gap-12">
+      <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+        {t("pageTitle")}
+      </h1>
+
+      {/* Background */}
+      <Section title={t("backgroundTitle")}>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+          {t("backgroundBody")}
+        </p>
+      </Section>
+
+      {/* Coverage */}
+      <Section title={t("coverageTitle")}>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+          {t("coverageBody")}
+        </p>
+        <div className="rounded-lg bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 px-4 py-3 mt-1">
+          <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+            {t("coverageBrands")}
+          </p>
+          <p className="text-sm text-zinc-700 dark:text-zinc-300">
+            {t("coverageBrandList")}
+          </p>
+        </div>
+      </Section>
+
+      {/* Data Maintenance */}
+      <Section title={t("dataTitle")}>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+          {t("dataBody")}
+        </p>
+        <p className="text-xs text-zinc-500 dark:text-zinc-500 mt-1">
+          {t("dataVersionNote")}
+        </p>
+      </Section>
+
+      {/* FAQ */}
+      <Section title={t("faqTitle")}>
+        <dl className="flex flex-col gap-5">
+          {faqItems.map((item) => (
+            <div key={item.q}>
+              <dt className="text-sm font-medium text-zinc-800 dark:text-zinc-200 mb-1">
+                {item.q}
+              </dt>
+              <dd className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                {item.a}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </Section>
+
+      {/* Disclaimer */}
+      <Section title={t("disclaimerTitle")}>
+        <div className="rounded-lg bg-amber-50/70 dark:bg-amber-950/20 border border-amber-200/70 dark:border-amber-800/40 px-4 py-3 flex flex-col gap-2">
+          <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+            {t("disclaimerSources")}
+          </p>
+          <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+            {t("disclaimerAccuracy")}
+          </p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-500 mt-1">
+            {t("disclaimerLiability")}
+          </p>
+        </div>
+      </Section>
+
+      {/* Privacy */}
+      <Section title={t("privacyTitle")}>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+          {t("privacyBody")}
+        </p>
+      </Section>
+
+      {/* Changelog */}
+      <Section title={t("changelogTitle")}>
+        <div className="rounded-lg border border-dashed border-zinc-200 dark:border-zinc-800 px-4 py-4">
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            {t("changelogBody")}
+          </p>
+          <p className="text-xs text-zinc-400 dark:text-zinc-600 mt-1">
+            {t("changelogPlaceholder")}
+          </p>
+        </div>
+      </Section>
+
+      {/* Feedback */}
+      <Section title={t("feedbackTitle")}>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          {t("feedbackBody")}
+        </p>
+        <div className="flex flex-col gap-2 mt-1">
+          {feedbackLinks.map(({ label, type: feedbackType, icon }) => (
+            <FeedbackTrigger
+              key={feedbackType}
+              type={feedbackType}
+              className="inline-flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors self-start"
+            >
+              <span className="text-zinc-400 dark:text-zinc-500">{icon}</span>
+              {label}
+            </FeedbackTrigger>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { Flag } from "lucide-react";
 import { allLenses, getLensUrl } from "@/lib/lens";
 import { lensImageStyle } from "@/lib/lens-image";
 import { buildSpecGroups } from "@/lib/lens-spec-groups";
@@ -11,6 +12,7 @@ import { ExternalLink } from "@/components/ui/external-link";
 import { LensPlaceholderIcon } from "@/components/ui/lens-placeholder-icon";
 import { Link } from "@/i18n/navigation";
 import AddToCompareButton from "@/components/AddToCompareButton";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
 
@@ -227,16 +229,26 @@ export default async function LensDetailPage({ params }: { params: Params }) {
           </div>
 
           {/* Actions */}
-          <div className="flex flex-wrap gap-3">
-            <AddToCompareButton lensId={lens.id} />
-            {url && (
-              <ExternalLink
-                href={url}
-                className="inline-flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
-              >
-                {t("officialSite")}
-              </ExternalLink>
-            )}
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-3">
+              <AddToCompareButton lensId={lens.id} />
+              {url && (
+                <ExternalLink
+                  href={url}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+                >
+                  {t("officialSite")}
+                </ExternalLink>
+              )}
+            </div>
+            <FeedbackTrigger
+              type="data_issue"
+              context={{ lensId: lens.id, lensModel: lens.model }}
+              className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors self-start"
+            >
+              <Flag size={11} />
+              {t("reportIssue")}
+            </FeedbackTrigger>
           </div>
 
           {/* Grouped spec table */}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+
+type FeedbackType = "data_issue" | "missing_lens" | "general";
+
+interface FeedbackPayload {
+  type: FeedbackType;
+  description: string;
+  context?: {
+    lensId?: string;
+    lensModel?: string;
+    searchQuery?: string;
+  };
+}
+
+const MAX_DESCRIPTION_LENGTH = 2000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  bucket.count += 1;
+  return true;
+}
+
+function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+function buildIssue(payload: FeedbackPayload): {
+  title: string;
+  body: string;
+  labels: string[];
+} {
+  const { type, description, context } = payload;
+  const lines: string[] = [];
+
+  if (type === "data_issue") {
+    lines.push(`**Type:** Data issue`);
+    if (context?.lensModel) {
+      lines.push(`**Lens:** ${context.lensModel}`);
+    }
+    if (context?.lensId) {
+      lines.push(`**Lens ID:** \`${context.lensId}\``);
+    }
+  } else if (type === "missing_lens") {
+    lines.push(`**Type:** Missing lens`);
+    if (context?.searchQuery) {
+      lines.push(`**Search query:** \`${context.searchQuery}\``);
+    }
+  } else {
+    lines.push(`**Type:** General feedback`);
+  }
+
+  lines.push("", "---", "", description);
+
+  let title: string;
+  if (type === "data_issue") {
+    title = context?.lensModel
+      ? `[Data] ${context.lensModel}`
+      : `[Data] Data issue report`;
+  } else if (type === "missing_lens") {
+    title = context?.searchQuery
+      ? `[Missing] ${context.searchQuery}`
+      : `[Missing] Missing lens suggestion`;
+  } else {
+    title = `[Feedback] General feedback`;
+  }
+
+  const labels = ["user-feedback", `feedback:${type}`];
+
+  return { title, body: lines.join("\n"), labels };
+}
+
+export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json(
+      { error: "rate_limited" },
+      { status: 429 }
+    );
+  }
+
+  let payload: FeedbackPayload;
+  try {
+    payload = (await req.json()) as FeedbackPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const validTypes: FeedbackType[] = ["data_issue", "missing_lens", "general"];
+  if (!payload?.type || !validTypes.includes(payload.type)) {
+    return NextResponse.json({ error: "invalid_type" }, { status: 400 });
+  }
+  if (
+    typeof payload.description !== "string" ||
+    payload.description.trim().length === 0
+  ) {
+    return NextResponse.json({ error: "empty_description" }, { status: 400 });
+  }
+  if (payload.description.length > MAX_DESCRIPTION_LENGTH) {
+    return NextResponse.json(
+      { error: "description_too_long" },
+      { status: 400 }
+    );
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_FEEDBACK_REPO;
+  if (!token || !repo) {
+    console.error("[feedback] missing GITHUB_TOKEN or GITHUB_FEEDBACK_REPO");
+    return NextResponse.json(
+      { error: "server_misconfigured" },
+      { status: 500 }
+    );
+  }
+
+  const issue = buildIssue(payload);
+
+  const ghRes = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(issue),
+  });
+
+  if (!ghRes.ok) {
+    const errText = await ghRes.text().catch(() => "");
+    console.error("[feedback] GitHub API error", ghRes.status, errText);
+    return NextResponse.json(
+      { error: "github_api_error" },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -27,12 +27,13 @@ import {
   useSortable,
   arrayMove,
 } from "@dnd-kit/sortable";
-import { GripVertical, X } from "lucide-react";
+import { Flag, GripVertical, X } from "lucide-react";
 import { LensPlaceholderIcon } from "@/components/ui/lens-placeholder-icon";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
 import { useRouter } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/LensSearchDialog";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
 import { useCompare } from "@/context/CompareProvider";
 import { MAX_COMPARE, allLenses, getLensUrl } from "@/lib/lens";
 import { lensImageStyle } from "@/lib/lens-image";
@@ -45,9 +46,11 @@ import type { Lens } from "@/lib/types";
 function LensHeaderContent({
   lens,
   officialSiteLabel,
+  reportLabel,
 }: {
   lens: Lens;
   officialSiteLabel: string;
+  reportLabel: string;
 }) {
   const tBrand = useTranslations("Brands");
   const url = getLensUrl(lens);
@@ -78,16 +81,27 @@ function LensHeaderContent({
       <p className="text-center font-semibold leading-snug text-zinc-900 dark:text-zinc-50">
         {lens.model}
       </p>
-      {url && (
-        <ExternalLink
-          href={url}
-          onClick={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-          className="mt-2 inline-flex items-center gap-1 self-center text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+      <div className="mt-2 flex items-center justify-center gap-3">
+        {url && (
+          <ExternalLink
+            href={url}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="inline-flex items-center gap-1 text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            {officialSiteLabel}
+          </ExternalLink>
+        )}
+        <FeedbackTrigger
+          type="data_issue"
+          context={{ lensId: lens.id, lensModel: lens.model }}
+          stopPropagation
+          className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
         >
-          {officialSiteLabel}
-        </ExternalLink>
-      )}
+          <Flag className="h-3 w-3" />
+          {reportLabel}
+        </FeedbackTrigger>
+      </div>
     </>
   );
 }
@@ -97,11 +111,13 @@ function LensHeaderContent({
 function SortableLensHeader({
   lens,
   officialSiteLabel,
+  reportLabel,
   removeLabel,
   onRemove,
 }: {
   lens: Lens;
   officialSiteLabel: string;
+  reportLabel: string;
   removeLabel: string;
   onRemove: () => void;
 }) {
@@ -133,7 +149,11 @@ function SortableLensHeader({
         </div>
       </div>
       <div className="mt-1 flex flex-col items-center text-center">
-        <LensHeaderContent lens={lens} officialSiteLabel={officialSiteLabel} />
+        <LensHeaderContent
+          lens={lens}
+          officialSiteLabel={officialSiteLabel}
+          reportLabel={reportLabel}
+        />
       </div>
     </th>
   );
@@ -177,11 +197,13 @@ function ColumnOverlay({
   lens,
   visibleGroups,
   officialSiteLabel,
+  reportLabel,
   valueCellLabels,
 }: {
   lens: Lens;
   visibleGroups: SpecGroup[];
   officialSiteLabel: string;
+  reportLabel: string;
   valueCellLabels: { yes: string; no: string; unknown: string; missing: string };
 }) {
   function renderRowValue(row: SpecRow) {
@@ -218,7 +240,11 @@ function ColumnOverlay({
         <div className="flex justify-end mb-1">
           <GripVertical className="w-4 h-4 text-zinc-400 dark:text-zinc-500" />
         </div>
-        <LensHeaderContent lens={lens} officialSiteLabel={officialSiteLabel} />
+        <LensHeaderContent
+          lens={lens}
+          officialSiteLabel={officialSiteLabel}
+          reportLabel={reportLabel}
+        />
       </div>
 
       {visibleGroups.map((group) => (
@@ -454,6 +480,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
                     key={lens.id}
                     lens={lens}
                     officialSiteLabel={t("officialSite")}
+                    reportLabel={td("reportIssue")}
                     removeLabel={t("removeLens", { model: lens.model })}
                     onRemove={() => handleRemoveLens(lens.id)}
                   />
@@ -729,6 +756,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
               lens={activeLens}
               visibleGroups={visibleGroups}
               officialSiteLabel={t("officialSite")}
+              reportLabel={td("reportIssue")}
               valueCellLabels={valueCellLabels}
             />
           )}

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export type FeedbackType = "data_issue" | "missing_lens" | "general";
+
+export interface FeedbackContext {
+  lensId?: string;
+  lensModel?: string;
+  searchQuery?: string;
+}
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  type: FeedbackType;
+  context?: FeedbackContext;
+}
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export default function FeedbackDialog({
+  open,
+  onOpenChange,
+  type,
+  context,
+}: FeedbackDialogProps) {
+  const t = useTranslations("Feedback");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const textareaId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      setDescription("");
+      setStatus("idle");
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  const titleKey =
+    type === "data_issue"
+      ? "titleDataIssue"
+      : type === "missing_lens"
+        ? "titleMissingLens"
+        : "titleGeneral";
+  const descriptionKey =
+    type === "data_issue"
+      ? "descriptionDataIssue"
+      : type === "missing_lens"
+        ? "descriptionMissingLens"
+        : "descriptionGeneral";
+
+  const contextLine =
+    type === "data_issue" && context?.lensModel
+      ? t("contextLens", { model: context.lensModel })
+      : type === "missing_lens" && context?.searchQuery
+        ? t("contextQuery", { query: context.searchQuery })
+        : null;
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (description.trim().length === 0 || status === "submitting") {
+      return;
+    }
+
+    setStatus("submitting");
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          description: description.trim(),
+          context: context ?? {},
+        }),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(data?.error ?? "request_failed");
+      }
+
+      setStatus("success");
+    } catch (err) {
+      setStatus("error");
+      setErrorMessage(err instanceof Error ? err.message : "unknown");
+    }
+  }
+
+  const canSubmit = description.trim().length > 0 && status !== "submitting";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t(titleKey)}</DialogTitle>
+          <DialogDescription>{t(descriptionKey)}</DialogDescription>
+        </DialogHeader>
+
+        {status === "success" ? (
+          <div className="px-5 py-6 text-sm text-zinc-700 dark:text-zinc-300">
+            {t("success")}
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-2">
+            {contextLine && (
+              <div className="rounded-lg bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 px-3 py-2 text-xs text-zinc-600 dark:text-zinc-400">
+                {contextLine}
+              </div>
+            )}
+            <label
+              htmlFor={textareaId}
+              className="text-xs font-medium text-zinc-600 dark:text-zinc-400"
+            >
+              {t("descriptionLabel")}
+            </label>
+            <textarea
+              id={textareaId}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("descriptionPlaceholder")}
+              rows={5}
+              maxLength={2000}
+              required
+              className="w-full resize-none rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600"
+            />
+            {status === "error" && (
+              <p className="text-xs text-red-600 dark:text-red-400">
+                {t("error")}
+                {errorMessage ? ` (${errorMessage})` : ""}
+              </p>
+            )}
+          </form>
+        )}
+
+        <DialogFooter>
+          {status === "success" ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              {t("close")}
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+              >
+                {status === "submitting" ? t("submitting") : t("submit")}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/FeedbackTrigger.tsx
+++ b/src/components/FeedbackTrigger.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import FeedbackDialog, {
+  type FeedbackContext,
+  type FeedbackType,
+} from "./FeedbackDialog";
+
+interface FeedbackTriggerProps {
+  type: FeedbackType;
+  context?: FeedbackContext;
+  className?: string;
+  children: ReactNode;
+  stopPropagation?: boolean;
+}
+
+export default function FeedbackTrigger({
+  type,
+  context,
+  className,
+  children,
+  stopPropagation = false,
+}: FeedbackTriggerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          if (stopPropagation) {
+            e.stopPropagation();
+          }
+          setOpen(true);
+        }}
+        onPointerDown={(e) => {
+          if (stopPropagation) {
+            e.stopPropagation();
+          }
+        }}
+        className={className}
+      >
+        {children}
+      </button>
+      <FeedbackDialog
+        open={open}
+        onOpenChange={setOpen}
+        type={type}
+        context={context}
+      />
+    </>
+  );
+}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
+import FeedbackTrigger from "./FeedbackTrigger";
 
 interface Props {
   lenses: Lens[];
@@ -161,9 +162,20 @@ export default function LensListClient({ lenses }: Props) {
         </div>
 
         {displayed.length === 0 ? (
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">
-            {t("noResults")}
-          </p>
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              {t("noResults")}
+            </p>
+            <p className="text-xs text-zinc-400 dark:text-zinc-500">
+              {t("suggestLens")}{" "}
+              <FeedbackTrigger
+                type="missing_lens"
+                className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              >
+                {t("suggestLensLink")}
+              </FeedbackTrigger>
+            </p>
+          </div>
         ) : (
           <div
             {...hookAttr("grid")}

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -23,6 +23,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import FeedbackTrigger from "./FeedbackTrigger";
 
 interface LensSearchResultState {
   actionLabel?: string;
@@ -196,6 +197,16 @@ export default function LensSearchDialog({
                 </p>
                 <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
                   {t("noResultsHint")}
+                </p>
+                <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
+                  {t("suggestLens")}{" "}
+                  <FeedbackTrigger
+                    type="missing_lens"
+                    context={{ searchQuery: deferredQuery.trim() }}
+                    className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                  >
+                    {t("suggestLensLink")}
+                  </FeedbackTrigger>
                 </p>
               </div>
             ) : (

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -28,6 +28,16 @@ export default function Nav() {
           >
             {t("lenses")}
           </Link>
+          <Link
+            href="/about"
+            className={`text-sm transition-colors ${
+              pathname === "/about"
+                ? "text-zinc-900 dark:text-zinc-50 font-medium"
+                : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50"
+            }`}
+          >
+            {t("about")}
+          </Link>
           <LensSearchDialog />
         </div>
       </nav>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -5,6 +5,7 @@
   },
   "Nav": {
     "lenses": "Lenses",
+    "about": "About",
     "compare": "Compare",
     "search": "Search"
   },
@@ -23,6 +24,8 @@
     "emptyDescription": "Auto-suggest will appear as soon as you enter a few characters.",
     "noResults": "No matching lenses found",
     "noResultsHint": "Try a shorter model fragment, brand name, or series keyword.",
+    "suggestLens": "Don't see the lens you're looking for?",
+    "suggestLensLink": "Tell us",
     "results": "Lens search results",
     "view": "Open",
     "generation": "Gen {value}"
@@ -103,6 +106,8 @@
     "clearCompare": "Clear",
     "resultsCount": "{count} lenses",
     "noResults": "No lenses match your filters.",
+    "suggestLens": "Can't find the lens you're looking for?",
+    "suggestLensLink": "Tell us",
     "equivSuffix": "eq."
   },
   "LensDetail": {
@@ -169,6 +174,7 @@
     "addToCompare": "Add to Compare",
     "removeFromCompare": "Remove",
     "officialSite": "Official site",
+    "reportIssue": "Report an issue",
     "notFound": "Lens not found."
   },
   "Brands": {
@@ -231,8 +237,69 @@
     "download": "Download PNG",
     "close": "Close"
   },
+  "About": {
+    "pageTitle": "About X Glass",
+
+    "backgroundTitle": "Background",
+    "backgroundBody": "X Glass is an independent tool for browsing and comparing Fujifilm X-mount lenses across all brands. It was built to fill a gap: no single tool offered a unified, cross-brand X-mount database with interactive side-by-side comparison.",
+
+    "coverageTitle": "Lens Coverage",
+    "coverageBody": "X Glass covers all commercially available lenses natively compatible with the Fujifilm X-mount, including Fujifilm's own XF, XC, and MK series, as well as third-party brands. Multiple generations of the same focal length are listed separately. Adapted lenses from other mounts are out of scope.",
+    "coverageBrands": "Currently indexed brands",
+    "coverageBrandList": "Fujifilm · Sigma · Tamron · Viltrox · TTArtisan · 7Artisans · Brightin Star · SG Image",
+
+    "dataTitle": "Data Maintenance",
+    "dataBody": "Lens data is collected and structured through an automated pipeline, with human review before each release. Updates are published when new lenses launch or when corrections are made.",
+    "dataVersionNote": "The version number and last-updated timestamp in the footer reflect the most recent data release.",
+
+    "faqTitle": "FAQ",
+    "faq1Q": "A lens I'm looking for isn't here. Why?",
+    "faq1A": "We aim for complete X-mount coverage, but the database grows incrementally and some lenses may not have been added yet. Use the feedback links at the bottom of this page to suggest a missing lens — that's the fastest way to get it on our radar.",
+    "faq2Q": "A spec doesn't match the manufacturer's page. Which is correct?",
+    "faq2A": "Always treat the manufacturer's official page as the source of truth. Our data may contain errors or lag behind spec revisions. If you spot a discrepancy, use the \"Report an issue\" link on the lens detail page.",
+    "faq3Q": "Is X Glass affiliated with Fujifilm or any lens brand?",
+    "faq3A": "No. X Glass is an independent project with no affiliation to Fujifilm or any other manufacturer. Lens names and brand marks are the property of their respective owners.",
+    "faq4Q": "Why do some fields show \"—\"?",
+    "faq4A": "A dash means the data hasn't been collected yet, or the manufacturer hasn't publicly disclosed that spec. We continuously work to fill in gaps.",
+
+    "disclaimerTitle": "Disclaimer & Data Sources",
+    "disclaimerSources": "Specifications are sourced primarily from manufacturer official websites and product pages.",
+    "disclaimerAccuracy": "Data may contain errors and specs can change without notice. Always verify critical specifications directly with the manufacturer before making a purchase decision.",
+    "disclaimerLiability": "X Glass is not responsible for any decisions made based on information presented here.",
+
+    "privacyTitle": "Privacy",
+    "privacyBody": "X Glass does not require user accounts and does not collect personal information.",
+
+    "changelogTitle": "Changelog",
+    "changelogBody": "A public changelog tracking data updates and corrections is planned.",
+    "changelogPlaceholder": "Coming soon",
+
+    "feedbackTitle": "Feedback & Contact",
+    "feedbackBody": "Spotted incorrect data or a missing lens? Reports go directly to the maintainer.",
+    "feedbackReport": "Report a data issue",
+    "feedbackSuggest": "Suggest a missing lens",
+    "feedbackGeneral": "General feedback"
+  },
   "Footer": {
     "dataInfo": "Data · {lensCount} lenses ·",
     "updatedPrefix": "Updated"
+  },
+  "Feedback": {
+    "titleDataIssue": "Report a data issue",
+    "titleMissingLens": "Suggest a missing lens",
+    "titleGeneral": "Send feedback",
+    "descriptionDataIssue": "Tell us what's wrong — wrong spec, broken image, typo, anything. It goes straight to the maintainer.",
+    "descriptionMissingLens": "Know an X-mount lens we're missing? Let us know and we'll add it to the queue.",
+    "descriptionGeneral": "Thoughts, bug reports, feature ideas — all welcome.",
+    "contextLens": "About: {model}",
+    "contextQuery": "Search query: {query}",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Describe the issue in as much detail as you like…",
+    "submit": "Submit",
+    "submitting": "Submitting…",
+    "cancel": "Cancel",
+    "close": "Close",
+    "success": "Thanks — your feedback was received. We'll take a look shortly.",
+    "error": "Something went wrong. Please try again in a moment."
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -5,6 +5,7 @@
   },
   "Nav": {
     "lenses": "镜头列表",
+    "about": "关于",
     "compare": "对比",
     "search": "搜索"
   },
@@ -23,6 +24,8 @@
     "emptyDescription": "输入几个字符后，就会自动出现建议结果。",
     "noResults": "没有找到匹配的镜头",
     "noResultsHint": "可以试试更短的型号片段、品牌名或系列关键词。",
+    "suggestLens": "没有找到你想要的镜头？",
+    "suggestLensLink": "告诉我们",
     "results": "镜头搜索结果",
     "view": "打开",
     "generation": "第 {value} 代"
@@ -103,6 +106,8 @@
     "clearCompare": "清空",
     "resultsCount": "共 {count} 款",
     "noResults": "没有符合条件的镜头。",
+    "suggestLens": "没有找到你想要的镜头？",
+    "suggestLensLink": "告诉我们",
     "equivSuffix": "等效"
   },
   "LensDetail": {
@@ -169,6 +174,7 @@
     "addToCompare": "加入对比",
     "removeFromCompare": "移除",
     "officialSite": "官网",
+    "reportIssue": "反馈数据问题",
     "notFound": "未找到该镜头。"
   },
   "Brands": {
@@ -230,8 +236,69 @@
     "download": "下载 PNG",
     "close": "关闭"
   },
+  "About": {
+    "pageTitle": "关于 X Glass",
+
+    "backgroundTitle": "项目背景",
+    "backgroundBody": "X Glass 是一个独立开发的富士 X 卡口镜头浏览与对比工具。它的诞生是为了填补一个空白：目前没有任何工具能够跨品牌、统一地收录 X 卡口镜头，并提供交互式并排对比功能。",
+
+    "coverageTitle": "收录范围",
+    "coverageBody": "X Glass 收录所有与富士 X 卡口原生兼容的在售镜头，包括富士自家的 XF、XC、MK 系列，以及各第三方品牌。同焦段的多代版本均独立收录。转接其他卡口的镜头不在收录范围内。",
+    "coverageBrands": "当前收录品牌",
+    "coverageBrandList": "富士 · 适马 · 腾龙 · 唯卓仕 · 铭匠光学 · 七工匠 · 星耀光学 · 深光影像",
+
+    "dataTitle": "数据维护",
+    "dataBody": "镜头数据通过自动化 Pipeline 采集和结构化处理，每次发布前均经过人工审阅。新镜头上市或发现数据错误时会推送更新。",
+    "dataVersionNote": "页面底部显示的版本号和更新时间反映的是最近一次数据发布的状态。",
+
+    "faqTitle": "常见问题",
+    "faq1Q": "我找的镜头不在列表里，为什么？",
+    "faq1A": "我们的目标是覆盖所有 X 卡口镜头，但数据库持续扩充中，部分镜头可能尚未录入。可以使用页面底部的反馈链接推荐缺失镜头，这是最快的方式。",
+    "faq2Q": "某个参数和厂商官网不一致，以哪个为准？",
+    "faq2A": "请以厂商官网为准。我们的数据可能存在错误或尚未同步最新规格。如果发现差异，请使用镜头详情页的「反馈数据问题」链接告知我们。",
+    "faq3Q": "X Glass 和富士或其他品牌有关系吗？",
+    "faq3A": "没有。X Glass 是完全独立的个人项目，与富士或任何镜头厂商均无关联。镜头名称和品牌标识归各自所有者所有。",
+    "faq4Q": "为什么有些字段显示「—」？",
+    "faq4A": "「—」表示该数据尚未采集，或厂商未公开该规格。我们会持续填补空缺。",
+
+    "disclaimerTitle": "免责声明与数据来源",
+    "disclaimerSources": "规格数据主要来源于厂商官方网站和产品页面。",
+    "disclaimerAccuracy": "数据可能存在错误，规格亦可能在未通知的情况下变更。购买前请直接向厂商核实关键规格。",
+    "disclaimerLiability": "X Glass 不对基于本站信息所做的任何决定承担责任。",
+
+    "privacyTitle": "隐私",
+    "privacyBody": "X Glass 不要求用户注册，也不收集任何个人信息。",
+
+    "changelogTitle": "更新日志",
+    "changelogBody": "我们计划提供公开的数据更新和修正记录。",
+    "changelogPlaceholder": "即将推出",
+
+    "feedbackTitle": "反馈与联系",
+    "feedbackBody": "发现数据有误或想推荐缺失的镜头？你的反馈会直接送达维护者。",
+    "feedbackReport": "反馈数据问题",
+    "feedbackSuggest": "推荐缺失镜头",
+    "feedbackGeneral": "其他反馈"
+  },
   "Footer": {
     "dataInfo": "数据 · {lensCount} 款镜头 ·",
     "updatedPrefix": "更新于"
+  },
+  "Feedback": {
+    "titleDataIssue": "反馈数据问题",
+    "titleMissingLens": "推荐缺失镜头",
+    "titleGeneral": "发送反馈",
+    "descriptionDataIssue": "参数错误、图片损坏、文字错别字，任何问题都可以告诉我们。反馈会直接送达维护者。",
+    "descriptionMissingLens": "发现我们漏收录的 X 卡口镜头？告诉我们，我们会加入处理队列。",
+    "descriptionGeneral": "想法、Bug 报告、功能建议，都欢迎。",
+    "contextLens": "关于：{model}",
+    "contextQuery": "搜索词：{query}",
+    "descriptionLabel": "描述",
+    "descriptionPlaceholder": "尽量详细描述一下问题…",
+    "submit": "提交",
+    "submitting": "提交中…",
+    "cancel": "取消",
+    "close": "关闭",
+    "success": "感谢反馈！我们已收到，稍后会查看。",
+    "error": "提交出错了，请稍后再试。"
   }
 }


### PR DESCRIPTION
Introduces a user-facing feedback flow so data issues and missing-lens suggestions can be submitted without a mail client:

- About page at /about with background, coverage, data, FAQ, disclaimer, privacy, changelog, and feedback sections; Nav entry added
- FeedbackDialog + FeedbackTrigger components (shadcn Dialog) wired to a new /api/feedback route that forwards submissions to GitHub Issues in the pipeline repo (anonymous, in-memory IP rate limit)
- Entry points: detail page report link, compare table per-lens header, About page (3 types), lens list empty state, search dialog empty state

Requires GITHUB_TOKEN and GITHUB_FEEDBACK_REPO env vars.