### PR TITLE
refactor(compare): replace JS section-label centering with CSS text-align

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -326,21 +326,12 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
     const thead = theadRef.current;
     if (!container || !thead) return;
 
-    const updateSectionCenter = () => {
-      // Center of the full visible viewport, expressed as a position in table
-      // coordinate space so that absolutely-positioned section labels stay locked
-      // to the midpoint of the screen regardless of horizontal scroll.
-      const center = container.scrollLeft + container.clientWidth / 2;
-      container.style.setProperty("--section-center", `${center}px`);
-    };
-
     const update = () => {
       const row = thead.querySelector("tr");
       if (row) {
         const cells = row.querySelectorAll("th");
         setColWidths(Array.from(cells).map((c) => c.getBoundingClientRect().width));
       }
-      updateSectionCenter();
     };
     update();
     const observer = new ResizeObserver(update);
@@ -356,9 +347,6 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
       if (phantomInnerRef.current) {
         phantomInnerRef.current.style.transform = `translateX(-${container.scrollLeft}px)`;
       }
-      // Keep section labels centered in the full visible viewport
-      const center = container.scrollLeft + container.clientWidth / 2;
-      container.style.setProperty("--section-center", `${center}px`);
     };
     container.addEventListener("scroll", onScroll, { passive: true });
     return () => container.removeEventListener("scroll", onScroll);
@@ -448,17 +436,8 @@ export default function CompareTable({ lenses: initialLenses }: Props) {
                     on scroll/resize) so it stays centered in the visible content
                     pane regardless of horizontal scroll position. */}
                 <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                  <td colSpan={totalColSpan} className="relative h-8">
-                    <span
-                      style={{
-                        position: "absolute",
-                        top: "50%",
-                        left: "var(--section-center, 50%)",
-                        transform: "translate(-50%, -50%)",
-                        whiteSpace: "nowrap",
-                      }}
-                      className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400"
-                    >
+                  <td colSpan={totalColSpan} className="h-8 text-center">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                       {group.label}
                     </span>
                   </td>


### PR DESCRIPTION
## Summary

- Section group labels (`OPTICS`, `AUTOFOCUS`, etc.) previously used a JS scroll listener to maintain a `--section-center` CSS variable, keeping the label dynamically centered in the visible viewport during horizontal scroll
- Replaced with plain `text-align: center` on the `<td>` — no JS, no scroll listener, no CSS variable
- The visual result is identical for the 2-lens case (no horizontal scroll); for 3+ lenses the label centers over the full table width rather than the visible viewport, which is acceptable since users encounter section headers while vertically scrolling (typically near scrollLeft ≈ 0)
- Net: **−21 lines**, one fewer scroll event listener, one fewer ResizeObserver callback

## Test plan

- [ ] 2-lens compare: section labels centered correctly on desktop and mobile
- [ ] 3-lens compare: section labels reasonably centered on desktop; acceptable on mobile with horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)