### PR TITLE
fix(og): use VERCEL_PROJECT_PRODUCTION_URL for metadataBase

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,9 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
 
 export const metadata: Metadata = {
-  metadataBase: process.env.VERCEL_URL
+  metadataBase: process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? new URL(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`)
+    : process.env.VERCEL_URL
     ? new URL(`https://${process.env.VERCEL_URL}`)
     : new URL("http://localhost:3000"),
 };


### PR DESCRIPTION
## Summary

- `metadataBase` was set to `VERCEL_URL`, which resolves to the per-deployment preview URL (unique per deploy). This caused `og:image` to point at a transient deployment domain rather than the production domain.
- Switched to prefer `VERCEL_PROJECT_PRODUCTION_URL` (Vercel system env var that always resolves to the canonical production URL), with `VERCEL_URL` as a fallback for preview deployments and `localhost:3000` for local dev.

## Test plan

- [ ] Merge and deploy to production
- [ ] Inspect `og:image` meta tag on `https://x-glass-rose.vercel.app/en` — should now point to `https://x-glass-rose.vercel.app/opengraph-image.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)