### PR TITLE
feat(mobile): lightbox image, share flash fix, cold-start skeleton, nav auto-hide

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -171,17 +171,40 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
   const td = useTranslations("LensDetail");
   const tBrand = useTranslations("Brands");
   const router = useRouter();
-  const { replaceCompare } = useCompare();
+  const { compareIds, replaceCompare } = useCompare();
   const initialLensIds = useMemo(
     () => initialLenses.map((lens) => lens.id),
     [initialLenses]
   );
   const [orderedIds, setOrderedIds] = useState(initialLensIds);
 
+  // Keep a ref to the latest compareIds so the init effect can read the
+  // current context value without re-running every time it changes.
+  const compareIdsRef = useRef(compareIds);
+  useEffect(() => { compareIdsRef.current = compareIds; }, [compareIds]);
+
   useEffect(() => {
-    replaceCompare(initialLensIds);
-    setOrderedIds(initialLensIds);
-  }, [initialLensIds, replaceCompare]);
+    if (initialLensIds.length > 0) {
+      // URL has IDs — URL is the source of truth.
+      replaceCompare(initialLensIds);
+      setOrderedIds(initialLensIds);
+    } else {
+      const existing = compareIdsRef.current;
+      if (existing.length > 0) {
+        // URL has no IDs but context does (e.g. user navigated via a bare
+        // /compare link). Restore from context and sync the URL so the
+        // server can hydrate the correct lenses.
+        setOrderedIds(existing);
+        startTransition(() => {
+          router.replace(`/lenses/compare?ids=${existing.join(",")}`);
+        });
+      } else {
+        // Genuine cold start — nothing to restore.
+        replaceCompare([]);
+        setOrderedIds([]);
+      }
+    }
+  }, [initialLensIds, replaceCompare, router]);
 
   const orderedLenses = orderedIds
     .map((id) => allLenses.find((lens) => lens.id === id))

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -515,8 +515,34 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
           </tr>
         </thead>
 
