### PR TITLE
feat(branding): copy & personality pass

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Nav from "@/components/Nav";
+import ConsoleEgg from "@/components/ConsoleEgg";
 import TestHookPanel from "@/components/TestHookPanel";
 import { CompareProvider } from "@/context/CompareProvider";
 import { TestHookProvider } from "@/context/TestHookProvider";
@@ -48,6 +49,7 @@ export default async function LocaleLayout({
     >
       <NextIntlClientProvider messages={messages}>
         <CompareProvider>
+          <ConsoleEgg />
           <Nav />
           {TESTHOOK_ALLOWED ? (
             <TestHookProvider>

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -37,9 +37,17 @@ export default async function ComparePage({
 
   if (lenses.length === 0) {
     return (
-      <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-16 flex flex-col items-center gap-4 text-center">
-        <p className="text-zinc-500 dark:text-zinc-400">{t("noLenses")}</p>
-        <Link href="/lenses" className="text-sm text-blue-500 hover:underline">
+      <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-24 flex flex-col items-center gap-3 text-center">
+        <p className="text-5xl font-bold text-zinc-200 dark:text-zinc-800 select-none">
+          {t("emptyHeading")}
+        </p>
+        <p className="text-sm text-zinc-400 dark:text-zinc-600">
+          {t("emptySubtext")}
+        </p>
+        <Link
+          href="/lenses"
+          className="mt-4 text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+        >
           ← {t("backToLenses")}
         </Link>
       </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -25,9 +25,6 @@ export default function Home() {
         <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400 max-w-sm">
           {t("appDesc")}
         </p>
-        <span className="mt-3 inline-block px-2 py-0.5 rounded-full border border-zinc-200 dark:border-zinc-800 text-[10px] font-mono text-zinc-400 dark:text-zinc-600 select-none">
-          {t("zeroHallucination")}
-        </span>
         <div className="mt-8 flex flex-col items-center gap-0">
           <Link
             href="/lenses"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -25,6 +25,9 @@ export default function Home() {
         <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400 max-w-sm">
           {t("appDesc")}
         </p>
+        <span className="mt-3 inline-block px-2 py-0.5 rounded-full border border-zinc-200 dark:border-zinc-800 text-[10px] font-mono text-zinc-400 dark:text-zinc-600 select-none">
+          {t("zeroHallucination")}
+        </span>
         <div className="mt-8 flex flex-col items-center gap-0">
           <Link
             href="/lenses"

--- a/src/components/ConsoleEgg.tsx
+++ b/src/components/ConsoleEgg.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { meta, brandCount } from "@/lib/lens";
+
+export default function ConsoleEgg() {
+  useEffect(() => {
+    console.log(
+      [
+        `X-Glass v${meta.version}`,
+        `lens.json loaded ✓`,
+        `${meta.lensCount} lenses · ${brandCount} brands`,
+        `No hallucinations guaranteed.`,
+      ].join("\n")
+    );
+  }, []);
+
+  return null;
+}

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -19,7 +19,7 @@ export default function DataInfo() {
     );
 
   const formatDate = (dateStr: string) =>
-    new Intl.DateTimeFormat(locale, { month: "long", day: "numeric" }).format(
+    new Intl.DateTimeFormat(locale, { year: "numeric", month: "long", day: "numeric" }).format(
       new Date(dateStr)
     );
 

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -32,7 +32,10 @@ export default function DataInfo() {
 
   return (
     <div className="flex flex-col items-center gap-0.5 mt-3">
-      <p className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+      <p
+        className="text-xs text-zinc-400 dark:text-zinc-500 font-mono"
+        title={h("dataTooltip")}
+      >
         {h("dataSnapshotCount", { count: meta.lensCount, brands: brandCount })}
       </p>
       <p

--- a/src/components/Tagline.tsx
+++ b/src/components/Tagline.tsx
@@ -8,7 +8,8 @@ export default function Tagline() {
   const [tagline, setTagline] = useState<string | null>(null);
 
   useEffect(() => {
-    setTagline(Math.random() < 0.5 ? t("tagline1") : t("tagline2"));
+    const taglines = [t("tagline1"), t("tagline2"), t("tagline3"), t("tagline4")];
+    setTagline(taglines[Math.floor(Math.random() * taglines.length)]);
   }, [t]);
 
   if (!tagline) return null;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,8 +1,7 @@
 {
   "Common": {
     "appName": "X-Glass",
-    "appDesc": "Lens data, normalized.",
-    "zeroHallucination": "0 hallucination"
+    "appDesc": "Lens data, normalized."
   },
   "Nav": {
     "lenses": "Lenses",
@@ -34,7 +33,7 @@
   "Home": {
     "cta": "Browse Lenses",
     "dataSnapshot": "lens.json loaded ✓",
-    "dataSnapshotCount": "{count} lenses · {brands} brands",
+    "dataSnapshotCount": "{count} lenses · {brands} brands · 0 hallucination",
     "dataSnapshotDate": "{date}",
     "dataTooltip": "Verified from manufacturer data. No AI-generated specs."
   },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,7 +1,8 @@
 {
   "Common": {
     "appName": "X-Glass",
-    "appDesc": "Lens data, normalized."
+    "appDesc": "Lens data, normalized.",
+    "zeroHallucination": "0 hallucination"
   },
   "Nav": {
     "lenses": "Lenses",
@@ -34,7 +35,8 @@
     "cta": "Browse Lenses",
     "dataSnapshot": "lens.json loaded ✓",
     "dataSnapshotCount": "{count} lenses · {brands} brands",
-    "dataSnapshotDate": "{date}"
+    "dataSnapshotDate": "{date}",
+    "dataTooltip": "Verified from manufacturer data. No AI-generated specs."
   },
   "LensList": {
     "title": "Lenses",
@@ -197,6 +199,8 @@
     "title": "Compare",
     "backToLenses": "Back to Lenses",
     "noLenses": "No lenses selected. Go back and pick some to compare.",
+    "emptyHeading": "it depends.",
+    "emptySubtext": "No best lens. Trade-offs everywhere.",
     "officialSite": "Official site",
     "buildCompare": "Build Your Compare Set",
     "buildCompareHint": "{count} of {max} slots filled. Add or remove lenses here before reviewing the full table.",
@@ -330,7 +334,9 @@
     "dataInfo": "Data · {lensCount} lenses ·",
     "updatedPrefix": "Updated",
     "tagline1": "Data over opinions",
-    "tagline2": "Glass matters"
+    "tagline2": "Glass matters",
+    "tagline3": "aperture ring > mode dial",
+    "tagline4": "f/2 feels right"
   },
   "Feedback": {
     "titleDataIssue": "Report a data issue",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,8 +1,7 @@
 {
   "Common": {
     "appName": "X-Glass",
-    "appDesc": "富士党专属的镜头图鉴",
-    "zeroHallucination": "0 hallucination"
+    "appDesc": "富士党专属的镜头图鉴"
   },
   "Nav": {
     "lenses": "镜头列表",
@@ -34,7 +33,7 @@
   "Home": {
     "cta": "浏览镜头",
     "dataSnapshot": "lens.json loaded ✓",
-    "dataSnapshotCount": "{count} 支镜头 · {brands} 个品牌",
+    "dataSnapshotCount": "{count} 支镜头 · {brands} 个品牌 · 0 hallucination",
     "dataSnapshotDate": "{date}",
     "dataTooltip": "数据来源于制造商官方规格，非 AI 生成。"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,7 +1,8 @@
 {
   "Common": {
     "appName": "X-Glass",
-    "appDesc": "富士党专属的镜头图鉴"
+    "appDesc": "富士党专属的镜头图鉴",
+    "zeroHallucination": "0 hallucination"
   },
   "Nav": {
     "lenses": "镜头列表",
@@ -34,7 +35,8 @@
     "cta": "浏览镜头",
     "dataSnapshot": "lens.json loaded ✓",
     "dataSnapshotCount": "{count} 支镜头 · {brands} 个品牌",
-    "dataSnapshotDate": "{date}"
+    "dataSnapshotDate": "{date}",
+    "dataTooltip": "数据来源于制造商官方规格，非 AI 生成。"
   },
   "LensList": {
     "title": "镜头列表",
@@ -196,6 +198,8 @@
     "title": "对比",
     "backToLenses": "返回列表",
     "noLenses": "未选择镜头，请返回列表选择要对比的镜头。",
+    "emptyHeading": "这得看情况。",
+    "emptySubtext": "没有最好的镜头，到处都是取舍。",
     "officialSite": "官网",
     "buildCompare": "组合你的对比列表",
     "buildCompareHint": "当前已填充 {count} / {max} 个槽位。你可以先在这里添加或移除镜头，再查看下方完整对比表。",
@@ -329,7 +333,9 @@
     "dataInfo": "数据 · {lensCount} 款镜头 ·",
     "updatedPrefix": "更新于",
     "tagline1": "Data over opinions",
-    "tagline2": "Glass matters"
+    "tagline2": "Glass matters",
+    "tagline3": "aperture ring > mode dial",
+    "tagline4": "f/2 feels right"
   },
   "Feedback": {
     "titleDataIssue": "反馈数据问题",


### PR DESCRIPTION
## Summary

- **Homepage**: add `0 hallucination` pill badge (font-mono, low-contrast) below the subtitle
- **DataFooter**: add native tooltip on the lens count line — "Verified from manufacturer data. No AI-generated specs."
- **Compare empty state**: replace placeholder text with styled `"it depends."` heading + `"No best lens. Trade-offs everywhere."` subtext; zh: `"这得看情况。"`
- **Console Easter egg**: new `ConsoleEgg` component logs version, lens count, and `No hallucinations guaranteed.` on mount — visible to anyone who opens DevTools
- **Footer taglines**: expand pool from 2 → 4, adding `aperture ring > mode dial` and `f/2 feels right`; refactor `Tagline.tsx` to array-based random selection

## Test plan

- [ ] Homepage: confirm `0 hallucination` badge renders below subtitle; hover lens count line to see tooltip
- [ ] Compare page: visit `/lenses/compare` (no `ids` param) — confirm `"it depends."` empty state
- [ ] DevTools console: refresh any page, confirm 4-line Easter egg output
- [ ] Footer: refresh homepage several times, confirm all 4 taglines can appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)