### PR TITLE
Move lens search from nav to browse page header

### DIFF
--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/select";
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
+import LensSearchDialog from "./LensSearchDialog";
 import FeedbackTrigger from "./FeedbackTrigger";
 
 interface Props {
@@ -87,9 +88,12 @@ export default function LensListClient({ lenses }: Props) {
     <>
       <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 py-8 flex flex-col gap-6 pb-24">
         <div className="flex flex-col gap-4">
-          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-            {t("title")}
-          </h1>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+              {t("title")}
+            </h1>
+            <LensSearchDialog triggerVariant="icon" />
+          </div>
           <LensFilters
             filters={filters}
             brands={brands}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
-import LensSearchDialog from "@/components/LensSearchDialog";
 import LogoMark from "@/components/LogoMark";
 
 export default function Nav() {
@@ -51,7 +50,6 @@ export default function Nav() {
           >
             {t("about")}
           </Link>
-          <LensSearchDialog />
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- remove the global lens search trigger from the top navigation
- add the lens search trigger next to the lens list title on the browse page
- keep search access scoped to the browse experience instead of exposing it as a site-wide entry point

## Testing
- Not run (not requested)