### PR TITLE
feat(share): mobile-optimized share panel with poster preview & lightbox

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -49,6 +49,8 @@ export function ShareButton({ lenses }: ShareButtonProps) {
 
   // Full-size lightbox
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const lightboxContainerRef = useRef<HTMLDivElement>(null);
+  const [lightboxScale, setLightboxScale] = useState(1);
 
   // Filename slug
   const slugRef = useRef("");
@@ -74,6 +76,21 @@ export function ShareButton({ lenses }: ShareButtonProps) {
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, []);
+
+  // Scale lightbox poster to fit container width on mobile
+  useEffect(() => {
+    if (!lightboxOpen) return;
+    const el = lightboxContainerRef.current;
+    if (!el) return;
+    const updateScale = () => {
+      const available = el.clientWidth - 48; // subtract p-6 (24px * 2)
+      setLightboxScale(Math.min(1, available / POSTER_W));
+    };
+    updateScale();
+    const ro = new ResizeObserver(updateScale);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [lightboxOpen]);
 
   // Keep shareUrl in sync when panel opens
   useEffect(() => {
@@ -320,8 +337,11 @@ export function ShareButton({ lenses }: ShareButtonProps) {
               className="w-full max-w-[820px] overflow-hidden rounded-2xl top-4 translate-y-0"
               showCloseButton
             >
-              <div className="max-h-[80svh] overflow-x-hidden overflow-y-auto bg-zinc-50 p-6 dark:bg-zinc-950 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <div className="mx-auto" style={{ width: POSTER_W }}>
+              <div
+                ref={lightboxContainerRef}
+                className="max-h-[80svh] overflow-y-auto bg-zinc-50 p-6 dark:bg-zinc-950 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              >
+                <div className="mx-auto" style={{ width: POSTER_W, zoom: lightboxScale }}>
                   <SharePoster
                     lenses={lenses}
                     labels={posterLabels}
@@ -330,11 +350,25 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                   />
                 </div>
               </div>
-              <DialogFooter>
+              <DialogFooter className="justify-center">
+                {canShareFile && (
+                  <button
+                    onClick={handleShareImage}
+                    disabled={posterGenerating}
+                    className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  >
+                    {posterGenerating ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Share2 className="size-4" />
+                    )}
+                    {t("posterShare")}
+                  </button>
+                )}
                 <button
                   onClick={handleDownload}
                   disabled={posterGenerating}
-                  className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  className="flex items-center gap-2 rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
                 >
                   {posterGenerating ? (
                     <Loader2 className="size-4 animate-spin" />
@@ -343,42 +377,47 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                   )}
                   {t("posterDownload")}
                 </button>
-                {canShareFile && (
-                  <button
-                    onClick={handleShareImage}
-                    disabled={posterGenerating}
-                    className="flex items-center gap-2 rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  >
-                    <Share2 className="size-4" />
-                    {t("posterShare")}
-                  </button>
-                )}
               </DialogFooter>
             </DialogContent>
           </Dialog>
 
           {/* Poster actions */}
           <div className="flex gap-2">
-            <button
-              onClick={handleDownload}
-              disabled={posterGenerating}
-              className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-            >
-              {posterGenerating ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Download className="size-4" />
-              )}
-              {t("posterDownload")}
-            </button>
-            {canShareFile && (
+            {canShareFile ? (
+              <>
+                <button
+                  onClick={handleShareImage}
+                  disabled={posterGenerating}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  {posterGenerating ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Share2 className="size-4" />
+                  )}
+                  {t("posterShare")}
+                </button>
+                <button
+                  onClick={handleDownload}
+                  disabled={posterGenerating}
+                  title={t("posterDownload")}
+                  className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                >
+                  <Download className="size-4" />
+                </button>
+              </>
+            ) : (
               <button
-                onClick={handleShareImage}
+                onClick={handleDownload}
                 disabled={posterGenerating}
-                title={t("posterShare")}
-                className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
               >
-                <Share2 className="size-4" />
+                {posterGenerating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Download className="size-4" />
+                )}
+                {t("posterDownload")}
               </button>
             )}
           </div>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -295,9 +295,9 @@ export function ShareButton({ lenses }: ShareButtonProps) {
 
         {/* ── Image tab ────────────────────────────────────────── */}
         <Tabs.Panel value="image" className="flex flex-col gap-3">
-          {/* Poster preview: scaled-down SharePoster in a clipped container */}
+          {/* Poster preview: full-bleed, breaks out of p-4 padding */}
           <div
-            className="group relative overflow-hidden rounded-lg cursor-zoom-in"
+            className="group relative -mx-4 cursor-zoom-in overflow-hidden"
             style={{ height: PREVIEW_H }}
             onClick={() => setLightboxOpen(true)}
           >
@@ -382,60 +382,54 @@ export function ShareButton({ lenses }: ShareButtonProps) {
             </DialogContent>
           </Dialog>
 
-          {/* Bottom controls — relative anchor for the floating Customize overlay */}
-          <div className="relative">
-            {/* Customize overlay: floats above action row, collapses fully when closed */}
-            <div
-              className={cn(
-                "absolute bottom-full left-0 right-0 z-10 overflow-hidden rounded-xl bg-white transition-[max-height] duration-200 ease-out dark:bg-zinc-900",
-                customOpen
-                  ? "max-h-48 shadow-[0_-4px_20px_rgba(0,0,0,0.10)]"
-                  : "max-h-0"
-              )}
-            >
-              <div className="flex flex-col gap-3 p-3">
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeTitle")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customTitle}
-                    onChange={(e) => setCustomTitle(e.target.value)}
-                    placeholder={tImage("comparison")}
-                    className={inputClass}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeSlogan")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customSlogan}
-                    onChange={(e) => setCustomSlogan(e.target.value)}
-                    placeholder={t("customizeSloganPlaceholder")}
-                    className={inputClass}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Action row — Customize toggle on the left, share actions on the right */}
-            <div className="flex gap-2">
-              {/* Customize toggle — leftmost, icon-only */}
-              <button
-                onClick={() => setCustomOpen((v) => !v)}
-                title={t("customize")}
-                className={cn(
-                  "flex items-center justify-center rounded-lg border px-3 py-2.5 transition-colors",
-                  customOpen
-                    ? "border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
-                    : "border-zinc-200 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
-                )}
-              >
-                <SlidersHorizontal className="size-4" />
-              </button>
+          {/* Action row — Customize Popover on the left, share actions on the right */}
+          <div className="flex gap-2">
+              {/* Customize — Popover anchored to this trigger button */}
+              <Popover.Root open={customOpen} onOpenChange={setCustomOpen}>
+                <Popover.Trigger
+                  title={t("customize")}
+                  className={cn(
+                    "flex items-center justify-center rounded-lg border px-3 py-2.5 outline-none transition-colors",
+                    customOpen
+                      ? "border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
+                      : "border-zinc-200 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                  )}
+                >
+                  <SlidersHorizontal className="size-4" />
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner side="top" align="start" sideOffset={8}>
+                    <Popover.Popup className="w-72 origin-(--transform-origin) rounded-xl border border-zinc-200 bg-white p-3 shadow-lg duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
+                      <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                            {t("customizeTitle")}
+                          </label>
+                          <input
+                            type="text"
+                            value={customTitle}
+                            onChange={(e) => setCustomTitle(e.target.value)}
+                            placeholder={tImage("comparison")}
+                            className={inputClass}
+                          />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                            {t("customizeSlogan")}
+                          </label>
+                          <input
+                            type="text"
+                            value={customSlogan}
+                            onChange={(e) => setCustomSlogan(e.target.value)}
+                            placeholder={t("customizeSloganPlaceholder")}
+                            className={inputClass}
+                          />
+                        </div>
+                      </div>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </Popover.Root>
 
               {/* Share + Download */}
               {canShareFile ? (
@@ -467,7 +461,6 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                   {t("posterDownload")}
                 </button>
               )}
-            </div>
           </div>
         </Tabs.Panel>
       </Tabs.Root>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -28,6 +28,7 @@ interface ShareButtonProps {
 export function ShareButton({ lenses }: ShareButtonProps) {
   const t = useTranslations("Share");
   const tImage = useTranslations("ShareImage");
+  const tBrand = useTranslations("Brands");
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [isDesktop, setIsDesktop] = useState(true);
@@ -209,7 +210,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
   const truncatedUrl =
     shareUrl.length > 56 ? shareUrl.slice(0, 56) + "…" : shareUrl;
 
-  const lensCaption = lenses.map((l) => `${l.brand} · ${l.model}`).join(" / ");
+  const lensCaption = lenses.map((l) => `${tBrand(l.brand)} · ${l.model}`).join(" / ");
 
   const triggerLabel = (
     <>
@@ -236,7 +237,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
         <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h2>
-        <p className="truncate text-xs text-zinc-400 dark:text-zinc-500">
+        <p className="text-xs leading-relaxed text-zinc-400 dark:text-zinc-500">
           {lensCaption}
         </p>
       </div>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -333,12 +333,12 @@ export function ShareButton({ lenses }: ShareButtonProps) {
           {/* Full-size lightbox — top-aligned, inner scroll */}
           <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
             <DialogContent
-              className="w-[calc(100vw-2rem)] max-w-[820px] overflow-hidden rounded-2xl top-4 translate-y-0"
+              className="flex w-[calc(100vw-2rem)] max-w-[820px] max-h-[calc(100svh-2rem)] flex-col overflow-hidden rounded-2xl top-4 translate-y-0 shadow-[0_8px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(0,0,0,0.06)]"
               showCloseButton
             >
               <div
                 ref={lightboxContainerRef}
-                className="max-h-[80svh] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                className="flex-1 min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               >
                 <div style={{ width: POSTER_W, zoom: lightboxScale }}>
                   <SharePoster

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -209,7 +209,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
   const truncatedUrl =
     shareUrl.length > 56 ? shareUrl.slice(0, 56) + "…" : shareUrl;
 
-  const lensCaption = lenses.map((l) => l.model).join(" · ");
+  const lensCaption = lenses.map((l) => l.model).join(" / ");
 
   const triggerLabel = (
     <>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -389,7 +389,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                 customOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
               )}
             >
-              <div className="overflow-hidden">
+              <div className="min-h-0 overflow-hidden">
                 <div className="flex flex-col gap-3 pb-3 pt-1">
                   <div className="flex flex-col gap-1">
                     <label className="text-xs text-zinc-400 dark:text-zinc-500">

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -19,7 +19,7 @@ import {
 // Scale the 750px poster down to fit the ~352px panel content area
 const POSTER_W = 750;
 const PREVIEW_SCALE = 352 / POSTER_W; // ≈ 0.469
-const PREVIEW_H = 260; // visible preview height in pixels
+const PREVIEW_H = 310; // visible preview height in pixels
 
 interface ShareButtonProps {
   lenses: Lens[];
@@ -323,7 +323,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
             </div>
 
             {/* Gradient fade at bottom */}
-            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white to-transparent dark:from-zinc-900" />
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-white to-transparent dark:from-zinc-900" />
 
             {/* Expand hint on hover */}
             <div className="absolute right-2 top-2 rounded-md bg-black/30 p-1 opacity-0 transition-opacity group-hover:opacity-100">
@@ -383,54 +383,56 @@ export function ShareButton({ lenses }: ShareButtonProps) {
 
           {/* Bottom controls — relative anchor for the floating Customize overlay */}
           <div className="relative">
-            {/* Customize overlay: expands upward over the preview, doesn't affect Drawer height */}
-            <div
-              className={cn(
-                "absolute bottom-full left-0 right-0 z-10 overflow-hidden rounded-t-xl bg-white transition-[max-height] duration-200 ease-out dark:bg-zinc-900",
-                customOpen ? "max-h-48 shadow-[0_-4px_16px_rgba(0,0,0,0.08)]" : "max-h-0"
-              )}
-            >
-              <div className="flex flex-col gap-3 p-3 pb-2">
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeTitle")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customTitle}
-                    onChange={(e) => setCustomTitle(e.target.value)}
-                    placeholder={tImage("comparison")}
-                    className={inputClass}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeSlogan")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customSlogan}
-                    onChange={(e) => setCustomSlogan(e.target.value)}
-                    placeholder={t("customizeSloganPlaceholder")}
-                    className={inputClass}
-                  />
+            {/* Customize overlay: always anchored above actions, trigger forms the bottom edge */}
+            <div className="absolute bottom-full left-0 right-0 z-10 rounded-xl bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.10)] dark:bg-zinc-900">
+              {/* Inputs — animated open/close, trigger always visible below */}
+              <div
+                className={cn(
+                  "overflow-hidden transition-[max-height] duration-200 ease-out",
+                  customOpen ? "max-h-48" : "max-h-0"
+                )}
+              >
+                <div className="flex flex-col gap-3 p-3 pb-0">
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                      {t("customizeTitle")}
+                    </label>
+                    <input
+                      type="text"
+                      value={customTitle}
+                      onChange={(e) => setCustomTitle(e.target.value)}
+                      placeholder={tImage("comparison")}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                      {t("customizeSlogan")}
+                    </label>
+                    <input
+                      type="text"
+                      value={customSlogan}
+                      onChange={(e) => setCustomSlogan(e.target.value)}
+                      placeholder={t("customizeSloganPlaceholder")}
+                      className={inputClass}
+                    />
+                  </div>
                 </div>
               </div>
+              {/* Trigger — always visible, forms the bottom edge of the panel */}
+              <button
+                onClick={() => setCustomOpen((v) => !v)}
+                className="flex w-full items-center justify-between px-3 py-2.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:hover:text-zinc-300"
+              >
+                <span>{t("customize")}</span>
+                <ChevronDown
+                  className={cn(
+                    "size-3.5 transition-transform duration-200",
+                    !customOpen && "rotate-180"
+                  )}
+                />
+              </button>
             </div>
-
-            {/* Customize trigger */}
-            <button
-              onClick={() => setCustomOpen((v) => !v)}
-              className="flex w-full items-center justify-between border-b border-zinc-100 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:border-zinc-800 dark:hover:text-zinc-300"
-            >
-              <span>{t("customize")}</span>
-              <ChevronDown
-                className={cn(
-                  "size-3.5 transition-transform duration-200",
-                  !customOpen && "rotate-180"
-                )}
-              />
-            </button>
 
             {/* Poster actions */}
             <div className="flex gap-2 pt-3">

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -380,6 +380,59 @@ export function ShareButton({ lenses }: ShareButtonProps) {
             </DialogContent>
           </Dialog>
 
+          {/* Customize accordion — sits above the action buttons, expands upward */}
+          <div className="flex flex-col border-b border-zinc-100 dark:border-zinc-800">
+            {/* Expandable content: in DOM before the trigger so it appears above */}
+            <div
+              className={cn(
+                "grid transition-[grid-template-rows] duration-200 ease-out",
+                customOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+              )}
+            >
+              <div className="overflow-hidden">
+                <div className="flex flex-col gap-3 pb-3 pt-1">
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                      {t("customizeTitle")}
+                    </label>
+                    <input
+                      type="text"
+                      value={customTitle}
+                      onChange={(e) => setCustomTitle(e.target.value)}
+                      placeholder={tImage("comparison")}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                      {t("customizeSlogan")}
+                    </label>
+                    <input
+                      type="text"
+                      value={customSlogan}
+                      onChange={(e) => setCustomSlogan(e.target.value)}
+                      placeholder={t("customizeSloganPlaceholder")}
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            {/* Trigger */}
+            <button
+              onClick={() => setCustomOpen((v) => !v)}
+              className="flex w-full items-center justify-between py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:hover:text-zinc-300"
+            >
+              <span>{t("customize")}</span>
+              <ChevronDown
+                className={cn(
+                  "size-3.5 transition-transform duration-200",
+                  !customOpen && "rotate-180"
+                )}
+              />
+            </button>
+          </div>
+
           {/* Poster actions */}
           <div className="flex gap-2">
             {canShareFile ? (
@@ -418,50 +471,6 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                 )}
                 {t("posterDownload")}
               </button>
-            )}
-          </div>
-
-          {/* Customize accordion */}
-          <div className="border-t border-zinc-100 pt-1 dark:border-zinc-800">
-            <button
-              onClick={() => setCustomOpen((v) => !v)}
-              className="flex w-full items-center justify-between py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:hover:text-zinc-300"
-            >
-              <span>{t("customize")}</span>
-              <ChevronDown
-                className={cn(
-                  "size-3.5 transition-transform duration-200",
-                  customOpen && "rotate-180"
-                )}
-              />
-            </button>
-            {customOpen && (
-              <div className="flex flex-col gap-3 pb-2 pt-2">
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeTitle")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customTitle}
-                    onChange={(e) => setCustomTitle(e.target.value)}
-                    placeholder={tImage("comparison")}
-                    className={inputClass}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                    {t("customizeSlogan")}
-                  </label>
-                  <input
-                    type="text"
-                    value={customSlogan}
-                    onChange={(e) => setCustomSlogan(e.target.value)}
-                    placeholder={t("customizeSloganPlaceholder")}
-                    className={inputClass}
-                  />
-                </div>
-              </div>
             )}
           </div>
         </Tabs.Panel>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -5,7 +5,7 @@ import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
 import { Tabs } from "@base-ui/react/tabs";
 import { useTranslations } from "next-intl";
-import { Share2, Copy, Check, Download, Loader2, ChevronDown, Expand } from "lucide-react";
+import { Share2, Copy, Check, Download, Loader2, Expand, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Lens } from "@/lib/types";
 import { rasterizePoster } from "@/lib/share-image";
@@ -383,96 +383,89 @@ export function ShareButton({ lenses }: ShareButtonProps) {
 
           {/* Bottom controls — relative anchor for the floating Customize overlay */}
           <div className="relative">
-            {/* Customize overlay: always anchored above actions, trigger forms the bottom edge */}
-            <div className="absolute bottom-full left-0 right-0 z-10 rounded-xl bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.10)] dark:bg-zinc-900">
-              {/* Inputs — animated open/close, trigger always visible below */}
-              <div
-                className={cn(
-                  "overflow-hidden transition-[max-height] duration-200 ease-out",
-                  customOpen ? "max-h-48" : "max-h-0"
-                )}
-              >
-                <div className="flex flex-col gap-3 p-3 pb-0">
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                      {t("customizeTitle")}
-                    </label>
-                    <input
-                      type="text"
-                      value={customTitle}
-                      onChange={(e) => setCustomTitle(e.target.value)}
-                      placeholder={tImage("comparison")}
-                      className={inputClass}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                      {t("customizeSlogan")}
-                    </label>
-                    <input
-                      type="text"
-                      value={customSlogan}
-                      onChange={(e) => setCustomSlogan(e.target.value)}
-                      placeholder={t("customizeSloganPlaceholder")}
-                      className={inputClass}
-                    />
-                  </div>
+            {/* Customize overlay: floats above action row, collapses fully when closed */}
+            <div
+              className={cn(
+                "absolute bottom-full left-0 right-0 z-10 overflow-hidden rounded-xl bg-white transition-[max-height] duration-200 ease-out dark:bg-zinc-900",
+                customOpen
+                  ? "max-h-48 shadow-[0_-4px_20px_rgba(0,0,0,0.10)]"
+                  : "max-h-0"
+              )}
+            >
+              <div className="flex flex-col gap-3 p-3">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                    {t("customizeTitle")}
+                  </label>
+                  <input
+                    type="text"
+                    value={customTitle}
+                    onChange={(e) => setCustomTitle(e.target.value)}
+                    placeholder={tImage("comparison")}
+                    className={inputClass}
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                    {t("customizeSlogan")}
+                  </label>
+                  <input
+                    type="text"
+                    value={customSlogan}
+                    onChange={(e) => setCustomSlogan(e.target.value)}
+                    placeholder={t("customizeSloganPlaceholder")}
+                    className={inputClass}
+                  />
                 </div>
               </div>
-              {/* Trigger — always visible, forms the bottom edge of the panel */}
-              <button
-                onClick={() => setCustomOpen((v) => !v)}
-                className="flex w-full items-center justify-between px-3 py-2.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:hover:text-zinc-300"
-              >
-                <span>{t("customize")}</span>
-                <ChevronDown
-                  className={cn(
-                    "size-3.5 transition-transform duration-200",
-                    !customOpen && "rotate-180"
-                  )}
-                />
-              </button>
             </div>
 
-            {/* Poster actions */}
-            <div className="flex gap-2 pt-3">
-            {canShareFile ? (
-              <>
-                <button
-                  onClick={handleShareImage}
-                  disabled={posterGenerating}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-                >
-                  {posterGenerating ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Share2 className="size-4" />
-                  )}
-                  {t("posterShare")}
-                </button>
+            {/* Action row — Customize toggle on the left, share actions on the right */}
+            <div className="flex gap-2">
+              {/* Customize toggle — leftmost, icon-only */}
+              <button
+                onClick={() => setCustomOpen((v) => !v)}
+                title={t("customize")}
+                className={cn(
+                  "flex items-center justify-center rounded-lg border px-3 py-2.5 transition-colors",
+                  customOpen
+                    ? "border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
+                    : "border-zinc-200 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                )}
+              >
+                <SlidersHorizontal className="size-4" />
+              </button>
+
+              {/* Share + Download */}
+              {canShareFile ? (
+                <>
+                  <button
+                    onClick={handleShareImage}
+                    disabled={posterGenerating}
+                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  >
+                    {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Share2 className="size-4" />}
+                    {t("posterShare")}
+                  </button>
+                  <button
+                    onClick={handleDownload}
+                    disabled={posterGenerating}
+                    title={t("posterDownload")}
+                    className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    <Download className="size-4" />
+                  </button>
+                </>
+              ) : (
                 <button
                   onClick={handleDownload}
                   disabled={posterGenerating}
-                  title={t("posterDownload")}
-                  className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
                 >
-                  <Download className="size-4" />
+                  {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+                  {t("posterDownload")}
                 </button>
-              </>
-            ) : (
-              <button
-                onClick={handleDownload}
-                disabled={posterGenerating}
-                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-              >
-                {posterGenerating ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Download className="size-4" />
-                )}
-                {t("posterDownload")}
-              </button>
-            )}
+              )}
             </div>
           </div>
         </Tabs.Panel>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -16,9 +16,10 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
-// Scale the 750px poster down to fit the ~352px panel content area
+// Scale the 750px poster down to fit the panel content area
 const POSTER_W = 750;
 const PREVIEW_SCALE = 352 / POSTER_W; // ≈ 0.469
+const PREVIEW_SCALED_W = POSTER_W * PREVIEW_SCALE; // 352px — visual width after scale
 const PREVIEW_H = 310; // visible preview height in pixels
 
 interface ShareButtonProps {
@@ -305,7 +306,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
               style={{
                 position: "absolute",
                 top: 0,
-                left: 0,
+                left: `calc(50% - ${PREVIEW_SCALED_W / 2}px)`,
                 width: POSTER_W,
                 transform: `scale(${PREVIEW_SCALE})`,
                 transformOrigin: "top left",

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -209,7 +209,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
   const truncatedUrl =
     shareUrl.length > 56 ? shareUrl.slice(0, 56) + "…" : shareUrl;
 
-  const lensCaption = lenses.map((l) => l.model).join(" / ");
+  const lensCaption = lenses.map((l) => `${l.brand} · ${l.model}`).join(" / ");
 
   const triggerLabel = (
     <>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -386,36 +386,34 @@ export function ShareButton({ lenses }: ShareButtonProps) {
             {/* Expandable content: in DOM before the trigger so it appears above */}
             <div
               className={cn(
-                "grid transition-[grid-template-rows] duration-200 ease-out",
-                customOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+                "overflow-hidden transition-[max-height] duration-200 ease-out",
+                customOpen ? "max-h-48" : "max-h-0"
               )}
             >
-              <div className="min-h-0 overflow-hidden">
-                <div className="flex flex-col gap-3 pb-3 pt-1">
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                      {t("customizeTitle")}
-                    </label>
-                    <input
-                      type="text"
-                      value={customTitle}
-                      onChange={(e) => setCustomTitle(e.target.value)}
-                      placeholder={tImage("comparison")}
-                      className={inputClass}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                      {t("customizeSlogan")}
-                    </label>
-                    <input
-                      type="text"
-                      value={customSlogan}
-                      onChange={(e) => setCustomSlogan(e.target.value)}
-                      placeholder={t("customizeSloganPlaceholder")}
-                      className={inputClass}
-                    />
-                  </div>
+              <div className="flex flex-col gap-3 pb-3 pt-1">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                    {t("customizeTitle")}
+                  </label>
+                  <input
+                    type="text"
+                    value={customTitle}
+                    onChange={(e) => setCustomTitle(e.target.value)}
+                    placeholder={tImage("comparison")}
+                    className={inputClass}
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                    {t("customizeSlogan")}
+                  </label>
+                  <input
+                    type="text"
+                    value={customSlogan}
+                    onChange={(e) => setCustomSlogan(e.target.value)}
+                    placeholder={t("customizeSloganPlaceholder")}
+                    className={inputClass}
+                  />
                 </div>
               </div>
             </div>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -19,7 +19,7 @@ import {
 // Scale the 750px poster down to fit the ~352px panel content area
 const POSTER_W = 750;
 const PREVIEW_SCALE = 352 / POSTER_W; // ≈ 0.469
-const PREVIEW_H = 220; // visible preview height in pixels
+const PREVIEW_H = 260; // visible preview height in pixels
 
 interface ShareButtonProps {
   lenses: Lens[];
@@ -381,16 +381,16 @@ export function ShareButton({ lenses }: ShareButtonProps) {
             </DialogContent>
           </Dialog>
 
-          {/* Customize accordion — sits above the action buttons, expands upward */}
-          <div className="flex flex-col border-b border-zinc-100 dark:border-zinc-800">
-            {/* Expandable content: in DOM before the trigger so it appears above */}
+          {/* Bottom controls — relative anchor for the floating Customize overlay */}
+          <div className="relative">
+            {/* Customize overlay: expands upward over the preview, doesn't affect Drawer height */}
             <div
               className={cn(
-                "overflow-hidden transition-[max-height] duration-200 ease-out",
-                customOpen ? "max-h-48" : "max-h-0"
+                "absolute bottom-full left-0 right-0 z-10 overflow-hidden rounded-t-xl bg-white transition-[max-height] duration-200 ease-out dark:bg-zinc-900",
+                customOpen ? "max-h-48 shadow-[0_-4px_16px_rgba(0,0,0,0.08)]" : "max-h-0"
               )}
             >
-              <div className="flex flex-col gap-3 pb-3 pt-1">
+              <div className="flex flex-col gap-3 p-3 pb-2">
                 <div className="flex flex-col gap-1">
                   <label className="text-xs text-zinc-400 dark:text-zinc-500">
                     {t("customizeTitle")}
@@ -417,10 +417,11 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                 </div>
               </div>
             </div>
-            {/* Trigger */}
+
+            {/* Customize trigger */}
             <button
               onClick={() => setCustomOpen((v) => !v)}
-              className="flex w-full items-center justify-between py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:hover:text-zinc-300"
+              className="flex w-full items-center justify-between border-b border-zinc-100 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 dark:border-zinc-800 dark:hover:text-zinc-300"
             >
               <span>{t("customize")}</span>
               <ChevronDown
@@ -430,10 +431,9 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                 )}
               />
             </button>
-          </div>
 
-          {/* Poster actions */}
-          <div className="flex gap-2">
+            {/* Poster actions */}
+            <div className="flex gap-2 pt-3">
             {canShareFile ? (
               <>
                 <button
@@ -471,6 +471,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
                 {t("posterDownload")}
               </button>
             )}
+            </div>
           </div>
         </Tabs.Panel>
       </Tabs.Root>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -83,8 +83,7 @@ export function ShareButton({ lenses }: ShareButtonProps) {
     const el = lightboxContainerRef.current;
     if (!el) return;
     const updateScale = () => {
-      const available = el.clientWidth - 48; // subtract p-6 (24px * 2)
-      setLightboxScale(Math.min(1, available / POSTER_W));
+      setLightboxScale(Math.min(1, el.clientWidth / POSTER_W));
     };
     updateScale();
     const ro = new ResizeObserver(updateScale);
@@ -334,14 +333,14 @@ export function ShareButton({ lenses }: ShareButtonProps) {
           {/* Full-size lightbox — top-aligned, inner scroll */}
           <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
             <DialogContent
-              className="w-full max-w-[820px] overflow-hidden rounded-2xl top-4 translate-y-0"
+              className="w-[calc(100vw-2rem)] max-w-[820px] overflow-hidden rounded-2xl top-4 translate-y-0"
               showCloseButton
             >
               <div
                 ref={lightboxContainerRef}
-                className="max-h-[80svh] overflow-y-auto bg-zinc-50 p-6 dark:bg-zinc-950 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                className="max-h-[80svh] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               >
-                <div className="mx-auto" style={{ width: POSTER_W, zoom: lightboxScale }}>
+                <div style={{ width: POSTER_W, zoom: lightboxScale }}>
                   <SharePoster
                     lenses={lenses}
                     labels={posterLabels}

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -282,7 +282,6 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
               width: 76,
               height: 76,
               borderRadius: 6,
-              border: "1.5px solid #e4e4e7",
               padding: 4,
               display: "flex",
               alignItems: "center",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -80,7 +80,7 @@ function DialogContent({
       >
         {children}
         {showCloseButton && (
-          <DialogPrimitive.Close className="absolute right-4 top-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-900 dark:hover:text-zinc-200">
+          <DialogPrimitive.Close className="absolute right-4 top-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/70 text-zinc-400 backdrop-blur-sm transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:bg-zinc-950/70 dark:hover:bg-zinc-900 dark:hover:text-zinc-200">
             <X className="h-4 w-4" />
           </DialogPrimitive.Close>
         )}


### PR DESCRIPTION
## Summary

- **Lightbox**: full-size poster viewer with zoom-to-fit scaling on mobile, 4-side viewport margins, box shadow, semi-transparent close button
- **Poster preview**: full-bleed thumbnail (breaks out of drawer padding), centered via `calc(50% - 176px)` formula, gradient fade at bottom, click-to-expand hint
- **Customize Popover**: replaced custom overlay with `@base-ui/react` Popover anchored to trigger button (`side=top align=start`), with open/close animation via portal — no longer pushes drawer height
- **Lens caption**: brand · model entries joined by ` / `, uses localized brand names, wraps instead of truncating
- **QR code**: removed border in share poster
- **Action row**: Customize icon button inline with Share Image / Download PNG

## Test plan

- [ ] Open share panel on mobile (iOS Safari): poster thumbnail renders centered and full-bleed
- [ ] Tap preview → lightbox opens with 16px margins on all 4 sides, close button visible
- [ ] Rotate device → lightbox poster rescales via ResizeObserver
- [ ] Open Customize popover → animates in above trigger, inputs update poster live, popover dismisses on outside click
- [ ] Caption wraps correctly with 3+ lenses; brand names are localized (zh vs en)
- [ ] Desktop: share panel opens as Popover (not Drawer), same feature set

🤖 Generated with [Claude Code](https://claude.com/claude-code)