### PR TITLE
fix: mobile UI improvements (card layout, nav conflict, weight format)

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useScrollContainer } from "@/context/ScrollContainerContext";
+import { useScrollContainer, useNavLock } from "@/context/ScrollContainerContext";
 import Image from "next/image";
 import { ExternalLink } from "@/components/ui/external-link";
 import { useTranslations } from "next-intl";
@@ -392,6 +392,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const scrollContainer = useScrollContainer();
+  const { lockNav } = useNavLock();
 
   // --- Phantom sticky header ---
   const theadRef = useRef<HTMLTableSectionElement>(null);
@@ -410,6 +411,12 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
     observer.observe(thead);
     return () => observer.disconnect();
   }, [scrollContainer]);
+
+  // Lock the nav hidden while the phantom header is active so only one
+  // top-chrome element occupies the screen at a time on mobile.
+  useEffect(() => {
+    lockNav(showPhantom);
+  }, [showPhantom]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Aperture } from "lucide-react";
+import { Aperture, Plus, Check } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
 import { ACTION_PRIMARY_CLS, CARD_SELECTED_BORDER_CLS } from "@/lib/ui-tokens";
@@ -67,7 +67,7 @@ export default function LensCard({
   return (
     <div
       {...hookAttr("card")}
-      className={`rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] ${
+      className={`rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] max-[499px]:relative ${
         isSelected
           ? CARD_SELECTED_BORDER_CLS
           : "border-zinc-200 dark:border-zinc-800"
@@ -153,10 +153,26 @@ export default function LensCard({
         </div>
       </Link>
 
+      {/* Mobile-only icon compare toggle — absolute in top-right corner */}
+      <button
+        onClick={onToggle}
+        disabled={selectionDisabled}
+        aria-label={isSelected ? t("removeFromCompare") : t("addToCompare")}
+        className={`hidden max-[499px]:flex absolute top-2.5 right-2.5 z-10 items-center justify-center h-7 w-7 rounded-full transition-colors ${
+          isSelected
+            ? ACTION_PRIMARY_CLS
+            : selectionDisabled
+              ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 cursor-not-allowed"
+              : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700"
+        }`}
+      >
+        {isSelected ? <Check className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+      </button>
+
       {/* Compare toggle */}
       <div
         {...hookAttr("cardFooter")}
-        className="mt-auto px-3 pb-3 sm:px-4 sm:pb-4"
+        className="mt-auto px-3 pb-3 sm:px-4 sm:pb-4 max-[499px]:hidden"
       >
         <Button
           size="sm"

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -32,6 +32,7 @@ export default function LensCard({
   const equivDisplay = fmt.focalRangeDisplay(fmt.focalEquiv(lens.focalLengthMin), fmt.focalEquiv(lens.focalLengthMax));
   const mfdDisplay = lens.minFocusDistance ? `${lens.minFocusDistance.cm}cm` : "—";
   const filterDisplay = fmt.filterSizeDisplay(lens.filterMm);
+  const weightDisplay = fmt.weightDisplay(lens.weightG, "g") ?? "—";
   const badges = [
     lens.af
       ? {
@@ -137,7 +138,7 @@ export default function LensCard({
             <div className="min-w-0 truncate">
               {equivDisplay} {t("equivSuffix")}
             </div>
-            <div className="shrink-0">{lens.weightG}g</div>
+            <div className="shrink-0">{weightDisplay}</div>
           </dl>
 
           {/* Desktop: 2×2 data grid */}
@@ -147,7 +148,7 @@ export default function LensCard({
             <div className="min-w-0 truncate">
               {equivDisplay} {t("equivSuffix")}
             </div>
-            <div className="text-right">{lens.weightG}g</div>
+            <div className="text-right">{weightDisplay}</div>
           </dl>
         </div>
       </Link>

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -76,15 +76,15 @@ export default function LensCard({
       {/* Clickable detail area */}
       <Link
         href={`/lenses/${lens.id}`}
-        className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+        className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors max-[499px]:flex-row"
       >
         <div
           {...hookAttr("cardMedia")}
-          className="relative aspect-[3/2] overflow-hidden border-b border-zinc-100/80 bg-zinc-50/40 sm:aspect-[5/4] dark:border-zinc-800 dark:bg-zinc-900/40"
+          className="relative aspect-[3/2] overflow-hidden border-b border-zinc-100/80 bg-zinc-50/40 sm:aspect-[5/4] dark:border-zinc-800 dark:bg-zinc-900/40 max-[499px]:aspect-auto max-[499px]:w-28 max-[499px]:shrink-0 max-[499px]:self-stretch max-[499px]:border-b-0 max-[499px]:border-r"
         >
           <div
             {...hookAttr("cardMediaInner")}
-            className="absolute inset-0 p-3 sm:p-7"
+            className="absolute inset-0 p-3 sm:p-7 max-[499px]:p-2"
           >
             <div className="relative h-full w-full overflow-hidden rounded-xl">
               {lens.imageUrl ? (
@@ -92,7 +92,7 @@ export default function LensCard({
                   src={lens.imageUrl}
                   alt={lens.model}
                   fill
-                  sizes="(max-width: 640px) 50vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
+                  sizes="(max-width: 499px) 112px, (max-width: 640px) 50vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
                   style={lensImageStyle}
                   className="object-contain"
                 />

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -7,7 +7,7 @@ import LensSearchDialog from "@/components/LensSearchDialog";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
 import { useCompare } from "@/context/CompareProvider";
-import { useScrollContainer } from "@/context/ScrollContainerContext";
+import { useScrollContainer, useNavLock } from "@/context/ScrollContainerContext";
 import { cn } from "@/lib/utils";
 
 export default function Nav() {
@@ -15,6 +15,7 @@ export default function Nav() {
   const pathname = usePathname();
   const { compareIds } = useCompare();
   const scrollContainer = useScrollContainer();
+  const { navLocked, lockNav } = useNavLock();
   const [hidden, setHidden] = useState(false);
   const lastScrollY = useRef(0);
 
@@ -35,11 +36,17 @@ export default function Nav() {
     return () => el.removeEventListener("scroll", onScroll);
   }, [scrollContainer]);
 
-  // Always reveal when navigating to a new page.
+  // Always reveal when navigating to a new page, and release any nav lock.
   useEffect(() => {
     setHidden(false);
     lastScrollY.current = 0;
-  }, [pathname]);
+    lockNav(false);
+  }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When the nav lock is released, immediately snap nav back to visible.
+  useEffect(() => {
+    if (!navLocked) setHidden(false);
+  }, [navLocked]);
 
   const compareHref =
     compareIds.length > 0
@@ -51,7 +58,7 @@ export default function Nav() {
       className={cn(
         "fixed top-0 inset-x-0 border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black z-30",
         "transition-transform duration-300 ease-in-out",
-        hidden && "-translate-y-full sm:translate-y-0"
+        (hidden || navLocked) && "-translate-y-full sm:translate-y-0"
       )}
     >
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 h-[var(--nav-height)] flex items-center justify-between">

--- a/src/context/ScrollContainerContext.tsx
+++ b/src/context/ScrollContainerContext.tsx
@@ -7,14 +7,22 @@ import { createContext, useContext, useState } from "react";
 // into their nearest common ancestor via context. This provider holds the scroll
 // element and exposes both the value (for listeners like Nav) and the setter (for
 // the scroll div to register itself).
+//
+// navLocked: when true, Nav stays hidden regardless of scroll direction.
+// Used by pages that have their own sticky header (e.g. CompareTable phantom header)
+// so that only one top-chrome element is visible at a time.
 interface ScrollContainerContextValue {
   el: HTMLDivElement | null;
   setEl: (el: HTMLDivElement | null) => void;
+  navLocked: boolean;
+  lockNav: (locked: boolean) => void;
 }
 
 const ScrollContainerContext = createContext<ScrollContainerContextValue>({
   el: null,
   setEl: () => {},
+  navLocked: false,
+  lockNav: () => {},
 });
 
 // Wrap Nav + ScrollContainer with this so both can access the shared state.
@@ -24,9 +32,10 @@ export function ScrollContainerProvider({
   children: React.ReactNode;
 }) {
   const [el, setEl] = useState<HTMLDivElement | null>(null);
+  const [navLocked, setNavLocked] = useState(false);
 
   return (
-    <ScrollContainerContext.Provider value={{ el, setEl }}>
+    <ScrollContainerContext.Provider value={{ el, setEl, navLocked, lockNav: setNavLocked }}>
       {children}
     </ScrollContainerContext.Provider>
   );
@@ -44,4 +53,9 @@ export function ScrollContainer({ children }: { children: React.ReactNode }) {
 
 export function useScrollContainer() {
   return useContext(ScrollContainerContext).el;
+}
+
+export function useNavLock() {
+  const { navLocked, lockNav } = useContext(ScrollContainerContext);
+  return { navLocked, lockNav };
 }


### PR DESCRIPTION
## Summary

- **Weight display bug**: `LensCard` was rendering `lens.weightG` directly. When the value is a range `[number, number]`, JSX would produce `"235,280g"` instead of `"235–280g"`. Now routes through `fmt.weightDisplay()` consistently with the detail/compare pages.

- **Mobile card layout**: Below 500px (single-column grid), cards switch from a tall vertical stack to a horizontal layout — image on the left (112px fixed width), text on the right, icon toggle button (`+` / `✓`) in the top-right corner. Fits 4–5 cards per screen vs ~1.5 before. Desktop grid unchanged.

- **Nav / phantom header conflict**: On the compare page, the auto-hide nav and the phantom sticky header were competing for the top-chrome space. Added `navLocked` state to `ScrollContainerContext`; when the phantom header activates (thead scrolls off screen), it locks the nav hidden. Only one top-chrome element is ever visible at a time on mobile.

## Test plan

- [ ] Lens with weight range (e.g. a lens where `weightG` is `[min, max]`) shows `Xg–Yg` on the card
- [ ] Mobile (<500px): cards display in horizontal layout, `+`/`✓` icon button in top-right, no full-width button
- [ ] Desktop (≥500px): card grid layout unchanged
- [ ] Compare page mobile: scroll down past the table header → nav hides and stays hidden while phantom header is shown; scroll back to top → phantom disappears, nav reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)