### PR TITLE
fix(ios-pwa): cover safe-area gap on homepage; reduce iris strip spacing 30%

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -10,7 +10,17 @@ export default function Home() {
   const h = useTranslations("Home");
 
   return (
-    <div className="flex flex-col bg-stone-100 dark:bg-zinc-950 h-full">
+    <div
+      className="flex flex-col bg-stone-100 dark:bg-zinc-950"
+      style={{
+        // h-full only fills the layout wrapper's content area (height − safe-area-inset-bottom
+        // padding). On iOS PWA the remaining safe-area strip has no background, leaving a white
+        // gap. Extending height into the padding zone covers it; the equal pb keeps content above
+        // the home indicator (mirrors the existing safe-area padding on the layout wrapper).
+        height: "calc(100% + env(safe-area-inset-bottom, 0px))",
+        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+      }}
+    >
       {/* Hero */}
       <section className="flex flex-col items-center justify-center text-center px-4 py-16 flex-1">
         <Iris config={IRIS_HERO} uid="hero" />

--- a/src/components/ApertureStrip.tsx
+++ b/src/components/ApertureStrip.tsx
@@ -23,7 +23,7 @@ const MARKS: Mark[] = ["A", 1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22];
 
 // Pixel spacing between consecutive marks. Chosen so ~3 marks are visible in
 // the unfeathered centre zone.
-const SPACING = 48;
+const SPACING = 34; // reduced 30% from original 48
 
 // Index of the nearest numeric mark to a given f-stop value.
 function nearestNumericIndex(fStop: number): number {
@@ -231,15 +231,16 @@ export default function ApertureStrip({
             mark === "A" ? (
               <div
                 key={i}
-                className="w-12 text-center text-xs font-semibold tracking-[0.03em]"
-                style={{ opacity: 0.85, color: "#C0452D" }}
+                className="flex-shrink-0 text-center text-xs font-semibold tracking-[0.03em]"
+                style={{ width: SPACING, opacity: 0.85, color: "#C0452D" }}
               >
                 A
               </div>
             ) : (
               <div
                 key={i}
-                className="w-12 text-center text-xs font-medium tracking-[0.03em] tabular-nums opacity-60"
+                className="flex-shrink-0 text-center text-xs font-medium tracking-[0.03em] tabular-nums opacity-60"
+                style={{ width: SPACING }}
               >
                 {formatMark(mark)}
               </div>


### PR DESCRIPTION
iOS PWA home screen bug: layout wrapper's pb-[safe-area-inset-bottom] creates
a padding zone that h-full doesn't reach, leaving bare body background visible.
Fix extends the homepage div height into that zone and adds matching internal
pb so content stays clear of the home indicator.

Iris strip: SPACING reduced 48→34px (≈30%), mark widths updated to match.

https://claude.ai/code/session_01KcYijfpg7J5PoYhWcseGEp