### PR TITLE
perf: skeleton loading states, image priority, and analytics deferral

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/loading.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/loading.tsx
@@ -1,0 +1,55 @@
+export default function LensDetailLoading() {
+  return (
+    <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+      {/* Back button placeholder */}
+      <div className="h-8 w-20 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+
+      <div className="flex flex-col sm:flex-row gap-8">
+        {/* Image */}
+        <div className="w-full max-w-56 mx-auto sm:mx-0 shrink-0 sm:w-56">
+          <div className="aspect-square rounded-2xl border border-zinc-100 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </div>
+
+        {/* Info */}
+        <div className="flex-1 flex flex-col gap-5">
+          <div className="flex flex-col gap-2">
+            <div className="h-4 w-24 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+            <div className="h-8 w-3/4 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <div className="h-9 w-32 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+            <div className="h-9 w-28 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          </div>
+
+          {/* Spec table */}
+          <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className={i > 0 ? "border-t border-zinc-100 dark:border-zinc-800" : ""}>
+                {/* Group header */}
+                <div className="px-4 py-2 bg-zinc-100/80 dark:bg-zinc-800/60">
+                  <div className="h-3 w-20 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+                </div>
+                {/* Rows */}
+                {Array.from({ length: 4 }).map((_, j) => (
+                  <div
+                    key={j}
+                    className="flex border-b border-zinc-100 dark:border-zinc-800 last:border-0"
+                  >
+                    <div className="w-40 shrink-0 px-4 py-2.5 bg-zinc-50/60 dark:bg-zinc-900/30">
+                      <div className="h-3 w-20 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+                    </div>
+                    <div className="flex-1 px-4 py-2.5">
+                      <div className="h-3 w-24 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -218,6 +218,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
                   sizes="224px"
                   style={lensImageStyle}
                   className="object-contain"
+                  priority
                 />
               </div>
             ) : (

--- a/src/app/[locale]/lenses/(browse)/loading.tsx
+++ b/src/app/[locale]/lenses/(browse)/loading.tsx
@@ -1,0 +1,62 @@
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 flex flex-col overflow-hidden max-[499px]:flex-row">
+      {/* Image area */}
+      <div className="relative aspect-[3/2] sm:aspect-[5/4] bg-zinc-100 dark:bg-zinc-800 animate-pulse max-[499px]:aspect-auto max-[499px]:w-[132px] max-[499px]:shrink-0 border-b border-zinc-100 dark:border-zinc-800 max-[499px]:border-b-0 max-[499px]:border-r" />
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-2 p-3 sm:gap-2.5 sm:p-4">
+        <div className="flex flex-col gap-1.5">
+          <div className="h-2.5 w-16 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-4 w-3/4 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-4 w-1/2 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </div>
+        <div className="flex gap-1 mt-1">
+          <div className="h-5 w-8 rounded-md bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-5 w-8 rounded-md bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </div>
+        <div className="mt-auto hidden sm:grid sm:grid-cols-2 sm:gap-x-3 gap-y-1.5">
+          <div className="h-3 w-12 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-3 w-10 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse ml-auto" />
+          <div className="h-3 w-16 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-3 w-10 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse ml-auto" />
+        </div>
+        <dl className="mt-auto flex items-baseline justify-between gap-2 sm:hidden">
+          <div className="h-3 w-20 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-3 w-8 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </dl>
+      </div>
+
+      {/* Footer button */}
+      <div className="px-3 pb-3 sm:px-4 sm:pb-4 max-[499px]:hidden">
+        <div className="h-9 w-full rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+export default function LensesLoading() {
+  return (
+    <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 py-8 flex flex-col gap-6 pb-24">
+      {/* Header */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="h-8 w-32 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </div>
+        {/* Filter bar placeholder */}
+        <div className="h-9 w-full rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        <div className="flex justify-between">
+          <div className="h-4 w-24 rounded bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+          <div className="h-8 w-40 rounded-full bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,9 @@
 import type { Metadata } from "next";
-import dynamic from "next/dynamic";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
-
-// Deferred off the critical render path — analytics must not block LCP or TBT
-const Analytics = dynamic(
-  () => import("@vercel/analytics/next").then((mod) => ({ default: mod.Analytics })),
-  { ssr: false }
-);
-const SpeedInsights = dynamic(
-  () => import("@vercel/speed-insights/next").then((mod) => ({ default: mod.SpeedInsights })),
-  { ssr: false }
-);
 
 export const metadata: Metadata = {
   metadataBase: process.env.VERCEL_URL

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,18 @@
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
+
+// Deferred off the critical render path — analytics must not block LCP or TBT
+const Analytics = dynamic(
+  () => import("@vercel/analytics/next").then((mod) => ({ default: mod.Analytics })),
+  { ssr: false }
+);
+const SpeedInsights = dynamic(
+  () => import("@vercel/speed-insights/next").then((mod) => ({ default: mod.SpeedInsights })),
+  { ssr: false }
+);
 
 export const metadata: Metadata = {
   metadataBase: process.env.VERCEL_URL

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -18,6 +18,7 @@ interface Props {
   isSelected: boolean;
   selectionDisabled: boolean;
   onToggle: () => void;
+  priority?: boolean;
 }
 
 export default function LensCard({
@@ -25,6 +26,7 @@ export default function LensCard({
   isSelected,
   selectionDisabled,
   onToggle,
+  priority = false,
 }: Props) {
   const t = useTranslations("LensList");
   const tBrand = useTranslations("Brands");
@@ -95,6 +97,7 @@ export default function LensCard({
                   sizes="(max-width: 499px) 112px, (max-width: 640px) 50vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
                   style={lensImageStyle}
                   className="object-contain"
+                  priority={priority}
                 />
               ) : (
                 <div className="flex h-full items-center justify-center overflow-hidden rounded-xl bg-white/80 dark:bg-zinc-950/70">

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -205,13 +205,14 @@ export default function LensListClient({ lenses }: Props) {
               transition={{ duration: 0.18, ease: "easeOut" }}
               className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
             >
-              {displayed.map((lens) => (
+              {displayed.map((lens, i) => (
                 <LensCard
                   key={lens.id}
                   lens={lens}
                   isSelected={compareIds.includes(lens.id)}
                   selectionDisabled={!canToggle(lens.id)}
                   onToggle={() => toggleCompare(lens.id)}
+                  priority={i < 8}
                 />
               ))}
             </motion.div>


### PR DESCRIPTION
## Summary

Addresses the three root causes identified in the Lighthouse report (Mobile Performance: 76, LCP 4.2s, TBT 420ms):

- **Blank screen on navigation** → Add `loading.tsx` skeleton screens for `/lenses` list and `/lenses/[id]` detail routes, so users see a layout-matched skeleton immediately instead of a white page
- **LCP 4.2s** → Pass `priority={true}` to the first 8 LensCards in the grid and to the single hero image on the detail page, so above-the-fold images are fetched before hydration completes
- **TBT 420ms / render-blocking 750ms** → Defer Vercel Analytics and SpeedInsights off the critical render path using `next/dynamic` + `ssr: false`; report showed these were the #1 contributor (683ms long task, 135 KiB unused JS, 750ms render-blocking)

## Test plan

- [ ] Navigate from homepage → /lenses: skeleton grid appears immediately, no white flash
- [ ] Navigate from /lenses → a lens detail page: skeleton layout appears immediately
- [ ] Re-run Lighthouse on /lenses to verify TBT and LCP improvement
- [ ] Confirm Vercel Analytics still records events in production (deferred load, not removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)