### PR TITLE
fix(search-dialog & lightbox): UX polish — keyboard scroll, input clear, backdrop dismiss, animation speed

### DIFF
--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -54,6 +54,7 @@ export default function LensSearchDialog({
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputId = useId();
   const titleId = useId();
   const descriptionId = useId();
@@ -78,6 +79,16 @@ export default function LensSearchDialog({
       setActiveIndex(0);
     }
   }, [open]);
+
+  // Scroll active result into view when navigating with keyboard
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const activeItem = container.querySelector('[aria-selected="true"]');
+    if (activeItem) {
+      (activeItem as HTMLElement).scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex]);
 
   const results = useMemo(
     () => searchLensIndex(lensSearchIndex, deferredQuery),
@@ -180,7 +191,7 @@ export default function LensSearchDialog({
             </div>
           </DialogHeader>
 
-          <div className="max-h-[60vh] overflow-y-auto px-3 py-3">
+          <div ref={scrollContainerRef} className="max-h-[60vh] overflow-y-auto px-3 py-3">
             {query.trim().length === 0 ? (
               <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
                 <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { allLenses } from "@/lib/lens";
@@ -164,9 +164,11 @@ export default function LensSearchDialog({
           className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
           showCloseButton
         >
-          <DialogHeader className="border-b border-zinc-100 dark:border-zinc-800 pr-12">
-            <DialogTitle>{t("title")}</DialogTitle>
-            <DialogDescription>{t("description")}</DialogDescription>
+          <DialogHeader className="border-b border-zinc-100 dark:border-zinc-800">
+            <div className="pr-12">
+              <DialogTitle>{t("title")}</DialogTitle>
+              <DialogDescription>{t("description")}</DialogDescription>
+            </div>
 
             <div className="mt-1 flex items-center gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 shadow-inner shadow-zinc-200/30 dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-black/20">
               <label htmlFor={inputId} className="sr-only">
@@ -188,10 +190,27 @@ export default function LensSearchDialog({
                 aria-autocomplete="list"
                 className="w-full border-0 bg-transparent text-sm text-zinc-950 outline-none placeholder:text-zinc-400 dark:text-zinc-50"
               />
+              {query && (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  onClick={() => {
+                    setQuery("");
+                    setActiveIndex(0);
+                    inputRef.current?.focus();
+                  }}
+                  className="shrink-0 text-zinc-400 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
             </div>
           </DialogHeader>
 
-          <div ref={scrollContainerRef} className="max-h-[60vh] overflow-y-auto px-3 py-3">
+          <div
+            ref={scrollContainerRef}
+            className="min-h-[240px] max-h-[60vh] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
+          >
             {query.trim().length === 0 ? (
               <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
                 <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -342,9 +342,9 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
             {/* Dialog fills the full viewport; all visual styling lives inside */}
             <DialogContent
               noDefaultPositioning
-              className="fixed inset-0 flex items-center justify-center border-0 bg-transparent p-0 shadow-none"
+              className="fixed inset-0 flex items-center justify-center border-0 bg-transparent p-0 shadow-none duration-100"
               backdropClassName={cn(
-                "transition-[background-color] duration-300",
+                "transition-[background-color] duration-150",
                 lightboxZoomed ? "bg-black/90 backdrop-blur-[2px]" : "bg-zinc-950/75"
               )}
               showCloseButton={false}
@@ -360,10 +360,10 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
                   <motion.div
                     key="preview"
                     ref={lightboxContainerRef}
-                    initial={{ opacity: 0, scale: 0.95 }}
+                    initial={{ opacity: 0, scale: 0.97 }}
                     animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.95 }}
-                    transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+                    exit={{ opacity: 0, scale: 0.97 }}
+                    transition={{ duration: 0.12, ease: "easeOut" }}
                     className={cn(
                       "relative w-[calc(100vw-4rem)] max-w-[750px] max-h-[calc(100svh-5rem)] overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden rounded-2xl bg-white shadow-[0_8px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(0,0,0,0.06)]",
                       !isDesktop && "cursor-zoom-in"
@@ -382,7 +382,7 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
-                    transition={{ duration: 0.2 }}
+                    transition={{ duration: 0.12 }}
                     className="fixed inset-0 flex flex-col overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
                     onClick={(e) => { if (e.target === e.currentTarget) setLightboxZoomed(false); }}
                   >

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -348,6 +348,9 @@ export function ShareButton({ lenses, variant = "default" }: ShareButtonProps) {
                 lightboxZoomed ? "bg-black/90 backdrop-blur-[2px]" : "bg-zinc-950/75"
               )}
               showCloseButton={false}
+              onClick={(e) => {
+                if (e.target === e.currentTarget) setLightboxOpen(false);
+              }}
             >
               {/* ── State-driven content ── */}
               <AnimatePresence mode="sync" initial={false}>


### PR DESCRIPTION
## Summary

- **Search dialog — keyboard nav scroll**: 方向键切换 AutoSuggest 选项时，列表现在自动滚动到当前高亮项（`scrollIntoView({ block: "nearest" })`）
- **Search dialog — UX polish**: 搜索框延展到全宽；新增内联清除 (X) 按钮；结果区改用细线自定义滚动条；`min-h-[240px]` 防止有无结果时的高度跳变
- **Dialog close button**: 使用 `ICON_CLOSE_BTN_CLS` token 统一关闭按钮设计语言
- **Lightbox — backdrop dismiss**: 全屏 Poster 预览点击阴影区域可关闭（`e.target === e.currentTarget` 判断）
- **Lightbox — animation speed**: 打开/关闭动画从 200ms 缩短至 100–120ms，scale 起始值从 0.95 调整为 0.97

## Test plan

- [ ] Search dialog: 输入内容后用方向键导航，列表超出可见区时自动滚动
- [ ] Search dialog: 点击 X 按钮清除搜索内容并保持焦点
- [ ] Search dialog: 有无结果切换时高度稳定不跳变
- [ ] Share lightbox: 点击 card 周围阴影区域可关闭
- [ ] Share lightbox: 开关动画感觉轻快不拖沓

🤖 Generated with [Claude Code](https://claude.com/claude-code)