### PR TITLE
feat(navigation): unify back button behavior

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -224,12 +224,8 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   return (
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
-      {/* Back link */}
-      <BackButton
-        fallbackHref="/lenses"
-        label={`← ${t("backToLenses")}`}
-        className="self-start text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-      />
+      {/* Back button */}
+      <BackButton fallbackHref="/lenses" />
 
       {/* Main content */}
       <div className="flex flex-col sm:flex-row gap-8">

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ExternalLink } from "@/components/ui/external-link";
 import { LensPlaceholderIcon } from "@/components/ui/lens-placeholder-icon";
 import { Link } from "@/i18n/navigation";
 import AddToCompareButton from "@/components/AddToCompareButton";
+import BackButton from "@/components/BackButton";
 import { ShareButton } from "@/components/ShareButton";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 import { ACTION_OUTLINE_CLS } from "@/lib/ui-tokens";
@@ -224,12 +225,11 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   return (
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
       {/* Back link */}
-      <Link
-        href="/lenses"
+      <BackButton
+        fallbackHref="/lenses"
+        label={`← ${t("backToLenses")}`}
         className="self-start text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-      >
-        ← {t("backToLenses")}
-      </Link>
+      />
 
       {/* Main content */}
       <div className="flex flex-col sm:flex-row gap-8">

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -27,24 +27,27 @@ export async function generateMetadata({
 export default async function ComparePage({
   searchParams,
 }: {
-  searchParams: Promise<{ ids?: string }>;
+  searchParams: Promise<{ ids?: string; from?: string; lensId?: string }>;
 }) {
-  const { ids } = await searchParams;
+  const { ids, from, lensId } = await searchParams;
   const t = await getTranslations("Compare");
 
   const lenses = parseLensIds(ids);
 
+  // Determine back destination: lens detail page if navigated from one, else lens list
+  const fallbackHref = from === "lens" && lensId ? `/lenses/${lensId}` : "/lenses";
+
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
       {/* Header */}
-      <ComparePageHeader lenses={lenses} minColumns={2} />
+      <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} />
 
       {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns */}
       <CompareTable lenses={lenses} minColumns={2} />
 
-{/* Back link */}
+      {/* Back link */}
       <BackButton
-        fallbackHref="/lenses"
+        fallbackHref={fallbackHref}
         label={`← ${t("backToLenses")}`}
         className="self-start text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
       />

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -45,12 +45,8 @@ export default async function ComparePage({
       {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns */}
       <CompareTable lenses={lenses} minColumns={2} />
 
-      {/* Back link */}
-      <BackButton
-        fallbackHref={fallbackHref}
-        label={`← ${t("backToLenses")}`}
-        className="self-start text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-      />
+      {/* Back button */}
+      <BackButton fallbackHref={fallbackHref} />
     </div>
   );
 }

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { ChevronLeft } from "lucide-react";
 import { useRouter } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
+import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
 
 interface BackButtonProps {
   fallbackHref: string;
-  label: string;
   className?: string;
 }
 
@@ -13,12 +14,17 @@ interface BackButtonProps {
  * Navigates to `fallbackHref`. The destination is determined by the caller —
  * use URL `?from=` params to pass context-aware targets.
  */
-export default function BackButton({ fallbackHref, label, className }: BackButtonProps) {
+export default function BackButton({ fallbackHref, className }: BackButtonProps) {
   const router = useRouter();
 
   return (
-    <button type="button" onClick={() => router.push(fallbackHref)} className={cn(className)}>
-      {label}
+    <button
+      type="button"
+      onClick={() => router.push(fallbackHref)}
+      className={cn(ICON_NAV_BTN_CLS, "h-8 w-8", className)}
+      aria-label="Go back"
+    >
+      <ChevronLeft className="h-4 w-4" />
     </button>
   );
 }

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -10,26 +10,14 @@ interface BackButtonProps {
 }
 
 /**
- * Navigates back in browser history when the previous page was within the same
- * origin. Falls back to `fallbackHref` when opened from an external link or
- * directly (no same-origin referrer).
+ * Navigates to `fallbackHref`. The destination is determined by the caller —
+ * use URL `?from=` params to pass context-aware targets.
  */
 export default function BackButton({ fallbackHref, label, className }: BackButtonProps) {
   const router = useRouter();
 
-  function handleBack() {
-    const sameOrigin =
-      document.referrer !== "" &&
-      new URL(document.referrer).origin === window.location.origin;
-    if (sameOrigin) {
-      router.back();
-    } else {
-      router.push(fallbackHref);
-    }
-  }
-
   return (
-    <button type="button" onClick={handleBack} className={cn(className)}>
+    <button type="button" onClick={() => router.push(fallbackHref)} className={cn(className)}>
       {label}
     </button>
   );

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -97,7 +97,6 @@ export default function CompareBar() {
               </button>
               <button
                 onClick={handleCompare}
-                disabled={selectedLenses.length < 2}
                 className={`shrink-0 text-sm font-medium px-4 py-2 rounded-xl ${ACTION_PRIMARY_CLS}`}
               >
                 {t("goCompare", { count: selectedLenses.length })}

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "@/i18n/navigation";
+import { useRouter, usePathname } from "@/i18n/navigation";
 import { allLenses } from "@/lib/lens";
 import { useCompare } from "@/context/CompareProvider";
 import { motion, AnimatePresence } from "motion/react";
@@ -17,6 +17,7 @@ export default function CompareBar() {
   const tBrand = useTranslations("Brands");
   const tCompare = useTranslations("Compare");
   const router = useRouter();
+  const pathname = usePathname();
   const { compareIds, toggleCompare, clearCompare } = useCompare();
 
   const selectedLenses = useMemo(
@@ -27,9 +28,16 @@ export default function CompareBar() {
     [compareIds]
   );
 
+  // Extract lens ID if currently on a lens detail page (/lenses/[id])
+  const currentLensId = useMemo(() => {
+    const match = pathname.match(/\/lenses\/(?!compare\b)([^/]+)$/);
+    return match?.[1] ?? null;
+  }, [pathname]);
+
   function handleCompare() {
     const ids = selectedLenses.map((l) => l.id).join(",");
-    router.push(`/lenses/compare?ids=${ids}`);
+    const fromParam = currentLensId ? `&from=lens&lensId=${currentLensId}` : "";
+    router.push(`/lenses/compare?ids=${ids}${fromParam}`);
   }
 
   return (

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -11,11 +11,12 @@ import type { Lens } from "@/lib/types";
 
 interface Props {
   lenses: Lens[];
+  fallbackHref: string;
   /** Matches CompareTable minColumns — button is hidden while empty slot columns are visible. */
   minColumns?: number;
 }
 
-export default function ComparePageHeader({ lenses, minColumns = 0 }: Props) {
+export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0 }: Props) {
   const t = useTranslations("Compare");
   const headerRef = useRef<HTMLDivElement>(null);
   const [showFab, setShowFab] = useState(false);
@@ -37,7 +38,7 @@ export default function ComparePageHeader({ lenses, minColumns = 0 }: Props) {
     <>
       <div ref={headerRef} className="flex items-center gap-3">
         <BackButton
-          fallbackHref="/lenses"
+          fallbackHref={fallbackHref}
           label="←"
           className="text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
         />

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -37,11 +37,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
   return (
     <>
       <div ref={headerRef} className="flex items-center gap-3">
-        <BackButton
-          fallbackHref={fallbackHref}
-          label="←"
-          className="text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-        />
+        <BackButton fallbackHref={fallbackHref} />
         <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h1>

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -28,6 +28,16 @@ export const LIST_ITEM_ACTIVE_CLS =
 export const ACTIVE_DOT_CLS = "bg-zinc-900 dark:bg-zinc-100";
 
 /**
+ * Square icon button for navigation actions (e.g. back).
+ * Transparent background by default; hover shows a subtle fill.
+ * Add a size class (e.g. `h-8 w-8`) per usage site.
+ */
+export const ICON_NAV_BTN_CLS =
+  "inline-flex shrink-0 items-center justify-center rounded-lg transition-colors " +
+  "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-100 active:text-zinc-900 " +
+  "dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-800 dark:active:text-zinc-100";
+
+/**
  * Circular dismiss / close icon button.
  * Normal state is transparent; hover/active shows a red fill + icon.
  * Add a size class (e.g. `h-8 w-8`) per usage site.

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -163,7 +163,6 @@
     "partial": "Partial",
     "unknown": "N/A",
     "missing": "-",
-    "backToLenses": "Back to Lenses",
     "addToCompare": "Add to Compare",
     "removeFromCompare": "Remove",
     "officialSite": "Official site",
@@ -181,7 +180,6 @@
   },
   "Compare": {
     "title": "Compare",
-    "backToLenses": "Back to Lenses",
     "officialSite": "Official site",
     "addLens": "Add lens",
     "selectFirst": "Add lens",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -163,7 +163,6 @@
     "partial": "部分",
     "unknown": "N/A",
     "missing": "-",
-    "backToLenses": "返回列表",
     "addToCompare": "加入对比",
     "removeFromCompare": "移除",
     "officialSite": "官网",
@@ -181,7 +180,6 @@
   },
   "Compare": {
     "title": "对比",
-    "backToLenses": "返回列表",
     "officialSite": "官网",
     "addLens": "添加镜头",
     "selectFirst": "添加镜头",


### PR DESCRIPTION
## Summary

- **Fix broken back navigation**: replaced unreliable `document.referrer` heuristic with explicit `?from=lens&lensId=` URL params. `CompareBar` now appends these params when navigating to the compare page from a lens detail page, so the back button correctly returns to that lens instead of always falling back to `/lenses`.
- **Remove single-lens restriction**: `CompareBar` no longer disables the compare button when only one lens is selected.
- **Redesign back button visuals**: replaced text label (`← Back to Lenses`) with a `ChevronLeft` icon button using the new `ICON_NAV_BTN_CLS` token — fixed `h-8 w-8` hit area, subtle hover fill, consistent with existing icon button patterns.
- **Clean up**: removed unused `backToLenses` i18n keys from both locales; simplified all `BackButton` call sites.

## Navigation flows covered

| Flow | Back destination |
|------|-----------------|
| List → Detail → back | List `/lenses` |
| List → Compare → back | List `/lenses` |
| List → Detail → Compare (`?from=lens`) → back | Detail `/lenses/[id]` |
| Cold start on Compare → back | List `/lenses` |

## Test plan

- [ ] List → Detail → back → lands on List
- [ ] List → Detail → add to compare → go compare → back → lands on Detail
- [ ] Open compare URL directly (cold start) → back → lands on List
- [ ] CompareBar with 1 lens selected — compare button is enabled
- [ ] Back button shows ChevronLeft icon with hover background on all three pages (detail top, compare top, compare bottom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)