### PR TITLE
feat(compare): UX improvements — share FAB, section labels, bool indicators, footer

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -54,16 +54,25 @@ function StructuredLines({ lines }: { lines: StructuredLine[] }) {
 function renderRowValue(
   row: SpecRow,
   lens: Lens,
-  labels: { yes: string; no: string; unknown: string; missing: string }
+  labels: { yes: string; no: string; partial: string; unknown: string; missing: string }
 ) {
   if (row.kind === "bool") {
+    const subVal = row.getSubValue?.(lens);
     return (
-      <BoolCell
-        value={row.getValue(lens)}
-        yes={labels.yes}
-        no={labels.no}
-        unknown={labels.unknown}
-      />
+      <div>
+        <BoolCell
+          value={row.getValue(lens)}
+          yes={labels.yes}
+          no={labels.no}
+          partial={labels.partial}
+          unknown={labels.unknown}
+        />
+        {subVal && (
+          <p className="mt-0.5 text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
+            {subVal}
+          </p>
+        )}
+      </div>
     );
   }
   const structuredLines = row.kind === "numeric" ? row.getStructuredLines?.(lens) : undefined;
@@ -184,6 +193,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   const valueCellLabels = {
     yes: t("yes"),
     no: t("no"),
+    partial: t("partial"),
     unknown: t("unknown"),
     missing: t("missing"),
   };
@@ -197,9 +207,11 @@ export default async function LensDetailPage({ params }: { params: Params }) {
         currentValue =
           v === true
             ? valueCellLabels.yes
-            : v === false
-              ? valueCellLabels.no
-              : valueCellLabels.unknown;
+            : v === "partial"
+              ? valueCellLabels.partial
+              : v === false
+                ? valueCellLabels.no
+                : valueCellLabels.unknown;
       } else {
         currentValue = row.getDisplayValue(lens) ?? undefined;
       }

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -3,7 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { parseLensIds } from "@/lib/lens";
 import { Link } from "@/i18n/navigation";
 import CompareTable from "@/components/CompareTable";
-import { ShareButton } from "@/components/ShareButton";
+import ComparePageHeader from "@/components/ComparePageHeader";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
 
 export async function generateMetadata({
@@ -49,21 +49,7 @@ export default async function ComparePage({
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          href="/lenses"
-          className="text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-        >
-          ←
-        </Link>
-        <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-          {t("title")}
-        </h1>
-        <CompareAddLensButton lenses={lenses} />
-        <div className="ml-auto">
-          <ShareButton lenses={lenses} />
-        </div>
-      </div>
+      <ComparePageHeader lenses={lenses} />
 
       {lenses.length < 2 ? (
         <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-200">
@@ -72,6 +58,12 @@ export default async function ComparePage({
       ) : null}
 
       <CompareTable lenses={lenses} />
+
+      {/* Bottom add-lens entry — visible when scrolled to bottom of a long table */}
+      <CompareAddLensButton
+        lenses={lenses}
+        triggerClassName="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-300 py-3 text-sm text-zinc-500 transition-colors hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-300"
+      />
 
       {/* Back link */}
       <Link

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -9,9 +9,10 @@ import type { Lens } from "@/lib/types";
 
 interface Props {
   lenses: Lens[];
+  triggerClassName?: string;
 }
 
-export default function CompareAddLensButton({ lenses }: Props) {
+export default function CompareAddLensButton({ lenses, triggerClassName }: Props) {
   const t = useTranslations("Compare");
   const router = useRouter();
 
@@ -49,7 +50,7 @@ export default function CompareAddLensButton({ lenses }: Props) {
       getResultState={getResultState}
       triggerVariant="button"
       triggerLabel={t("addLens")}
-      triggerClassName="h-9 whitespace-nowrap rounded-full border border-zinc-300 bg-white px-3.5 text-sm text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-900"
+      triggerClassName={triggerClassName ?? "h-9 whitespace-nowrap rounded-full border border-zinc-300 bg-white px-3.5 text-sm text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-900"}
     />
   );
 }

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { ShareButton } from "@/components/ShareButton";
+import CompareAddLensButton from "@/components/CompareAddLensButton";
+import type { Lens } from "@/lib/types";
+
+interface Props {
+  lenses: Lens[];
+}
+
+export default function ComparePageHeader({ lenses }: Props) {
+  const t = useTranslations("Compare");
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [showFab, setShowFab] = useState(false);
+
+  // Show the FAB when the header row scrolls behind the nav bar
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowFab(!entry.isIntersecting),
+      // Shrink the root rect by the nav height (56px) so the FAB appears
+      // as soon as the header disappears behind the nav, not the viewport top
+      { rootMargin: "-56px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <>
+      <div ref={headerRef} className="flex items-center gap-3">
+        <Link
+          href="/lenses"
+          className="text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+        >
+          ←
+        </Link>
+        <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+          {t("title")}
+        </h1>
+        <CompareAddLensButton lenses={lenses} />
+        <div className="ml-auto">
+          <ShareButton lenses={lenses} />
+        </div>
+      </div>
+
+      {/* Floating share FAB — slides up when the header share button is out of view */}
+      <div
+        className={`fixed bottom-6 right-4 z-40 transition-all duration-200 sm:right-6 ${
+          showFab
+            ? "opacity-100 translate-y-0 pointer-events-auto"
+            : "opacity-0 translate-y-3 pointer-events-none"
+        }`}
+        aria-hidden={!showFab}
+      >
+        <ShareButton lenses={lenses} variant="fab" />
+      </div>
+    </>
+  );
+}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -370,7 +370,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
               <div
                 key={lens.id}
                 style={{ width: colWidths[i + 1], flexShrink: 0 }}
-                className="border-l border-zinc-200 px-2 py-1.5 text-center dark:border-zinc-800"
+                className="px-2 py-1.5 text-center"
               >
                 <p className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">
                   {tBrand(lens.brand)}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -651,9 +651,12 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
               </React.Fragment>
             );
           })}
+        </tbody>
+
+        <tfoot>
           {/* Footer row: official site + report links per lens */}
-          <tr className="border-t border-zinc-200 dark:border-zinc-800">
-            <td className="sticky left-0 z-10 bg-zinc-50 px-3 py-2 dark:bg-zinc-900" />
+          <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
+            <td className="sticky left-0 z-10 bg-zinc-100/80 px-3 py-2 dark:bg-zinc-800/60" />
             {orderedLenses.map((lens) => {
               const url = getLensUrl(lens);
               const fields = lensFields.get(lens.id);
@@ -682,7 +685,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
               );
             })}
           </tr>
-        </tbody>
+        </tfoot>
       </table>
     </div>
     </>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -427,17 +427,14 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
           {visibleGroups.map((group) => {
             return (
               <React.Fragment key={group.label}>
-                {/* Group header row.
-                    sticky on a colSpan <td> is unreliable in WebKit/Blink,
-                    so we keep the td unstyled (full-row background via row bg)
-                    and use a sticky inner div anchored just past the label column. */}
+                {/* Group header row: sticky anchor cell holds the label column,
+                    content cell spans the lens columns and centers the label. */}
                 <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                  <td colSpan={totalColSpan} className="py-2">
-                    <div className="sticky left-24 inline-block px-3">
-                      <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                        {group.label}
-                      </span>
-                    </div>
+                  <td className="sticky left-0 z-10 bg-zinc-100/80 dark:bg-zinc-800/60" />
+                  <td colSpan={orderedLenses.length} className="py-2 text-center">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                      {group.label}
+                    </span>
                   </td>
                 </tr>
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -325,14 +325,10 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
     if (!container || !thead) return;
 
     const updateSectionCenter = () => {
-      // Center of the visible content pane (everything right of the sticky label
-      // column), expressed as a position in table coordinate space so that
-      // absolutely-positioned section labels always appear in the middle of the
-      // non-sticky viewport area regardless of horizontal scroll.
-      const firstTh = thead.querySelector("th");
-      const labelColW = firstTh ? firstTh.offsetWidth : 96;
-      const center =
-        container.scrollLeft + labelColW + (container.clientWidth - labelColW) / 2;
+      // Center of the full visible viewport, expressed as a position in table
+      // coordinate space so that absolutely-positioned section labels stay locked
+      // to the midpoint of the screen regardless of horizontal scroll.
+      const center = container.scrollLeft + container.clientWidth / 2;
       container.style.setProperty("--section-center", `${center}px`);
     };
 
@@ -358,11 +354,8 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
       if (phantomInnerRef.current) {
         phantomInnerRef.current.style.transform = `translateX(-${container.scrollLeft}px)`;
       }
-      // Keep section labels centered in the visible content pane
-      const firstTh = thead.querySelector("th");
-      const labelColW = firstTh ? firstTh.offsetWidth : 96;
-      const center =
-        container.scrollLeft + labelColW + (container.clientWidth - labelColW) / 2;
+      // Keep section labels centered in the full visible viewport
+      const center = container.scrollLeft + container.clientWidth / 2;
       container.style.setProperty("--section-center", `${center}px`);
     };
     container.addEventListener("scroll", onScroll, { passive: true });

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -424,15 +424,17 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
           {visibleGroups.map((group) => {
             return (
               <React.Fragment key={group.label}>
-                {/* Group header row */}
-                <tr className="border-b border-zinc-100 dark:border-zinc-800/60">
-                  <td
-                    colSpan={totalColSpan}
-                    className="sticky left-0 z-10 px-4 py-2 bg-zinc-100/80 dark:bg-zinc-800/60"
-                  >
-                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                      {group.label}
-                    </span>
+                {/* Group header row.
+                    sticky on a colSpan <td> is unreliable in WebKit/Blink,
+                    so we keep the td unstyled (full-row background via row bg)
+                    and use a sticky inner div anchored just past the label column. */}
+                <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
+                  <td colSpan={totalColSpan} className="py-2">
+                    <div className="sticky left-24 inline-block px-3">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                        {group.label}
+                      </span>
+                    </div>
                   </td>
                 </tr>
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -698,7 +698,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
         <tfoot>
           {/* Footer row: official site + report links per lens */}
           <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
-            <td className="sticky left-0 z-10 bg-zinc-100/80 px-3 py-2 dark:bg-zinc-800/60" />
+            <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
             {orderedLenses.map((lens) => {
               const url = getLensUrl(lens);
               const fields = lensFields.get(lens.id);

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -158,6 +158,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
   const valueCellLabels = {
     yes: td("yes"),
     no: td("no"),
+    partial: td("partial"),
     unknown: td("unknown"),
     missing: td("missing"),
   };
@@ -283,9 +284,11 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
             currentValue =
               v === true
                 ? valueCellLabels.yes
-                : v === false
-                  ? valueCellLabels.no
-                  : valueCellLabels.unknown;
+                : v === "partial"
+                  ? valueCellLabels.partial
+                  : v === false
+                    ? valueCellLabels.no
+                    : valueCellLabels.unknown;
           } else {
             currentValue = row.getDisplayValue(lens) ?? undefined;
           }
@@ -471,18 +474,27 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
                           row.getNote?.(lens);
 
                         if (row.kind === "bool") {
+                          const subVal = row.getSubValue?.(lens);
                           return (
                             <td
                               key={lens.id}
                               className="px-3 py-3 text-center text-zinc-700 dark:text-zinc-300"
                             >
                               <div className="flex items-center justify-center gap-1">
-                                <BoolCell
-                                  value={row.getValue(lens)}
-                                  yes={valueCellLabels.yes}
-                                  no={valueCellLabels.no}
-                                  unknown={valueCellLabels.unknown}
-                                />
+                                <div>
+                                  <BoolCell
+                                    value={row.getValue(lens)}
+                                    yes={valueCellLabels.yes}
+                                    no={valueCellLabels.no}
+                                    partial={valueCellLabels.partial}
+                                    unknown={valueCellLabels.unknown}
+                                  />
+                                  {subVal && (
+                                    <p className="mt-0.5 text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
+                                      {subVal}
+                                    </p>
+                                  )}
+                                </div>
                                 {fieldNote && (
                                   <FieldNotePopover note={fieldNote} />
                                 )}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -323,12 +323,26 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
     const container = containerRef.current;
     const thead = theadRef.current;
     if (!container || !thead) return;
+
+    const updateSectionCenter = () => {
+      // Center of the visible content pane (everything right of the sticky label
+      // column), expressed as a position in table coordinate space so that
+      // absolutely-positioned section labels always appear in the middle of the
+      // non-sticky viewport area regardless of horizontal scroll.
+      const firstTh = thead.querySelector("th");
+      const labelColW = firstTh ? firstTh.offsetWidth : 96;
+      const center =
+        container.scrollLeft + labelColW + (container.clientWidth - labelColW) / 2;
+      container.style.setProperty("--section-center", `${center}px`);
+    };
+
     const update = () => {
       const row = thead.querySelector("tr");
       if (row) {
         const cells = row.querySelectorAll("th");
         setColWidths(Array.from(cells).map((c) => c.getBoundingClientRect().width));
       }
+      updateSectionCenter();
     };
     update();
     const observer = new ResizeObserver(update);
@@ -338,11 +352,18 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return;
+    const thead = theadRef.current;
+    if (!container || !thead) return;
     const onScroll = () => {
       if (phantomInnerRef.current) {
         phantomInnerRef.current.style.transform = `translateX(-${container.scrollLeft}px)`;
       }
+      // Keep section labels centered in the visible content pane
+      const firstTh = thead.querySelector("th");
+      const labelColW = firstTh ? firstTh.offsetWidth : 96;
+      const center =
+        container.scrollLeft + labelColW + (container.clientWidth - labelColW) / 2;
+      container.style.setProperty("--section-center", `${center}px`);
     };
     container.addEventListener("scroll", onScroll, { passive: true });
     return () => container.removeEventListener("scroll", onScroll);
@@ -427,12 +448,22 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
           {visibleGroups.map((group) => {
             return (
               <React.Fragment key={group.label}>
-                {/* Group header row: sticky anchor cell holds the label column,
-                    content cell spans the lens columns and centers the label. */}
+                {/* Group header row.
+                    The label is absolutely positioned at --section-center (updated
+                    on scroll/resize) so it stays centered in the visible content
+                    pane regardless of horizontal scroll position. */}
                 <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                  <td className="sticky left-0 z-10 bg-zinc-100/80 dark:bg-zinc-800/60" />
-                  <td colSpan={orderedLenses.length} className="py-2 text-center">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  <td colSpan={totalColSpan} className="relative h-8">
+                    <span
+                      style={{
+                        position: "absolute",
+                        top: "50%",
+                        left: "var(--section-center, 50%)",
+                        transform: "translate(-50%, -50%)",
+                        whiteSpace: "nowrap",
+                      }}
+                      className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400"
+                    >
                       {group.label}
                     </span>
                   </td>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -198,7 +198,7 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
 
   const triggerLabel = (
     <>
-      <Share2 className="size-4" />
+      <Share2 className="size-5" />
       <span className="hidden sm:inline">{t("button")}</span>
     </>
   );
@@ -435,7 +435,7 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
   const isFab = variant === "fab";
 
   const defaultTriggerClass =
-    "flex cursor-pointer items-center gap-1.5 rounded-md text-sm text-zinc-500 outline-none transition-colors hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-50";
+    "flex cursor-pointer items-center gap-1.5 rounded-md p-1 text-sm text-zinc-500 outline-none transition-colors hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-50";
 
   const fabTriggerClass =
     "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-900 text-white shadow-lg outline-none transition-colors hover:bg-zinc-700 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200";

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -23,9 +23,10 @@ const PREVIEW_H = 220; // visible preview height in pixels
 
 interface ShareButtonProps {
   lenses: Lens[];
+  variant?: "default" | "fab";
 }
 
-export function ShareButton({ lenses }: ShareButtonProps) {
+export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
   const t = useTranslations("Share");
   const tImage = useTranslations("ShareImage");
   const [open, setOpen] = useState(false);
@@ -431,23 +432,36 @@ export function ShareButton({ lenses }: ShareButtonProps) {
     </div>
   );
 
+  const isFab = variant === "fab";
+
+  const defaultTriggerClass =
+    "flex cursor-pointer items-center gap-1.5 rounded-md text-sm text-zinc-500 outline-none transition-colors hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-50";
+
+  const fabTriggerClass =
+    "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-900 text-white shadow-lg outline-none transition-colors hover:bg-zinc-700 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200";
+
+  const triggerContent = isFab ? (
+    <Share2 className="size-5" />
+  ) : (
+    triggerLabel
+  );
+
   // Before mount: static placeholder to avoid layout shift
   const shareControl = !mounted ? (
     <button
       disabled
-      className="flex cursor-default items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400"
       aria-hidden
+      className={isFab ? fabTriggerClass + " cursor-default opacity-0" : "flex cursor-default items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400"}
     >
-      <Share2 className="size-4" />
-      {t("button")}
+      {isFab ? <Share2 className="size-5" /> : <><Share2 className="size-4" />{t("button")}</>}
     </button>
   ) : isDesktop ? (
     <Popover.Root open={open} onOpenChange={(nextOpen) => setOpen(nextOpen)}>
-      <Popover.Trigger className="flex cursor-pointer items-center gap-1.5 rounded-md text-sm text-zinc-500 outline-none transition-colors hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-50">
-        {triggerLabel}
+      <Popover.Trigger className={isFab ? fabTriggerClass : defaultTriggerClass}>
+        {triggerContent}
       </Popover.Trigger>
       <Popover.Portal>
-        <Popover.Positioner side="bottom" align="end" sideOffset={8}>
+        <Popover.Positioner side={isFab ? "top" : "bottom"} align="end" sideOffset={8}>
           <Popover.Popup className="w-96 max-h-[calc(100svh-80px)] overflow-y-auto origin-(--transform-origin) rounded-xl bg-white shadow-lg ring-1 ring-zinc-200 duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-zinc-900 dark:ring-zinc-800">
             {panelContent}
           </Popover.Popup>
@@ -460,8 +474,8 @@ export function ShareButton({ lenses }: ShareButtonProps) {
       onOpenChange={(nextOpen) => setOpen(nextOpen)}
       swipeDirection="down"
     >
-      <Drawer.Trigger className="flex cursor-pointer items-center gap-1.5 rounded-md text-sm text-zinc-500 outline-none transition-colors hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-50">
-        {triggerLabel}
+      <Drawer.Trigger className={isFab ? fabTriggerClass : defaultTriggerClass}>
+        {triggerContent}
       </Drawer.Trigger>
       <Drawer.Portal>
         <Drawer.Backdrop className="fixed inset-0 bg-black/40 duration-150 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />

--- a/src/components/ui/bool-cell.tsx
+++ b/src/components/ui/bool-cell.tsx
@@ -1,18 +1,27 @@
 interface BoolCellProps {
-  value: boolean | undefined;
+  value: boolean | "partial" | undefined;
   yes: string;
   no: string;
   unknown: string;
+  partial?: string;
 }
 
-export function BoolCell({ value, yes, no, unknown }: BoolCellProps) {
+export function BoolCell({ value, yes, no, unknown, partial }: BoolCellProps) {
   if (value === undefined) {
     return <>{unknown}</>;
+  }
+  if (value === "partial") {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="inline-block h-2 w-2 rounded-full bg-amber-400 dark:bg-amber-500" />
+        {partial ?? "Partial"}
+      </span>
+    );
   }
   return (
     <span className="inline-flex items-center gap-1.5">
       <span
-        className={`inline-block w-2 h-2 rounded-full ${
+        className={`inline-block h-2 w-2 rounded-full ${
           value ? "bg-green-500" : "bg-zinc-300 dark:bg-zinc-600"
         }`}
       />

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -82,7 +82,9 @@ export interface NumericRow extends BaseRow {
 
 export interface BoolRow extends BaseRow {
   kind: "bool";
-  getValue: (l: Lens) => boolean | undefined;
+  getValue: (l: Lens) => boolean | "partial" | undefined;
+  /** Optional supplemental text rendered below the bool indicator (e.g. "6 stops" for OIS). */
+  getSubValue?: (l: Lens) => string | undefined;
 }
 
 export type SpecRow = TextRow | NumericRow | BoolRow;
@@ -249,6 +251,7 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
           hasData: (l) => l.apertureBladeCount !== undefined,
           getDisplayValue: (l) => fmt.optionalNumber(l.apertureBladeCount, ""),
           toComparable: (l) => l.apertureBladeCount,
+          bestDir: "max",
         },
         {
           kind: "text",
@@ -358,12 +361,15 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
       label: labels.groupStabilization,
       rows: [
         {
-          kind: "text",
+          kind: "bool",
           label: labels.ois,
           fieldNoteKey: "ois" as FieldNoteKey,
           hasData: () => true,
-          getDisplayValue: (l) =>
-            fmt.oisDisplay(l.ois, l.oisStops, { yes, no }),
+          getValue: (l) => l.ois,
+          getSubValue: (l) =>
+            l.ois && l.oisStops !== undefined
+              ? `${l.oisStops} stops`
+              : undefined,
         },
       ] satisfies SpecRow[],
     },
@@ -417,12 +423,11 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
       label: labels.groupFeatures,
       rows: [
         {
-          kind: "text",
+          kind: "bool",
           label: labels.wr,
           fieldNoteKey: "wr" as FieldNoteKey,
           hasData: () => true,
-          getDisplayValue: (l) =>
-            fmt.wrDisplay(l.wr, { yes, no, partial }),
+          getValue: (l) => (l.wr === "partial" ? "partial" : l.wr),
         },
         {
           kind: "bool",


### PR DESCRIPTION
## Summary

- **Share FAB**: floating circular share button appears when the header scrolls out of view (IntersectionObserver); header share icon enlarged
- **Bottom add-lens entry**: second "Add Lens" trigger at the bottom of the compare table so users don't need to scroll back up
- **Section labels**: always centered in the visible viewport regardless of horizontal scroll (JS CSS variable approach)
- **OIS / WR upgraded to bool indicators**: green/gray dot with stops as sub-value for OIS; amber dot for partial WR state (`BoolCell` extended to support tristate)
- **Phantom header**: removed inconsistent column dividers
- **Footer row**: moved to `<tfoot>` with distinct background, fully opaque sticky label cell to prevent bleed-through
- **Mobile lens list**: various layout and touch-target improvements

## Test plan

- [ ] Desktop: scroll compare table down — share FAB appears; click opens popover upward
- [ ] Mobile: horizontal scroll — section labels (OPTICS, FOCUS, etc.) stay centered in viewport
- [ ] Footer row: scroll table horizontally — "Official site" / "Report" links fully hidden behind sticky label column (no semi-transparent bleed)
- [ ] OIS column: lenses with OIS show green dot + stops sub-value; lenses without show gray dot
- [ ] WR column: lenses with partial WR show amber dot
- [ ] Bottom "Add Lens" button is visible below the table without scrolling back to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)