### PR TITLE
feat(animation): introduce Framer Motion for P0 spring animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "geist": "^1.7.0",
         "lucide-react": "^1.7.0",
         "modern-screenshot": "^4.6.8",
+        "motion": "^12.38.0",
         "next": "16.2.1",
         "next-intl": "^4.8.3",
         "react": "19.2.4",
@@ -6457,6 +6458,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -8327,6 +8355,47 @@
       "version": "4.6.8",
       "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.6.8.tgz",
       "integrity": "sha512-GJkv/yWPOJTlxj1LZDU2k474cDyOWL+LVaqTdDWQwQ5d8zIuTz1892+1cV9V0ZpK6HYZFo/+BNLBbierO9d2TA==",
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "geist": "^1.7.0",
     "lucide-react": "^1.7.0",
     "modern-screenshot": "^4.6.8",
+    "motion": "^12.38.0",
     "next": "16.2.1",
     "next-intl": "^4.8.3",
     "react": "19.2.4",

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { allLenses } from "@/lib/lens";
 import { useCompare } from "@/context/CompareProvider";
+import { motion, AnimatePresence } from "motion/react";
+import { spring } from "@/lib/animation";
 
 export default function CompareBar() {
   const t = useTranslations("LensList");
@@ -21,63 +23,77 @@ export default function CompareBar() {
     [compareIds]
   );
 
-  if (selectedLenses.length === 0) {
-    return null;
-  }
-
   function handleCompare() {
     const ids = selectedLenses.map((l) => l.id).join(",");
     router.push(`/lenses/compare?ids=${ids}`);
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-zinc-200 dark:border-zinc-800 bg-white/95 dark:bg-black/95 backdrop-blur-sm pb-[env(safe-area-inset-bottom,0px)]">
-      <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-6">
-        <div className="flex min-w-0 flex-1 gap-2 overflow-x-auto pb-1 sm:pb-0">
-          {selectedLenses.map((lens) => {
-            const brandName = tBrand(lens.brand);
-            const displayName = `${brandName} ${lens.model}`;
+    <AnimatePresence>
+      {selectedLenses.length > 0 && (
+        <motion.div
+          key="compare-bar"
+          initial={{ y: "100%" }}
+          animate={{ y: 0 }}
+          exit={{ y: "100%" }}
+          transition={spring.snappy}
+          className="fixed bottom-0 left-0 right-0 z-40 border-t border-zinc-200 dark:border-zinc-800 bg-white/95 dark:bg-black/95 backdrop-blur-sm pb-[env(safe-area-inset-bottom,0px)]"
+        >
+          <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-6">
+            <div className="flex min-w-0 flex-1 gap-2 overflow-x-auto pb-1 sm:pb-0">
+              <AnimatePresence mode="popLayout">
+                {selectedLenses.map((lens) => {
+                  const brandName = tBrand(lens.brand);
+                  const displayName = `${brandName} ${lens.model}`;
 
-            return (
-              <div
-                key={lens.id}
-                className="flex items-start gap-1.5 shrink-0 rounded-lg bg-zinc-100 px-2.5 py-1.5 dark:bg-zinc-800"
+                  return (
+                    <motion.div
+                      key={lens.id}
+                      layout
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.8 }}
+                      transition={spring.snappy}
+                      className="flex items-start gap-1.5 shrink-0 rounded-lg bg-zinc-100 px-2.5 py-1.5 dark:bg-zinc-800"
+                    >
+                      <span className="flex max-w-[132px] min-w-0 flex-col leading-tight sm:max-w-[168px]">
+                        <span className="truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500 dark:text-zinc-400">
+                          {brandName}
+                        </span>
+                        <span className="truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                          {lens.model}
+                        </span>
+                      </span>
+                      <button
+                        onClick={() => toggleCompare(lens.id)}
+                        className="mt-0.5 text-base leading-none text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
+                        aria-label={tCompare("removeLens", { model: displayName })}
+                      >
+                        ×
+                      </button>
+                    </motion.div>
+                  );
+                })}
+              </AnimatePresence>
+            </div>
+            <div className="flex items-center justify-end gap-3 sm:shrink-0">
+              <button
+                onClick={clearCompare}
+                className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
               >
-                <span className="flex max-w-[132px] min-w-0 flex-col leading-tight sm:max-w-[168px]">
-                  <span className="truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500 dark:text-zinc-400">
-                    {brandName}
-                  </span>
-                  <span className="truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
-                    {lens.model}
-                  </span>
-                </span>
-                <button
-                  onClick={() => toggleCompare(lens.id)}
-                  className="mt-0.5 text-base leading-none text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
-                  aria-label={tCompare("removeLens", { model: displayName })}
-                >
-                  ×
-                </button>
-              </div>
-            );
-          })}
-        </div>
-        <div className="flex items-center justify-end gap-3 sm:shrink-0">
-          <button
-            onClick={clearCompare}
-            className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
-          >
-            {t("clearCompare")}
-          </button>
-          <button
-            onClick={handleCompare}
-            disabled={selectedLenses.length < 2}
-            className="shrink-0 text-sm font-medium px-4 py-2 rounded-xl bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            {t("goCompare", { count: selectedLenses.length })}
-          </button>
-        </div>
-      </div>
-    </div>
+                {t("clearCompare")}
+              </button>
+              <button
+                onClick={handleCompare}
+                disabled={selectedLenses.length < 2}
+                className="shrink-0 text-sm font-medium px-4 py-2 rounded-xl bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {t("goCompare", { count: selectedLenses.length })}
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -64,7 +64,7 @@ export default function LensCard({
   return (
     <div
       {...hookAttr("card")}
-      className={`rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-all ${
+      className={`rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] ${
         isSelected
           ? "border-blue-500 ring-1 ring-blue-500 shadow-lg shadow-blue-500/10"
           : "border-zinc-200 dark:border-zinc-800"

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { spring } from "@/lib/animation";
 import { useTranslations } from "next-intl";
 import type { Lens } from "@/lib/types";
 import {
@@ -162,48 +164,67 @@ export default function LensListClient({ lenses }: Props) {
           </div>
         </div>
 
-        {displayed.length === 0 ? (
-          <div className="flex flex-col gap-2">
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              {t("noResults")}
-            </p>
-            <p className="text-xs text-zinc-400 dark:text-zinc-500">
-              {t("suggestLens")}{" "}
-              <FeedbackTrigger
-                type="missing_lens"
-                className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              >
-                {t("suggestLensLink")}
-              </FeedbackTrigger>
-            </p>
-          </div>
-        ) : (
-          <div
-            {...hookAttr("grid")}
-            className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-          >
-            {displayed.map((lens) => (
-              <LensCard
-                key={lens.id}
-                lens={lens}
-                isSelected={compareIds.includes(lens.id)}
-                selectionDisabled={!canToggle(lens.id)}
-                onToggle={() => toggleCompare(lens.id)}
-              />
-            ))}
-          </div>
-        )}
+        <AnimatePresence mode="wait" initial={false}>
+          {displayed.length === 0 ? (
+            <motion.div
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="flex flex-col gap-2"
+            >
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                {t("noResults")}
+              </p>
+              <p className="text-xs text-zinc-400 dark:text-zinc-500">
+                {t("suggestLens")}{" "}
+                <FeedbackTrigger
+                  type="missing_lens"
+                  className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                >
+                  {t("suggestLensLink")}
+                </FeedbackTrigger>
+              </p>
+            </motion.div>
+          ) : (
+            <motion.div
+              key={displayed.map((l) => l.id).join()}
+              {...hookAttr("grid")}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.18, ease: "easeOut" }}
+              className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+            >
+              {displayed.map((lens) => (
+                <LensCard
+                  key={lens.id}
+                  lens={lens}
+                  isSelected={compareIds.includes(lens.id)}
+                  selectionDisabled={!canToggle(lens.id)}
+                  onToggle={() => toggleCompare(lens.id)}
+                />
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
 
-      {showScrollTop && (
-        <button
-          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          className="fixed bottom-24 right-6 z-40 w-10 h-10 flex items-center justify-center rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-md text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
-          aria-label="Back to top"
-        >
-          <ChevronUp size={16} />
-        </button>
-      )}
+      <AnimatePresence>
+        {showScrollTop && (
+          <motion.button
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={spring.bounce}
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            className="fixed bottom-24 right-6 z-40 w-10 h-10 flex items-center justify-center rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-md text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
+            aria-label="Back to top"
+          >
+            <ChevronUp size={16} />
+          </motion.button>
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/src/lib/animation.ts
+++ b/src/lib/animation.ts
@@ -1,0 +1,16 @@
+import type { Transition } from "motion/react";
+
+export const spring = {
+  snappy: {
+    type: "spring",
+    stiffness: 500,
+    damping: 30,
+    mass: 1,
+  } satisfies Transition,
+  bounce: {
+    type: "spring",
+    stiffness: 400,
+    damping: 20,
+    mass: 0.8,
+  } satisfies Transition,
+};


### PR DESCRIPTION
## Summary

- Install `motion` package; add shared spring configs in `src/lib/animation.ts`
- **CompareBar**: spring slide-up/down on appear/disappear; chips spring scale in/out with layout animation
- **Lens list grid**: container opacity fade on filter change (lightweight, zero per-item overhead)
- **Scroll-to-top button**: fade + scale with spring bounce on mount/unmount
- **LensCard**: narrow `transition-all` → `transition-[border-color,box-shadow]` to avoid FM transform conflicts

Existing `tw-animate-css` animations (Dialog, Select, Popover) are untouched.

## Test plan

- [ ] Toggle a brand filter — grid fades out then in
- [ ] Add first lens to compare — CompareBar springs up from bottom
- [ ] Add second lens — second chip springs in, bar stays
- [ ] Remove one chip — chip springs out, remaining chip reflows smoothly
- [ ] Clear all — CompareBar springs down and disappears
- [ ] Scroll past 400px — scroll-to-top button fades+scales in; scroll back — fades out
- [ ] Open Dialog / Select dropdown — existing CSS animations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)