### PR TITLE
refactor(spec-groups): single-pass resolve, field note in Report Dialog

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -5,9 +5,8 @@ import { getTranslations } from "next-intl/server";
 import { Flag } from "lucide-react";
 import { allLenses, getLensUrl } from "@/lib/lens";
 import { lensImageStyle } from "@/lib/lens-image";
-import { buildSpecGroups, getSpecRowPlainTextValue } from "@/lib/lens-spec-groups";
-import type { SpecRow, StructuredLine } from "@/lib/lens-spec-groups";
-import type { Lens } from "@/lib/types";
+import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens-spec-groups";
+import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens-spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
 import { LensPlaceholderIcon } from "@/components/ui/lens-placeholder-icon";
 import { Link } from "@/i18n/navigation";
@@ -55,50 +54,46 @@ function StructuredLines({ lines }: { lines: StructuredLine[] }) {
 }
 
 function renderRowValue(
-  row: SpecRow,
-  lens: Lens,
-  labels: { yes: string; no: string; partial: string; unknown: string; missing: string }
+  resolved: ResolvedSpecRow,
+  labels: { yes: string; no: string; partial: string; unknown: string; missing: string },
 ) {
-  if (row.kind === "bool") {
-    const subVal = row.getSubValue?.(lens);
+  if (resolved.kind === "bool") {
     return (
       <div>
         <BoolCell
-          value={row.getValue(lens)}
+          value={resolved.boolValue}
           yes={labels.yes}
           no={labels.no}
           partial={labels.partial}
           unknown={labels.unknown}
         />
-        {subVal && (
+        {resolved.subValue && (
           <p className="mt-0.5 text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-            {subVal}
+            {resolved.subValue}
           </p>
         )}
       </div>
     );
   }
-  const structuredLines = row.kind === "numeric" ? row.getStructuredLines?.(lens) : undefined;
-  const sub = row.getSubValue?.(lens);
-  if (structuredLines && structuredLines.length > 0) {
+  if (resolved.kind === "numeric" && resolved.structuredLines && resolved.structuredLines.length > 0) {
     return (
       <div>
-        <StructuredLines lines={structuredLines} />
-        {sub && (
+        <StructuredLines lines={resolved.structuredLines} />
+        {resolved.subValue && (
           <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-            {sub}
+            {resolved.subValue}
           </p>
         )}
       </div>
     );
   }
-  const primary = row.getDisplayValue(lens);
+  // resolved is ResolvedTextRow here
   return (
     <div>
-      <span className="whitespace-pre-line">{primary ?? labels.missing}</span>
-      {sub && (
+      <span className="whitespace-pre-line">{resolved.displayValue ?? labels.missing}</span>
+      {resolved.subValue && (
         <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-          {sub}
+          {resolved.subValue}
         </p>
       )}
     </div>
@@ -117,7 +112,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   const tBrand = await getTranslations("Brands");
   const url = getLensUrl(lens);
 
-  const groups = buildSpecGroups({
+  const specGroups = buildSpecGroups({
     groupOptics: t("groupOptics"),
     groupFocus: t("groupFocus"),
     groupStabilization: t("groupStabilization"),
@@ -186,13 +181,6 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   });
 
   // Per-view suppression: hide rows where this lens has no data.
-  const visibleGroups = groups
-    .map((group) => ({
-      ...group,
-      rows: group.rows.filter((row) => row.hasData(lens)),
-    }))
-    .filter((group) => group.rows.length > 0);
-
   const valueCellLabels = {
     yes: t("yes"),
     no: t("no"),
@@ -201,12 +189,14 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     missing: t("missing"),
   };
 
-  // Field options for the feedback dialog — mirrors exactly what the user sees in the spec table.
-  const reportableFields = visibleGroups.flatMap((group) =>
-    group.rows.map((row) => {
-      const currentValue = getSpecRowPlainTextValue(row, lens, valueCellLabels);
-      return { label: row.label, currentValue };
-    })
+  // Resolve all row values once. This is the single source of truth for both
+  // the rendered spec table and the Report Dialog's field list.
+  const resolvedGroups = resolveSpecGroups(specGroups, lens, valueCellLabels);
+
+  // Field options for the Report Dialog — taken directly from resolved values,
+  // identical to what is rendered in the spec table below.
+  const reportableFields = resolvedGroups.flatMap((group) =>
+    group.rows.map((row) => ({ label: row.label, currentValue: row.plainText }))
   );
 
   return (
@@ -273,7 +263,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
           {/* Grouped spec table */}
           <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
-            {visibleGroups.map((group, groupIdx) => (
+            {resolvedGroups.map((group, groupIdx) => (
               <div
                 key={group.label}
                 className={groupIdx > 0 ? "border-t border-zinc-200 dark:border-zinc-800" : ""}
@@ -288,23 +278,18 @@ export default async function LensDetailPage({ params }: { params: Params }) {
                 {/* Rows */}
                 <table className="w-full text-sm">
                   <tbody>
-                    {group.rows.map((row) => (
+                    {group.rows.map((resolved) => (
                       <tr
-                        key={row.label}
+                        key={resolved.label}
                         className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
                       >
                         <td className="px-4 py-2.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/30 w-40 whitespace-nowrap align-top">
-                          {row.label}
+                          {resolved.label}
                         </td>
                         <td className="px-4 py-2.5 text-zinc-700 dark:text-zinc-300">
                           <div className="flex items-center gap-1.5">
-                            {renderRowValue(row, lens, valueCellLabels)}
-                            {(() => {
-                              const note =
-                                (row.fieldNoteKey ? lens.fieldNotes?.[row.fieldNoteKey] : undefined) ??
-                                row.getNote?.(lens);
-                              return note ? <FieldNotePopover note={note} /> : null;
-                            })()}
+                            {renderRowValue(resolved, valueCellLabels)}
+                            {resolved.note && <FieldNotePopover note={resolved.note} />}
                           </div>
                         </td>
                       </tr>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -25,8 +25,8 @@ import { useCompare } from "@/context/CompareProvider";
 import { allLenses, getLensUrl, MAX_COMPARE } from "@/lib/lens";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { lensImageStyle } from "@/lib/lens-image";
-import { buildSpecGroups, getSpecRowPlainTextValue } from "@/lib/lens-spec-groups";
-import type { SpecRow, SpecGroup, StructuredLine } from "@/lib/lens-spec-groups";
+import { buildSpecGroups, resolveSpecRow } from "@/lib/lens-spec-groups";
+import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens-spec-groups";
 import type { Lens } from "@/lib/types";
 
 // --- LensHeaderContent: shared inner card content ---
@@ -317,6 +317,23 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
     [td]
   );
 
+  // Resolve all row values once per (lens, row) pair — single source of truth
+  // for both the rendered cells and the Report Dialog's field list.
+  const resolvedPerLens = useMemo(() => {
+    const map = new Map<string, Map<string, ResolvedSpecRow>>();
+    for (const lens of orderedLenses) {
+      const rowMap = new Map<string, ResolvedSpecRow>();
+      for (const group of allGroups) {
+        for (const row of group.rows) {
+          const resolved = resolveSpecRow(row, lens, valueCellLabels);
+          if (resolved) rowMap.set(row.label, resolved);
+        }
+      }
+      map.set(lens.id, rowMap);
+    }
+    return map;
+  }, [allGroups, orderedLenses, valueCellLabels]);
+
   // Per-view suppression: hide rows where no compared lens has data.
   const visibleGroups = useMemo(
     () =>
@@ -324,28 +341,31 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
         .map((group) => ({
           ...group,
           rows: group.rows.filter((row) =>
-            orderedLenses.some((l) => row.hasData(l))
+            orderedLenses.some((l) => resolvedPerLens.get(l.id)?.has(row.label))
           ),
         }))
         .filter((group) => group.rows.length > 0),
-    [allGroups, orderedLenses]
+    [allGroups, orderedLenses, resolvedPerLens]
   );
 
-  // Per-lens reportable fields: only rows visible for each specific lens.
+  // Per-lens Report Dialog fields — derived from resolved values, identical to
+  // what is rendered in the table cells.
   const lensFields = useMemo(() => {
     const map = new Map<string, FeedbackField[]>();
     for (const lens of orderedLenses) {
-      const fields = allGroups
-        .flatMap((group) => group.rows)
-        .filter((row) => row.hasData(lens))
-        .map((row) => {
-          const currentValue = getSpecRowPlainTextValue(row, lens, valueCellLabels);
-          return { label: row.label, currentValue };
-        });
+      const rowMap = resolvedPerLens.get(lens.id);
+      if (!rowMap) continue;
+      const fields: FeedbackField[] = [];
+      for (const group of allGroups) {
+        for (const row of group.rows) {
+          const resolved = rowMap.get(row.label);
+          if (resolved) fields.push({ label: resolved.label, currentValue: resolved.plainText });
+        }
+      }
       map.set(lens.id, fields);
     }
     return map;
-  }, [allGroups, orderedLenses, valueCellLabels]);
+  }, [resolvedPerLens, allGroups, orderedLenses]);
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const scrollContainer = useScrollContainer();
@@ -513,11 +533,14 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
 
                 {/* Data rows */}
                 {group.rows.map((row) => {
-                  // Compute best value for numeric rows
+                  // Compute best value for numeric rows using pre-resolved comparables.
                   let bestVal: number | null = null;
                   if (row.kind === "numeric" && row.bestDir) {
                     const vals = orderedLenses
-                      .map(row.toComparable)
+                      .map((l) => {
+                        const r = resolvedPerLens.get(l.id)?.get(row.label);
+                        return r?.kind === "numeric" ? r.comparable : undefined;
+                      })
                       .filter((v): v is number => v !== undefined);
                     if (vals.length > 1) {
                       bestVal =
@@ -539,12 +562,21 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
 
                       {/* Value cells — filled lenses */}
                       {orderedLenses.map((lens) => {
-                        const fieldNote =
-                          (row.fieldNoteKey ? lens.fieldNotes?.[row.fieldNoteKey] : undefined) ??
-                          row.getNote?.(lens);
+                        const resolved = resolvedPerLens.get(lens.id)?.get(row.label);
 
-                        if (row.kind === "bool") {
-                          const subVal = row.getSubValue?.(lens);
+                        // Lens has no data for this row — render empty cell.
+                        if (!resolved) {
+                          return (
+                            <td
+                              key={lens.id}
+                              className="px-3 py-3 text-center text-zinc-400 dark:text-zinc-600"
+                            >
+                              {valueCellLabels.missing}
+                            </td>
+                          );
+                        }
+
+                        if (resolved.kind === "bool") {
                           return (
                             <td
                               key={lens.id}
@@ -553,38 +585,31 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                               <div className="flex items-center justify-center gap-1">
                                 <div>
                                   <BoolCell
-                                  value={row.getValue(lens)}
-                                  yes={valueCellLabels.yes}
-                                  no={valueCellLabels.no}
-                                  partial={valueCellLabels.partial}
-                                  unknown={valueCellLabels.missing}
-                                />
-                                  {subVal && (
+                                    value={resolved.boolValue}
+                                    yes={valueCellLabels.yes}
+                                    no={valueCellLabels.no}
+                                    partial={valueCellLabels.partial}
+                                    unknown={valueCellLabels.missing}
+                                  />
+                                  {resolved.subValue && (
                                     <p className="mt-0.5 text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                      {subVal}
+                                      {resolved.subValue}
                                     </p>
                                   )}
                                 </div>
-                                {fieldNote && (
-                                  <FieldNotePopover note={fieldNote} />
-                                )}
+                                {resolved.note && <FieldNotePopover note={resolved.note} />}
                               </div>
                             </td>
                           );
                         }
 
-                        if (row.kind === "numeric") {
-                          const comparable = row.toComparable(lens);
+                        if (resolved.kind === "numeric") {
                           const isBest =
-                            bestVal !== null && comparable === bestVal;
-                          const fragment = isBest
-                            ? row.getHighlightFragment?.(lens)
-                            : undefined;
-                          const subVal = row.getSubValue?.(lens);
-                          const structuredLines = row.getStructuredLines?.(lens);
+                            bestVal !== null && resolved.comparable === bestVal;
+                          const fragment = isBest ? resolved.highlightFragment : undefined;
 
                           // --- Structured multi-line rendering ---
-                          if (structuredLines && structuredLines.length > 0) {
+                          if (resolved.structuredLines && resolved.structuredLines.length > 0) {
                             return (
                               <td
                                 key={lens.id}
@@ -592,7 +617,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                               >
                                 <div className="flex items-center justify-center gap-1">
                                   <div className="flex flex-col items-center gap-0.5">
-                                    {structuredLines.map(
+                                    {resolved.structuredLines.map(
                                       (line: StructuredLine, i: number) => {
                                         const lineHighlighted =
                                           isBest && fragment === line.value;
@@ -618,22 +643,20 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                                         );
                                       }
                                     )}
-                                    {subVal && (
+                                    {resolved.subValue && (
                                       <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                        {subVal}
+                                        {resolved.subValue}
                                       </p>
                                     )}
                                   </div>
-                                  {fieldNote && (
-                                    <FieldNotePopover note={fieldNote} />
-                                  )}
+                                  {resolved.note && <FieldNotePopover note={resolved.note} />}
                                 </div>
                               </td>
                             );
                           }
 
                           // --- Plain string rendering ---
-                          const displayVal = row.getDisplayValue(lens);
+                          const displayVal = resolved.displayValue;
                           const usePartialHighlight =
                             isBest &&
                             fragment !== undefined &&
@@ -689,23 +712,19 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                                   <span className="whitespace-pre-line">
                                     {primaryNode}
                                   </span>
-                                  {subVal && (
+                                  {resolved.subValue && (
                                     <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                      {subVal}
+                                      {resolved.subValue}
                                     </p>
                                   )}
                                 </div>
-                                {fieldNote && (
-                                  <FieldNotePopover note={fieldNote} />
-                                )}
+                                {resolved.note && <FieldNotePopover note={resolved.note} />}
                               </div>
                             </td>
                           );
                         }
 
                         // text row
-                        const displayVal = row.getDisplayValue(lens);
-                        const subVal = row.getSubValue?.(lens);
                         return (
                           <td
                             key={lens.id}
@@ -714,17 +733,15 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                             <div className="flex items-center justify-center gap-1">
                               <div>
                                 <span className="whitespace-pre-line">
-                                  {displayVal ?? valueCellLabels.missing}
+                                  {resolved.displayValue ?? valueCellLabels.missing}
                                 </span>
-                                {subVal && (
+                                {resolved.subValue && (
                                   <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-                                    {subVal}
+                                    {resolved.subValue}
                                   </p>
                                 )}
                               </div>
-                              {fieldNote && (
-                                <FieldNotePopover note={fieldNote} />
-                              )}
+                              {resolved.note && <FieldNotePopover note={resolved.note} />}
                             </div>
                           </td>
                         );

--- a/src/lib/__tests__/lens-spec-groups.test.ts
+++ b/src/lib/__tests__/lens-spec-groups.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSpecGroups, getSpecRowPlainTextValue } from "@/lib/lens-spec-groups";
+import { buildSpecGroups, resolveSpecRow } from "@/lib/lens-spec-groups";
 import type { Lens } from "@/lib/types";
 
 const labels = {
@@ -106,12 +106,12 @@ function getRow(label: string) {
   return row!;
 }
 
-describe("getSpecRowPlainTextValue", () => {
+describe("resolveSpecRow — plainText", () => {
   it("includes secondary text for bool rows", () => {
     const lens = makeLens({ ois: true, oisStops: 5 });
     const row = getRow("OIS");
 
-    expect(getSpecRowPlainTextValue(row, lens, valueLabels)).toBe("Yes\n5 stops");
+    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe("Yes\n5 stops");
   });
 
   it("serializes structured numeric rows and macro details", () => {
@@ -124,7 +124,7 @@ describe("getSpecRowPlainTextValue", () => {
     });
     const row = getRow("Min Focus Distance");
 
-    expect(getSpecRowPlainTextValue(row, lens, valueLabels)).toBe(
+    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe(
       "15cm (Wide)\n30cm (Tele)\nMacro: 12cm"
     );
   });
@@ -136,7 +136,7 @@ describe("getSpecRowPlainTextValue", () => {
     });
     const row = getRow("Dimensions");
 
-    expect(getSpecRowPlainTextValue(row, lens, valueLabels)).toBe(
+    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe(
       "⌀65 × 71mm\nRetracted 60mm\nTele 89mm"
     );
   });

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -207,8 +207,8 @@ export interface SpecGroupLabels {
   motorClass: Record<FocusMotorClass, string>;
 }
 
-function joinWithSub(primary: string, subValue: string | undefined): string {
-  return subValue ? `${primary}\n${subValue}` : primary;
+function joinParts(...parts: (string | undefined)[]): string {
+  return parts.filter(Boolean).join("\n");
 }
 
 /**
@@ -247,7 +247,7 @@ export function resolveSpecRow(
       note,
       boolValue,
       subValue,
-      plainText: joinWithSub(primaryText, subValue),
+      plainText: joinParts(primaryText, subValue, note),
     };
   }
 
@@ -271,7 +271,7 @@ export function resolveSpecRow(
       comparable: row.toComparable(lens),
       bestDir: row.bestDir,
       highlightFragment: row.getHighlightFragment?.(lens),
-      plainText: joinWithSub(primary, subValue),
+      plainText: joinParts(primary, subValue, note),
     };
   }
 
@@ -284,7 +284,7 @@ export function resolveSpecRow(
     note,
     displayValue,
     subValue,
-    plainText: joinWithSub(displayValue ?? labels.missing, subValue),
+    plainText: joinParts(displayValue ?? labels.missing, subValue, note),
   };
 }
 

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -104,6 +104,50 @@ export interface SpecValueTextLabels {
 }
 
 // ---------------------------------------------------------------------------
+// Resolved row types — all formatter functions already called, values are plain data
+// ---------------------------------------------------------------------------
+
+export interface ResolvedTextRow {
+  kind: "text";
+  label: string;
+  /** Resolved note for the ⓘ popover, if any. */
+  note?: string;
+  displayValue?: string;
+  subValue?: string;
+  /** Plain-text representation of the visible cell — single source of truth for the Report Dialog. */
+  plainText: string;
+}
+
+export interface ResolvedNumericRow {
+  kind: "numeric";
+  label: string;
+  note?: string;
+  displayValue?: string;
+  subValue?: string;
+  structuredLines?: StructuredLine[];
+  comparable?: number;
+  bestDir?: "min" | "max";
+  highlightFragment?: string;
+  plainText: string;
+}
+
+export interface ResolvedBoolRow {
+  kind: "bool";
+  label: string;
+  note?: string;
+  boolValue: boolean | "partial" | undefined;
+  subValue?: string;
+  plainText: string;
+}
+
+export type ResolvedSpecRow = ResolvedTextRow | ResolvedNumericRow | ResolvedBoolRow;
+
+export interface ResolvedSpecGroup {
+  label: string;
+  rows: ResolvedSpecRow[];
+}
+
+// ---------------------------------------------------------------------------
 // Labels interface — caller passes all pre-translated strings
 // ---------------------------------------------------------------------------
 
@@ -163,51 +207,104 @@ export interface SpecGroupLabels {
   motorClass: Record<FocusMotorClass, string>;
 }
 
-function appendSubValue(primary: string | undefined, subValue: string | undefined) {
-  if (!primary && !subValue) return undefined;
-  if (!subValue) return primary;
-  return primary ? `${primary}\n${subValue}` : subValue;
-}
-
-function structuredLinesToText(lines: StructuredLine[] | undefined) {
-  if (!lines || lines.length === 0) return undefined;
-  return lines
-    .map((line) => (line.label ? `${line.value} (${line.label})` : line.value))
-    .join("\n");
+function joinWithSub(primary: string, subValue: string | undefined): string {
+  return subValue ? `${primary}\n${subValue}` : primary;
 }
 
 /**
- * Returns the plain-text value as closely as possible to what the user sees in
- * the spec table, including structured lines and secondary text.
+ * Resolves a single spec row for a specific lens, calling all formatter functions
+ * exactly once. Returns null when this lens has no data for the row (caller should
+ * omit the row from the visible set for this lens).
+ *
+ * The returned `plainText` field is the single source of truth for the Report
+ * Dialog's "current value" — identical to what is rendered in the spec table.
  */
-export function getSpecRowPlainTextValue(
+export function resolveSpecRow(
   row: SpecRow,
   lens: Lens,
   labels: SpecValueTextLabels
-): string | undefined {
+): ResolvedSpecRow | null {
+  if (!row.hasData(lens)) return null;
+
+  const note =
+    (row.fieldNoteKey ? lens.fieldNotes?.[row.fieldNoteKey] : undefined) ??
+    row.getNote?.(lens);
+
   if (row.kind === "bool") {
-    const value = row.getValue(lens);
-    const primary =
-      value === true
+    const boolValue = row.getValue(lens);
+    const subValue = row.getSubValue?.(lens);
+    const primaryText =
+      boolValue === true
         ? labels.yes
-        : value === "partial"
+        : boolValue === "partial"
           ? labels.partial
-          : value === false
+          : boolValue === false
             ? labels.no
             : labels.unknown;
-    return appendSubValue(primary, row.getSubValue?.(lens));
+    return {
+      kind: "bool",
+      label: row.label,
+      note,
+      boolValue,
+      subValue,
+      plainText: joinWithSub(primaryText, subValue),
+    };
   }
 
   if (row.kind === "numeric") {
+    const structuredLines = row.getStructuredLines?.(lens);
+    const displayValue = row.getDisplayValue(lens);
+    const subValue = row.getSubValue?.(lens);
     const primary =
-      structuredLinesToText(row.getStructuredLines?.(lens)) ??
-      row.getDisplayValue(lens) ??
-      labels.missing;
-    return appendSubValue(primary, row.getSubValue?.(lens));
+      structuredLines && structuredLines.length > 0
+        ? structuredLines
+            .map((l) => (l.label ? `${l.value} (${l.label})` : l.value))
+            .join("\n")
+        : (displayValue ?? labels.missing);
+    return {
+      kind: "numeric",
+      label: row.label,
+      note,
+      displayValue,
+      subValue,
+      structuredLines,
+      comparable: row.toComparable(lens),
+      bestDir: row.bestDir,
+      highlightFragment: row.getHighlightFragment?.(lens),
+      plainText: joinWithSub(primary, subValue),
+    };
   }
 
-  const primary = row.getDisplayValue(lens) ?? labels.missing;
-  return appendSubValue(primary, row.getSubValue?.(lens));
+  // text
+  const displayValue = row.getDisplayValue(lens);
+  const subValue = row.getSubValue?.(lens);
+  return {
+    kind: "text",
+    label: row.label,
+    note,
+    displayValue,
+    subValue,
+    plainText: joinWithSub(displayValue ?? labels.missing, subValue),
+  };
+}
+
+/**
+ * Resolves all spec groups for a single lens, filtering out rows and groups
+ * where the lens has no data. Use on the detail page or any single-lens view.
+ */
+export function resolveSpecGroups(
+  groups: SpecGroup[],
+  lens: Lens,
+  labels: SpecValueTextLabels
+): ResolvedSpecGroup[] {
+  return groups
+    .map((group) => ({
+      label: group.label,
+      rows: group.rows
+        .map((row) => resolveSpecRow(row, lens, labels))
+        .filter((r): r is ResolvedSpecRow => r !== null),
+    }))
+    .filter((group) => group.rows.length > 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -247,7 +247,7 @@ export function resolveSpecRow(
       note,
       boolValue,
       subValue,
-      plainText: joinParts(primaryText, subValue, note),
+      plainText: joinParts(primaryText, subValue, note && `(${note})`),
     };
   }
 
@@ -271,7 +271,7 @@ export function resolveSpecRow(
       comparable: row.toComparable(lens),
       bestDir: row.bestDir,
       highlightFragment: row.getHighlightFragment?.(lens),
-      plainText: joinParts(primary, subValue, note),
+      plainText: joinParts(primary, subValue, note && `(${note})`),
     };
   }
 
@@ -284,7 +284,7 @@ export function resolveSpecRow(
     note,
     displayValue,
     subValue,
-    plainText: joinParts(displayValue ?? labels.missing, subValue, note),
+    plainText: joinParts(displayValue ?? labels.missing, subValue, note && `(${note})`),
   };
 }
 


### PR DESCRIPTION
## Summary

- Replace `getSpecRowPlainTextValue` with `resolveSpecRow` / `resolveSpecGroups`: all formatter functions are now called exactly once per (row, lens) pair, eliminating the risk of drift between the spec table and the Report Dialog's "current value"
- `ResolvedSpecRow.plainText` is the single source of truth — both the rendered cell and the feedback field derive from the same computation
- Field notes (previously only visible via the ⓘ popover) are now appended to `plainText` in parentheses, so the Report Dialog shows the full context a user sees

## Test plan

- [ ] Detail page: spec table renders correctly, Report Dialog field list matches table rows and values
- [ ] Compare table: cells render correctly, best-value highlighting works, Report Dialog per-lens fields match
- [ ] Field with a field note (e.g. Filter Size = N/A): Report Dialog shows `N/A\n(note text)`
- [ ] `vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)