-        {orderedLenses.length > 0 && <tbody>
-          {visibleGroups.map((group) => {
+        <tbody>
+          {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
+          {orderedLenses.length === 0 && allGroups.map((group) => (
+            <React.Fragment key={group.label}>
+              <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
+                <td colSpan={totalColSpan} className="h-8 text-center">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {group.label}
+                  </span>
+                </td>
+              </tr>
+              {group.rows.map((row) => (
+                <tr key={row.label} className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+                  <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
+                    {row.label}
+                  </td>
+                  {Array.from({ length: emptySlotCount }).map((_, i) => (
+                    <td key={i} className="px-3 py-3 text-center text-xs text-zinc-200 dark:text-zinc-800">
+                      —
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </React.Fragment>
+          ))}
+
+          {/* Populated table: only rendered when at least one lens is selected */}
+          {orderedLenses.length > 0 && visibleGroups.map((group) => {
             return (
               <React.Fragment key={group.label}>
                 {/* Group header row.
@@ -759,7 +785,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
               </React.Fragment>
             );
           })}
-        </tbody>}
+        </tbody>
 
         {orderedLenses.length > 0 && <tfoot>
           {/* Footer row: official site + report links per lens */}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -5,10 +5,16 @@ import { Link, usePathname } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
+import { useCompare } from "@/context/CompareProvider";
 
 export default function Nav() {
   const t = useTranslations("Nav");
   const pathname = usePathname();
+  const { compareIds } = useCompare();
+  const compareHref =
+    compareIds.length > 0
+      ? `/lenses/compare?ids=${compareIds.join(",")}`
+      : "/lenses/compare";
 
   return (
     <header className="shrink-0 border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black z-30">
@@ -33,7 +39,7 @@ export default function Nav() {
             {t("lenses")}
           </Link>
           <Link
-            href="/lenses/compare"
+            href={compareHref}
             className={`text-sm transition-colors ${
               pathname.startsWith("/lenses/compare")
                 ? "text-zinc-900 dark:text-zinc-50 font-medium"

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,23 +1,59 @@
 "use client";
 
+import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
 import { useCompare } from "@/context/CompareProvider";
+import { useScrollContainer } from "@/context/ScrollContainerContext";
+import { cn } from "@/lib/utils";
 
 export default function Nav() {
   const t = useTranslations("Nav");
   const pathname = usePathname();
   const { compareIds } = useCompare();
+  const scrollContainer = useScrollContainer();
+  const [hidden, setHidden] = useState(false);
+  const lastScrollY = useRef(0);
+
+  // Hide on scroll-down, reveal on scroll-up (mobile only — sm: always visible via CSS).
+  useEffect(() => {
+    const el = scrollContainer;
+    if (!el) return;
+    const onScroll = () => {
+      const y = el.scrollTop;
+      if (y > lastScrollY.current && y > 56) {
+        setHidden(true);
+      } else if (y < lastScrollY.current) {
+        setHidden(false);
+      }
+      lastScrollY.current = y;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [scrollContainer]);
+
+  // Always reveal when navigating to a new page.
+  useEffect(() => {
+    setHidden(false);
+    lastScrollY.current = 0;
+  }, [pathname]);
+
   const compareHref =
     compareIds.length > 0
       ? `/lenses/compare?ids=${compareIds.join(",")}`
       : "/lenses/compare";
 
   return (
-    <header className="shrink-0 border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black z-30">
+    <header
+      className={cn(
+        "shrink-0 border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black z-30",
+        "transition-[margin-top] duration-300 ease-in-out",
+        hidden && "-mt-14 sm:mt-0"
+      )}
+    >
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         <Link
           href="/"

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -559,7 +559,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
         {/* When the lightbox is open its own backdrop (z-60) covers everything;
             suppress the Drawer backdrop to avoid double-darkening the top half. */}
         <Drawer.Backdrop className={cn(
-          `fixed inset-0 ${Z.overlay} duration-150 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+          `fixed inset-0 ${Z.overlay} transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
           lightboxOpen ? "bg-transparent" : "bg-black/40"
         )} />
         <Drawer.Popup className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[env(safe-area-inset-bottom,0px)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -83,13 +83,10 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);
 
-    // Compute lightbox scale from window.innerWidth — avoids portal-ref timing
-    // issues where clientWidth reads 0 before the dialog has laid out.
-    // Card CSS: mobile = calc(100vw - 44px), desktop (sm+) = calc(100vw - 24px),
-    // both capped at max-w-[750px].
+    // Compute lightbox scale from window.innerWidth. Card CSS width is
+    // calc(100vw - 44px) capped at max-w-[750px], so we mirror that exactly.
     const updateLightboxScale = () => {
-      const margin = window.innerWidth >= 640 ? 24 : 44;
-      setLightboxScale(Math.min(1, (window.innerWidth - margin) / POSTER_W));
+      setLightboxScale(Math.min(1, (window.innerWidth - 44) / POSTER_W));
     };
     updateLightboxScale();
     window.addEventListener("resize", updateLightboxScale);
@@ -371,7 +368,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
               }}
             >
               {/* Wrapper: anchor for the mobile close button only; NOT the resize-observed element */}
-              <div className="relative w-[calc(100vw-44px)] max-w-[750px] sm:w-[calc(100vw-1.5rem)]">
+              <div className="relative w-[calc(100vw-44px)] max-w-[750px]">
                 {/* Mobile-only close button — center sits on the top-right corner of the card */}
                 <button
                   onClick={() => setLightboxOpen(false)}

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -55,7 +55,8 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
 
   // Full-size lightbox
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [lightboxScale, setLightboxScale] = useState(1);
+  const [lightboxImageUrl, setLightboxImageUrl] = useState<string | null>(null);
+  const [lightboxImageLoading, setLightboxImageLoading] = useState(false);
   const [hasScrolled, setHasScrolled] = useState(false);
   const [isScrollable, setIsScrollable] = useState(false);
   const lightboxScrollRef = useRef<HTMLDivElement | null>(null);
@@ -83,32 +84,17 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);
 
-    // Compute lightbox scale from window.innerWidth. Card CSS width is
-    // calc(100vw - 44px) capped at max-w-[750px], so we mirror that exactly.
-    const updateLightboxScale = () => {
-      setLightboxScale(Math.min(1, (window.innerWidth - 44) / POSTER_W));
-    };
-    updateLightboxScale();
-    window.addEventListener("resize", updateLightboxScale);
-
     return () => {
       mq.removeEventListener("change", handler);
-      window.removeEventListener("resize", updateLightboxScale);
     };
   }, []);
 
-  // Detect whether the lightbox poster is scrollable; reset scroll hint state on close
+  // Reset scroll hint state when lightbox closes
   useEffect(() => {
     if (!lightboxOpen) {
       setHasScrolled(false);
       setIsScrollable(false);
-      return;
     }
-    const id = requestAnimationFrame(() => {
-      const el = lightboxScrollRef.current;
-      if (el) setIsScrollable(el.scrollHeight > el.clientHeight + 1);
-    });
-    return () => cancelAnimationFrame(id);
   }, [lightboxOpen]);
 
   // Keep shareUrl in sync when panel opens
@@ -226,6 +212,20 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
     }
   }, [lenses]);
 
+  const handleOpenLightbox = useCallback(async () => {
+    setLightboxOpen(true);
+    if (!posterRef.current) return;
+    setLightboxImageLoading(true);
+    try {
+      const url = await rasterizePoster(posterRef.current);
+      setLightboxImageUrl(url);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLightboxImageLoading(false);
+    }
+  }, []);
+
   const truncatedUrl =
     shareUrl.length > 56 ? shareUrl.slice(0, 56) + "…" : shareUrl;
 
@@ -317,7 +317,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
           <div
             className="group relative -mx-4 cursor-zoom-in overflow-hidden"
             style={{ height: PREVIEW_H }}
-            onClick={() => setLightboxOpen(true)}
+            onClick={handleOpenLightbox}
           >
             {/* Scale wrapper: absolute so it doesn't affect flow height */}
             <div
@@ -355,7 +355,10 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
             open={lightboxOpen}
             onOpenChange={(open) => {
               setLightboxOpen(open);
-              if (!open) { setHasScrolled(false); setIsScrollable(false); }
+              if (!open) {
+                setLightboxImageUrl(null);
+                setLightboxImageLoading(false);
+              }
             }}
           >
             <DialogContent
@@ -385,15 +388,27 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
                   transition={{ duration: 0.12, ease: "easeOut" }}
                   className="relative w-full overflow-hidden rounded-2xl bg-white shadow-[0_8px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(0,0,0,0.06)]"
                 >
-                  {/* Scrollable poster at full (fit-scaled) width */}
+                  {/* Rasterized poster image — naturally scales to card width, no zoom math needed */}
                   <div
                     ref={lightboxScrollRef}
-                    className="max-h-[calc(100svh-3rem-10px)] overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100svh-3rem)]"
+                    className="max-h-[calc(100svh-3rem-10px)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100svh-3rem)]"
                     onScroll={() => { if (!hasScrolled) setHasScrolled(true); }}
                   >
-                    <div style={{ width: POSTER_W, zoom: lightboxScale }}>
-                      <SharePoster lenses={lenses} labels={posterLabels} custom={posterCustom} shareUrl={shareUrl} />
-                    </div>
+                    {lightboxImageLoading ? (
+                      <div className="flex h-48 items-center justify-center">
+                        <Loader2 className="size-6 animate-spin text-zinc-400" />
+                      </div>
+                    ) : lightboxImageUrl ? (
+                      <img
+                        src={lightboxImageUrl}
+                        alt=""
+                        className="w-full"
+                        onLoad={() => {
+                          const el = lightboxScrollRef.current;
+                          if (el) setIsScrollable(el.scrollHeight > el.clientHeight + 1);
+                        }}
+                      />
+                    ) : null}
                   </div>
 
                   {/* Scroll hint: bottom gradient + double chevron, disappears on first scroll */}


### PR DESCRIPTION
## Summary

- **fix(lightbox):** Replace zoom+HTML approach in the share lightbox with a rasterized PNG. On open, `rasterizePoster()` generates the image; `<img className="w-full">` displays it — the browser scales naturally with no JS math. Removes `lightboxScale` state, resize listener, `overflow-x-hidden`, and the second `SharePoster` render in the portal.

- **fix(drawer):** Sync backdrop `duration-150` → `duration-200` to match popup, and add `transition-colors` so the `bg-transparent`/`bg-black/40` toggle (while lightbox is open) eases instead of snapping — both were causing a flash on dismiss.

- **feat(compare):** Show all spec group headers and row labels on cold start, with `—` placeholder cells. Users see every comparable dimension before adding any lenses.

- **fix(compare):** Preserve context IDs when navigating to `/lenses/compare` via bare links (Nav, home CTA). `CompareTable` init now falls back to context IDs and redirects to `?ids=...` if the URL arrives empty. Nav link is also context-aware to avoid the intermediate flash.

- **feat(nav):** Auto-hide navbar on scroll-down, reveal on scroll-up — mobile only (`sm:` breakpoint always shows it on desktop). Uses `ScrollContainer` scroll events + `-mt-14` negative margin so the content area expands to full viewport height when hidden. Resets to visible on every route change.

## Test plan

- [ ] Share lightbox: tap poster preview → spinner → full-res image appears, no clipping on any screen width
- [ ] Share drawer dismiss: no flash/flicker on swipe-down or tap-outside
- [ ] Compare cold start: spec skeleton visible with all group/row labels and `—` placeholders
- [ ] Navigate to `/lenses/compare` from Nav while lenses are selected → IDs preserved, no context drop
- [ ] Mobile scroll: navbar hides on scroll-down, reappears on scroll-up; always visible on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)