### PR TITLE
[codex] Fix compare missing value semantics

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -290,7 +290,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
                   ? valueCellLabels.partial
                   : v === false
                     ? valueCellLabels.no
-                    : valueCellLabels.unknown;
+                    : valueCellLabels.missing;
           } else {
             currentValue = row.getDisplayValue(lens) ?? undefined;
           }
@@ -506,12 +506,12 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
                               <div className="flex items-center justify-center gap-1">
                                 <div>
                                   <BoolCell
-                                    value={row.getValue(lens)}
-                                    yes={valueCellLabels.yes}
-                                    no={valueCellLabels.no}
-                                    partial={valueCellLabels.partial}
-                                    unknown={valueCellLabels.unknown}
-                                  />
+                                  value={row.getValue(lens)}
+                                  yes={valueCellLabels.yes}
+                                  no={valueCellLabels.no}
+                                  partial={valueCellLabels.partial}
+                                  unknown={valueCellLabels.missing}
+                                />
                                   {subVal && (
                                     <p className="mt-0.5 text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
                                       {subVal}
@@ -596,7 +596,7 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
 
                           let primaryNode: React.ReactNode;
                           if (displayVal === undefined) {
-                            primaryNode = valueCellLabels.unknown;
+                            primaryNode = valueCellLabels.missing;
                           } else if (usePartialHighlight && fragment) {
                             const idx = displayVal.indexOf(fragment);
                             const before = displayVal.slice(0, idx);


### PR DESCRIPTION
## What changed

This PR fixes missing-value rendering in the compare table.

- Boolean rows now show `-` when the value is unknown or missing
- Numeric rows now show `-` when the value is unknown or missing
- Explicit `N/A` values are still preserved for truly not-applicable cases such as `filterMm === SPEC_NA`

## Why

The previous behavior rendered `undefined` boolean and numeric values as `N/A`, which conflated missing data with not-applicable data.

This change aligns the compare table with the product FAQ semantics, where a dash means the data has not been collected yet or has not been publicly disclosed.

## Impact

Users should now see a clearer distinction between:

- `-` for missing / unknown / unpublished data
- `N/A` for true not-applicable cases

## Validation

- Reviewed the compare table rendering branches in `src/components/CompareTable.tsx`
- Confirmed the change only affects missing-value fallbacks
- Automated checks were not runnable in this worktree because local binaries for `tsc` and `eslint` are currently unavailable
