### PR TITLE
Fix lens search ranking for exact numeric focal matches

### DIFF
--- a/src/lib/__tests__/lens-search.test.ts
+++ b/src/lib/__tests__/lens-search.test.ts
@@ -60,6 +60,26 @@ const lenses = [
     minAperture: 22,
   },
   {
+    id: "fuji-xf100-400",
+    brand: "fujifilm",
+    series: "XF",
+    model: "XF 100-400mm F4.5-5.6 R LM OIS WR",
+    focalLengthMin: 100,
+    focalLengthMax: 400,
+    maxAperture: [4.5, 5.6],
+    minAperture: 22,
+  },
+  {
+    id: "sigma-100-400",
+    brand: "sigma",
+    series: "Contemporary",
+    model: "100-400mm F5-6.3 DG DN OS",
+    focalLengthMin: 100,
+    focalLengthMax: 400,
+    maxAperture: [5, 6.3],
+    minAperture: 22,
+  },
+  {
     id: "artisans-25-18",
     brand: "7artisans",
     series: undefined,
@@ -204,6 +224,19 @@ describe("searchLenses — focal & aperture tokens", () => {
   it("'40' alone matches the 40mm lens by focal token", () => {
     const results = searchLenses(lenses, "40");
     expect(results[0]?.id).toBe("fuji-xf40-28");
+  });
+
+  it("'40' prefers complete 40mm hits over 400mm prefix hits", () => {
+    const results = searchLenses(lenses, "40");
+    const fuji40Idx = results.findIndex((l) => l.id === "fuji-xf40-28");
+    const fuji100400Idx = results.findIndex((l) => l.id === "fuji-xf100-400");
+    const sigma100400Idx = results.findIndex((l) => l.id === "sigma-100-400");
+
+    expect(fuji40Idx).toBeGreaterThanOrEqual(0);
+    expect(fuji100400Idx).toBeGreaterThanOrEqual(0);
+    expect(sigma100400Idx).toBeGreaterThanOrEqual(0);
+    expect(fuji40Idx).toBeLessThan(fuji100400Idx);
+    expect(fuji40Idx).toBeLessThan(sigma100400Idx);
   });
 
   it("'18-50' matches the zoom lens", () => {

--- a/src/lib/lens-search.ts
+++ b/src/lib/lens-search.ts
@@ -162,21 +162,43 @@ export function buildLensSearchIndex(lenses: Lens[]): LensSearchIndex {
 // Scoring
 // ---------------------------------------------------------------------------
 
-type MatchStrength = "exact" | "wordPrefix" | "includes" | "none";
+type MatchStrength =
+  | "exact"
+  | "boundaryPrefix"
+  | "wordPrefix"
+  | "includes"
+  | "none";
+
+function isBoundaryPrefix(token: string, query: string): boolean {
+  if (!token.startsWith(query) || token.length === query.length) {
+    return false;
+  }
+
+  const nextChar = token[query.length];
+
+  // Prefer complete numeric chunks such as "40" in "40mm" over broader
+  // numeric prefixes such as "40" in "400mm".
+  if (/^\d+$/.test(query)) {
+    return /\D/.test(nextChar);
+  }
+
+  return true;
+}
 
 function matchStrength(tokens: string[], query: string): MatchStrength {
   if (tokens.includes(query)) return "exact";
+  if (tokens.some((t) => isBoundaryPrefix(t, query))) return "boundaryPrefix";
   if (tokens.some((t) => t.startsWith(query))) return "wordPrefix";
   if (tokens.some((t) => t.includes(query))) return "includes";
   return "none";
 }
 
 const WEIGHTS: Record<keyof TokenBucket, Record<MatchStrength, number>> = {
-  model:    { exact: 600, wordPrefix: 450, includes: 280, none: 0 },
-  brand:    { exact: 260, wordPrefix: 200, includes: 120, none: 0 },
-  alias:    { exact: 240, wordPrefix: 180, includes: 110, none: 0 },
-  series:   { exact: 210, wordPrefix: 160, includes: 110, none: 0 },
-  aperture: { exact: 190, wordPrefix: 170, includes: 140, none: 0 },
+  model:    { exact: 600, boundaryPrefix: 520, wordPrefix: 450, includes: 280, none: 0 },
+  brand:    { exact: 260, boundaryPrefix: 220, wordPrefix: 200, includes: 120, none: 0 },
+  alias:    { exact: 240, boundaryPrefix: 200, wordPrefix: 180, includes: 110, none: 0 },
+  series:   { exact: 210, boundaryPrefix: 180, wordPrefix: 160, includes: 110, none: 0 },
+  aperture: { exact: 190, boundaryPrefix: 180, wordPrefix: 170, includes: 140, none: 0 },
 };
 
 /**


### PR DESCRIPTION
## Summary
- prioritize numeric boundary-prefix matches like `40mm` over broader numeric prefixes like `400mm`
- add a `boundaryPrefix` match strength and corresponding scoring weights in lens search ranking
- add regression coverage to ensure `40` ranks true `40mm` matches ahead of `100-400mm` results

## Testing
- Not run (not requested)