### PR TITLE
fix(aperture-strip): drag state cleanup + iris interactive mode refactor

### DIFF
--- a/src/app/[locale]/design-lab/iris/actions.ts
+++ b/src/app/[locale]/design-lab/iris/actions.ts
@@ -9,7 +9,7 @@ import { writeFile, readFile } from "fs/promises";
 import { exec } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { type IrisConfig, type IrisInitAnimation } from "@/config/iris-config";
+import { type IrisConfig, type IrisAnimation, type IrisInteractiveMode } from "@/config/iris-config";
 
 const execAsync = promisify(exec);
 
@@ -31,30 +31,78 @@ function findPresetBody(content: string, presetName: string): { bodyStart: numbe
   return { bodyStart, bodyEnd: bodyEnd - 1 };
 }
 
+/**
+ * Extract the content between the braces of a nested object field, e.g.
+ * `fieldName: { … }` → returns the string between the braces.
+ */
+function extractObjectBlock(body: string, key: string): string | null {
+  const startPattern = new RegExp(`\\b${key}:\\s*\\{`);
+  const startMatch = startPattern.exec(body);
+  if (!startMatch) return null;
+
+  const blockStart = startMatch.index + startMatch[0].length;
+  let depth = 1, pos = blockStart;
+  while (pos < body.length && depth > 0) {
+    if (body[pos] === "{") depth++;
+    if (body[pos] === "}") depth--;
+    pos++;
+  }
+  return body.slice(blockStart, pos - 1);
+}
+
 /** Serialize an IrisConfig into a tidy object-literal body (indented with 2 spaces). */
 function serializeBody(v: IrisConfig): string {
   const lines: string[] = [];
   const add = (key: string, val: string) => lines.push(`  ${key}: ${val},`);
 
-  add("N",             String(v.N));
-  add("pinDistance",   String(v.pinDistance));
-  add("slotOffset",    v.slotOffset.toFixed(6));
-  add("bladeLength",   String(v.bladeLength));
-  add("bladeWidth",    String(v.bladeWidth));
-  add("openFStop",     v.openFStop.toFixed(1));
-  add("defaultFStop",  v.defaultFStop.toFixed(1));
-  add("size",          String(v.size));
-  if (v.strokeWidth   !== undefined) add("strokeWidth",   v.strokeWidth.toFixed(2));
-  if (v.bladeColor    !== undefined) add("bladeColor",    `"${v.bladeColor}"`);
-  if (v.strokeColor   !== undefined) add("strokeColor",   `"${v.strokeColor}"`);
-  if (v.interactive   !== undefined) add("interactive",   String(v.interactive));
-  if (v.initAnimation !== undefined) add("initAnimation", `{ sweepMs: ${v.initAnimation.sweepMs}, totalMs: ${v.initAnimation.totalMs} }`);
-  if (v.closedFStop   !== undefined) add("closedFStop",   String(v.closedFStop));
-  if (v.hotzoneScaleH !== undefined) add("hotzoneScaleH", v.hotzoneScaleH.toFixed(2));
-  if (v.hotzoneScaleV !== undefined) add("hotzoneScaleV", v.hotzoneScaleV.toFixed(2));
-  if (v.chaseTauMs    !== undefined) add("chaseTauMs",    String(v.chaseTauMs));
-  if (v.easeOutMs     !== undefined) add("easeOutMs",     String(v.easeOutMs));
-  if (v.catchupMs     !== undefined) add("catchupMs",     String(v.catchupMs));
+  // Kinematic fields
+  add("N",            String(v.N));
+  add("pinDistance",  String(v.pinDistance));
+  add("slotOffset",   v.slotOffset.toFixed(6));
+  add("bladeLength",  String(v.bladeLength));
+  add("bladeWidth",   String(v.bladeWidth));
+  add("openFStop",    v.openFStop.toFixed(1));
+  add("defaultFStop", v.defaultFStop.toFixed(1));
+  add("size",         String(v.size));
+
+  // Appearance
+  if (v.strokeWidth !== undefined) add("strokeWidth", v.strokeWidth.toFixed(2));
+  if (v.bladeColor  !== undefined) add("bladeColor",  `"${v.bladeColor}"`);
+  if (v.strokeColor !== undefined) add("strokeColor", `"${v.strokeColor}"`);
+
+  // Aperture limit
+  if (v.closedFStop !== undefined) add("closedFStop", String(v.closedFStop));
+
+  // Interactive mode — serialized as a nested object
+  if (v.interactive !== undefined) {
+    if (v.interactive.type === "hover") {
+      const h = v.interactive;
+      const inner: string[] = [`    type: "hover",`];
+      if (h.hotzoneScaleH !== undefined) inner.push(`    hotzoneScaleH: ${h.hotzoneScaleH.toFixed(2)},`);
+      if (h.hotzoneScaleV !== undefined) inner.push(`    hotzoneScaleV: ${h.hotzoneScaleV.toFixed(2)},`);
+      if (h.easeOutMs     !== undefined) inner.push(`    easeOutMs: ${h.easeOutMs},`);
+      if (h.catchupMs     !== undefined) inner.push(`    catchupMs: ${h.catchupMs},`);
+      lines.push(`  interactive: {\n${inner.join("\n")}\n  },`);
+    } else if (v.interactive.type === "tap") {
+      const t = v.interactive;
+      if (t.animation.type === "sweep") {
+        lines.push(
+          `  interactive: {\n` +
+          `    type: "tap",\n` +
+          `    animation: { type: "sweep", sweepMs: ${t.animation.sweepMs}, totalMs: ${t.animation.totalMs} },\n` +
+          `  },`
+        );
+      }
+    }
+  }
+  if (v.apertureStrip !== undefined) add("apertureStrip", String(v.apertureStrip));
+
+  // Mount animation
+  if (v.onMount !== undefined && v.onMount.type === "sweep") {
+    add("onMount", `{ type: "sweep", sweepMs: ${v.onMount.sweepMs}, totalMs: ${v.onMount.totalMs} }`);
+  }
+
+  if (v.chaseTauMs !== undefined) add("chaseTauMs", String(v.chaseTauMs));
 
   return "\n" + lines.join("\n") + "\n";
 }
@@ -74,32 +122,51 @@ export async function readFromConfig(
 
     const body = content.slice(range.bodyStart, range.bodyEnd);
 
-    function extractNum(key: string): number | undefined {
-      const m = new RegExp(`\\b${key}:\\s*([\\d.]+)`).exec(body);
+    function extractNum(key: string, src = body): number | undefined {
+      const m = new RegExp(`\\b${key}:\\s*([\\d.]+)`).exec(src);
       return m ? parseFloat(m[1]) : undefined;
     }
     function extractStr(key: string): string | undefined {
       const m = new RegExp(`\\b${key}:\\s*"([^"]*)"`) .exec(body);
       return m ? m[1] : undefined;
     }
-    function extractBool(key: string): boolean | undefined {
-      const m = new RegExp(`\\b${key}:\\s*(true|false)`).exec(body);
-      return m ? m[1] === "true" : undefined;
+    function extractAnimation(key: string, src = body): IrisAnimation | undefined {
+      const m = new RegExp(`\\b${key}:\\s*\\{[^}]*type:\\s*"sweep"[^}]*sweepMs:\\s*(\\d+)[^}]*totalMs:\\s*(\\d+)`).exec(src);
+      if (m) return { type: "sweep", sweepMs: parseInt(m[1]), totalMs: parseInt(m[2]) };
+      return undefined;
     }
-    function extractInitAnim(): IrisInitAnimation | undefined {
-      const m = /\binitAnimation:\s*\{\s*sweepMs:\s*(\d+),\s*totalMs:\s*(\d+)\s*\}/.exec(body);
-      if (m) return { sweepMs: parseInt(m[1]), totalMs: parseInt(m[2]) };
+    function extractInteractive(): IrisInteractiveMode | undefined {
+      const block = extractObjectBlock(body, "interactive");
+      if (!block) return undefined;
+
+      const typeMatch = /\btype:\s*"(hover|tap)"/.exec(block);
+      if (!typeMatch) return undefined;
+
+      if (typeMatch[1] === "hover") {
+        return {
+          type: "hover",
+          hotzoneScaleH: extractNum("hotzoneScaleH", block),
+          hotzoneScaleV: extractNum("hotzoneScaleV", block),
+          easeOutMs:     extractNum("easeOutMs",     block),
+          catchupMs:     extractNum("catchupMs",     block),
+        };
+      }
+      if (typeMatch[1] === "tap") {
+        const anim = extractAnimation("animation", block);
+        if (!anim) return undefined;
+        return { type: "tap", animation: anim };
+      }
       return undefined;
     }
 
     const N = extractNum("N");
-    const pinDistance = extractNum("pinDistance");
-    const slotOffset  = extractNum("slotOffset");
-    const bladeLength = extractNum("bladeLength");
-    const bladeWidth  = extractNum("bladeWidth");
-    const openFStop   = extractNum("openFStop");
+    const pinDistance  = extractNum("pinDistance");
+    const slotOffset   = extractNum("slotOffset");
+    const bladeLength  = extractNum("bladeLength");
+    const bladeWidth   = extractNum("bladeWidth");
+    const openFStop    = extractNum("openFStop");
     const defaultFStop = extractNum("defaultFStop");
-    const size        = extractNum("size");
+    const size         = extractNum("size");
 
     // Required fields — return null if any are missing.
     if (N === undefined || pinDistance === undefined || slotOffset === undefined ||
@@ -109,25 +176,21 @@ export async function readFromConfig(
     }
 
     return {
-      N:             Math.round(N),
+      N:            Math.round(N),
       pinDistance,
       slotOffset,
       bladeLength,
       bladeWidth,
       openFStop,
       defaultFStop,
-      size:          Math.round(size),
-      strokeWidth:   extractNum("strokeWidth"),
-      bladeColor:    extractStr("bladeColor"),
-      strokeColor:   extractStr("strokeColor"),
-      interactive:   extractBool("interactive"),
-      initAnimation: extractInitAnim(),
-      closedFStop:   extractNum("closedFStop"),
-      hotzoneScaleH: extractNum("hotzoneScaleH"),
-      hotzoneScaleV: extractNum("hotzoneScaleV"),
-      chaseTauMs:    extractNum("chaseTauMs"),
-      easeOutMs:     extractNum("easeOutMs"),
-      catchupMs:     extractNum("catchupMs"),
+      size:         Math.round(size),
+      strokeWidth:  extractNum("strokeWidth"),
+      bladeColor:   extractStr("bladeColor"),
+      strokeColor:  extractStr("strokeColor"),
+      closedFStop:  extractNum("closedFStop"),
+      interactive:  extractInteractive(),
+      onMount:      extractAnimation("onMount"),
+      chaseTauMs:   extractNum("chaseTauMs"),
     };
   } catch {
     return null;

--- a/src/app/[locale]/design-lab/iris/page.tsx
+++ b/src/app/[locale]/design-lab/iris/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/iris-kinematics";
 import { readFromConfig, exportToConfig } from "./actions";
 import { IRIS_HERO, IRIS_NAV, IRIS_LAB, R_HOUSING } from "@/config/iris-config";
-import type { IrisConfig, IrisInitAnimation } from "@/config/iris-config";
+import type { IrisConfig, IrisAnimation } from "@/config/iris-config";
 import Iris from "@/components/Iris";
 
 // SVG coordinate space: origin at iris center, R_HOUSING = outer display radius.
@@ -408,14 +408,15 @@ export default function ApertureV2Lab() {
     if (v.strokeWidth !== undefined) setStrokeWidth(v.strokeWidth);
     setOpenFStop(v.openFStop);
     setDefaultFStop(v.defaultFStop);
-    setInteractive(v.interactive ?? false);
-    setInitAnimation(v.initAnimation);
+    const hc = v.interactive?.type === "hover" ? v.interactive : null;
+    setInteractive(hc !== null);
+    setOnMount(v.onMount);
     setClosedFStop(v.closedFStop ?? 22);
     setChaseTauMs(v.chaseTauMs ?? 60);
-    setEaseOutMs(v.easeOutMs ?? 700);
-    setCatchupMs(v.catchupMs ?? 300);
-    setHotzoneScaleH(v.hotzoneScaleH ?? 1.5);
-    setHotzoneScaleV(v.hotzoneScaleV ?? 1.0);
+    setEaseOutMs(hc?.easeOutMs ?? 700);
+    setCatchupMs(hc?.catchupMs ?? 300);
+    setHotzoneScaleH(hc?.hotzoneScaleH ?? 1.5);
+    setHotzoneScaleV(hc?.hotzoneScaleV ?? 1.0);
     setPreviewSize(v.size);
     setIsPlaying(false);
     startRef.current = undefined;
@@ -438,14 +439,16 @@ export default function ApertureV2Lab() {
       bladeColor: grayHex(bladeGray),
       strokeColor: grayHex(strokeGray),
       strokeWidth,
-      interactive,
-      initAnimation,
+      interactive: interactive ? {
+        type: "hover" as const,
+        hotzoneScaleH,
+        hotzoneScaleV,
+        easeOutMs,
+        catchupMs,
+      } : undefined,
+      onMount,
       closedFStop,
       chaseTauMs,
-      easeOutMs,
-      catchupMs,
-      hotzoneScaleH,
-      hotzoneScaleV,
     };
     const key = selectedProfile === "production:hero" ? "IRIS_HERO"
       : selectedProfile === "production:nav" ? "IRIS_NAV" : "IRIS_LAB";
@@ -487,7 +490,7 @@ export default function ApertureV2Lab() {
   const [showFStopRing, setShowFStopRing] = useState(false);
   const [fStopRingOuter, setFStopRingOuter] = useState(true);
   const [interactive, setInteractive] = useState(false);
-  const [initAnimation, setInitAnimation] = useState<IrisInitAnimation | undefined>(undefined);
+  const [onMount, setOnMount] = useState<IrisAnimation | undefined>(undefined);
   const [openFStop, setOpenFStop] = useState(1.4);
   const [defaultFStop, setDefaultFStop] = useState(5.6);
   const [closedFStop, setClosedFStop] = useState(22);
@@ -521,18 +524,14 @@ export default function ApertureV2Lab() {
     bladeColor: grayHex(bladeGray),
     strokeColor: grayHex(strokeGray),
     strokeWidth,
-    interactive: false,
-    initAnimation,
+    interactive: undefined,
+    onMount,
     closedFStop,
     chaseTauMs,
-    easeOutMs,
-    catchupMs,
-    hotzoneScaleH,
-    hotzoneScaleV,
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [config.N, config.pinDistance, config.slotOffset, config.bladeLength, config.bladeWidth,
-      openFStop, defaultFStop, closedFStop, chaseTauMs, easeOutMs, catchupMs,
-      hotzoneScaleH, hotzoneScaleV, previewSize, bladeGray, strokeGray, strokeWidth, initAnimation]);
+      openFStop, defaultFStop, closedFStop, chaseTauMs,
+      previewSize, bladeGray, strokeGray, strokeWidth, onMount]);
 
   // Animation: theta oscillates between range.min and range.max
   const rafRef = useRef<number | undefined>(undefined);
@@ -964,27 +963,27 @@ export default function ApertureV2Lab() {
               >
                 <input
                   type="checkbox"
-                  checked={initAnimation !== undefined}
+                  checked={onMount !== undefined}
                   onChange={(e) => {
                     const checked = e.target.checked;
-                    setInitAnimation(checked ? { sweepMs: 800, totalMs: 1000 } : undefined);
+                    setOnMount(checked ? { type: "sweep", sweepMs: 800, totalMs: 1000 } : undefined);
                     if (checked) setPreviewAnimKey(k => k + 1);
                   }}
                   style={{ accentColor: "#18181b", width: 14, height: 14 }}
                 />
                 Init Animation
               </label>
-              {initAnimation !== undefined && (
+              {onMount !== undefined && onMount.type === "sweep" && (
                 <>
                   <div className="space-y-1">
                     <div className="flex justify-between text-xs">
                       <span className="text-zinc-500">Sweep</span>
-                      <span className="text-zinc-700 font-mono">{initAnimation.sweepMs} ms</span>
+                      <span className="text-zinc-700 font-mono">{onMount.sweepMs} ms</span>
                     </div>
-                    <input type="range" min={200} max={2000} step={50} value={initAnimation.sweepMs}
+                    <input type="range" min={200} max={2000} step={50} value={onMount.sweepMs}
                       onChange={(e) => {
                         const sweepMs = parseFloat(e.target.value);
-                        setInitAnimation(prev => prev ? { ...prev, sweepMs } : prev);
+                        setOnMount((prev): IrisAnimation | undefined => prev ? { ...prev, sweepMs } : prev);
                         setPreviewAnimKey(k => k + 1);
                       }}
                       className="w-full" style={{ accentColor: "#18181b" }}
@@ -993,14 +992,14 @@ export default function ApertureV2Lab() {
                   <div className="space-y-1">
                     <div className="flex justify-between text-xs">
                       <span className="text-zinc-500">Total</span>
-                      <span className="text-zinc-700 font-mono">{initAnimation.totalMs} ms</span>
+                      <span className="text-zinc-700 font-mono">{onMount.totalMs} ms</span>
                     </div>
                     <input type="range"
-                      min={initAnimation.sweepMs + 100} max={3000} step={50}
-                      value={initAnimation.totalMs}
+                      min={onMount.sweepMs + 100} max={3000} step={50}
+                      value={onMount.totalMs}
                       onChange={(e) => {
                         const totalMs = parseFloat(e.target.value);
-                        setInitAnimation(prev => prev ? { ...prev, totalMs } : prev);
+                        setOnMount((prev): IrisAnimation | undefined => prev ? { ...prev, totalMs } : prev);
                         setPreviewAnimKey(k => k + 1);
                       }}
                       className="w-full" style={{ accentColor: "#18181b" }}

--- a/src/components/ApertureStrip.tsx
+++ b/src/components/ApertureStrip.tsx
@@ -155,6 +155,13 @@ export default function ApertureStrip({
 
   function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
     if (!dragRef.current) return;
+    // If the button was released outside the browser window, pointerup never
+    // fired — detect this here and end the drag cleanly.
+    if (e.buttons === 0) {
+      dragRef.current = null;
+      snapToNearest(lastValidOffsetRef.current);
+      return;
+    }
     const raw     = dragRef.current.startOffset + (e.clientX - dragRef.current.startX);
     const clamped = Math.max(minOffset, Math.min(maxOffset, raw));
     lastValidOffsetRef.current = clamped;

--- a/src/components/Iris.tsx
+++ b/src/components/Iris.tsx
@@ -9,9 +9,15 @@
 // Theming: bladeColor/strokeColor in the config override the Tailwind
 // fill-*/stroke-* utilities used for automatic light/dark switching.
 //
-// Hotzone: when interactive is true, a transparent wrapper div sized to
-// size*hotzoneScaleH × size*hotzoneScaleV captures mouse events, giving the
-// iris a wider/taller interactive area than its rendered footprint.
+// Interaction modes (mutually exclusive, set via config.interactive):
+//   "hover" — aperture tracks horizontal mouse position across a hotzone div
+//             sized by hotzoneScaleH/V.
+//   "tap"   — clicking (desktop) or touching (mobile) plays the configured
+//             animation. Shows a pointer cursor.
+//   absent  — no interaction; iris sits at defaultFStop.
+//
+// Animations: config.onMount plays on mount; interactive.type === "tap" plays
+// on click/touch. Both share the same playAnimation() engine and chase loop.
 //
 // ApertureStrip: when apertureStrip is true in the config, a mobile-only
 // touch strip is rendered below the iris (hidden on md+ screens).
@@ -27,7 +33,7 @@ import {
   findThetaForInradius,
   findThetaForFStop,
 } from "@/lib/iris-kinematics";
-import { R_HOUSING, type IrisConfig } from "@/config/iris-config";
+import { R_HOUSING, type IrisConfig, type IrisAnimation } from "@/config/iris-config";
 import ApertureStrip from "@/components/ApertureStrip";
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -53,19 +59,24 @@ export default function Iris({
 }: IrisProps) {
   const {
     size: configSize,
-    interactive = false,
+    interactive,
     apertureStrip = false,
-    initAnimation,
+    onMount,
     closedFStop = 22,
-    hotzoneScaleH = 1,
-    hotzoneScaleV = 1,
     chaseTauMs = 60,
-    easeOutMs = 700,
     bladeColor,
     strokeColor,
     strokeWidth,
   } = rawConfig;
   const size = sizeProp ?? configSize;
+
+  // Derive interaction mode flags and hover-specific config.
+  const isHover     = interactive?.type === "hover";
+  const isTap       = interactive?.type === "tap";
+  const hoverConfig = isHover ? interactive : null;
+  const hotzoneScaleH = hoverConfig?.hotzoneScaleH ?? 1;
+  const hotzoneScaleV = hoverConfig?.hotzoneScaleV ?? 1;
+  const easeOutMs     = hoverConfig?.easeOutMs     ?? 700;
 
   const dc = useMemo(() => buildDerivedConfig(rawConfig, R_HOUSING), [rawConfig]);
   const thetaOpen = useMemo(() => computeThetaOpen(dc, R_HOUSING), [dc]);
@@ -78,11 +89,11 @@ export default function Iris({
   [rawConfig.defaultFStop, rawConfig.openFStop, dc, thetaOpen, thetaMax]);
 
   const [theta, setTheta] = useState<number>(DEFAULT_THETA);
-  const [initAnimating, setInitAnimating] = useState(!!initAnimation);
-  const thetaRef    = useRef<number>(DEFAULT_THETA);
-  const animRef     = useRef<number | null>(null);
-  const chaseRef    = useRef<number | null>(null);
-  const initAnimRef = useRef<number | null>(null);
+  const [isAnimating, setIsAnimating] = useState(!!onMount);
+  const thetaRef       = useRef<number>(DEFAULT_THETA);
+  const animRef        = useRef<number | null>(null);
+  const chaseRef       = useRef<number | null>(null);
+  const initAnimRef    = useRef<number | null>(null);
   const targetThetaRef = useRef<number>(DEFAULT_THETA);
   const lastFrameRef   = useRef<number>(0);
   const defaultThetaRef = useRef(DEFAULT_THETA);
@@ -102,22 +113,31 @@ export default function Iris({
     if (initAnimRef.current) cancelAnimationFrame(initAnimRef.current);
   }, []);
 
+  // When not in hover mode, keep theta in sync with DEFAULT_THETA so the iris
+  // reflects any config change (e.g. Design Lab parameter tuning).
   useEffect(() => {
-    if (interactive) return;
+    if (isHover) return;
     thetaRef.current = DEFAULT_THETA;
     setTheta(DEFAULT_THETA);
-  }, [DEFAULT_THETA, interactive]);
+  }, [DEFAULT_THETA, isHover]);
 
-  // ── Init animation ────────────────────────────────────────────────────────
-  // Two-phase sweep on mount: open → closed → default. Directly drives
-  // targetThetaRef — same chase loop as mouse hover and strip drag.
-  useEffect(() => {
-    if (!initAnimation) return;
-    const { sweepMs, totalMs } = initAnimation;
+  // ── Animation engine ──────────────────────────────────────────────────────
+  // Shared by mount animation and tap interaction. Cancels any in-flight
+  // animations before starting, so the two triggers can never overlap.
+  // startChase / stopChase are function declarations hoisted to the top of
+  // this render function — accessible here even though defined below.
+
+  function playAnimation(anim: IrisAnimation) {
+    if (anim.type !== "sweep") return;
+    const { sweepMs, totalMs } = anim;
+
+    if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
+    if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
 
     thetaRef.current = thetaOpen;
     targetThetaRef.current = thetaOpen;
     setTheta(thetaOpen);
+    setIsAnimating(true);
     startChase();
 
     const startTime = performance.now();
@@ -133,11 +153,16 @@ export default function Iris({
       } else {
         targetThetaRef.current = defaultThetaRef.current;
         initAnimRef.current = null;
-        setInitAnimating(false);
+        setIsAnimating(false);
       }
     }
     initAnimRef.current = requestAnimationFrame(tick);
+  }
 
+  // ── Mount animation ───────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!onMount) return;
+    playAnimation(onMount);
     return () => {
       if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
       stopChase();
@@ -147,8 +172,6 @@ export default function Iris({
   }, []);
 
   // ── Imperative controls (used by ApertureStrip) ───────────────────────────
-  // startChase / stopChase are function declarations hoisted to the top of
-  // this render function — accessible here even though defined below.
 
   function driveToFStop(fStop: number) {
     if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
@@ -175,9 +198,7 @@ export default function Iris({
   const vbHalf  = R_HOUSING - dc.bladeWidth + 2;
   const viewBox = `${-vbHalf} ${-vbHalf} ${vbHalf * 2} ${vbHalf * 2}`;
 
-  // ── Mouse interaction ──────────────────────────────────────────────────────
-  // Events fire on the hotzone wrapper div (sized by hotzoneScaleH/V), not
-  // the SVG itself, so the interactive area can extend beyond the iris footprint.
+  // ── Chase loop ────────────────────────────────────────────────────────────
 
   function startChase() {
     if (chaseRef.current) return;
@@ -207,6 +228,10 @@ export default function Iris({
     if (chaseRef.current) { cancelAnimationFrame(chaseRef.current); chaseRef.current = null; }
   }
 
+  // ── Hover interaction ─────────────────────────────────────────────────────
+  // Events fire on the hotzone wrapper div (sized by hotzoneScaleH/V), not
+  // the SVG itself, so the interactive area can extend beyond the iris footprint.
+
   function posToDiameterTheta(clientX: number, rect: DOMRect): number {
     const rawPos = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
     if (inradiusOpen <= 0) return thetaOpen + rawPos * (thetaMax - thetaOpen);
@@ -216,7 +241,7 @@ export default function Iris({
   }
 
   function handleMouseEnter(e: React.MouseEvent<HTMLDivElement>) {
-    if (!interactive) return;
+    if (!isHover) return;
     if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
     if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
     const rect = e.currentTarget.getBoundingClientRect();
@@ -225,14 +250,14 @@ export default function Iris({
   }
 
   function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
-    if (!interactive) return;
+    if (!isHover) return;
     const rect = e.currentTarget.getBoundingClientRect();
     targetThetaRef.current = posToDiameterTheta(e.clientX, rect);
     startChase();
   }
 
   function handleMouseLeave() {
-    if (!interactive) return;
+    if (!isHover) return;
     stopChase();
     const startTheta = thetaRef.current;
     const startTime  = performance.now();
@@ -248,8 +273,15 @@ export default function Iris({
     animRef.current = requestAnimationFrame(tick);
   }
 
+  // ── Tap interaction ───────────────────────────────────────────────────────
+
+  function handleClick() {
+    if (interactive?.type !== "tap") return;
+    playAnimation(interactive.animation);
+  }
+
   // ── Current f-stop (for ApertureStrip sync) ────────────────────────────────
-  // Derived from theta so the strip can mirror the iris position during init
+  // Derived from theta so the strip can mirror the iris position during any
   // animation and after release easing. Uses f = f_open × (r_open / r).
 
   const currentFStop = useMemo(() => {
@@ -261,26 +293,28 @@ export default function Iris({
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
-  const wrapperW = interactive ? size * hotzoneScaleH : size;
-  const wrapperH = interactive ? size * hotzoneScaleV : size;
+  const wrapperW = isHover ? size * hotzoneScaleH : size;
+  const wrapperH = isHover ? size * hotzoneScaleV : size;
 
   return (
     <div
       className={className}
       style={{ display: "inline-flex", flexDirection: "column", alignItems: "center", flexShrink: 0 }}
     >
-      {/* Hotzone wrapper — captures mouse events */}
+      {/* Hotzone wrapper — captures mouse/tap events */}
       <div
         style={{
-          width:           wrapperW,
-          height:          wrapperH,
-          display:         "flex",
-          alignItems:      "center",
-          justifyContent:  "center",
+          width:          wrapperW,
+          height:         wrapperH,
+          display:        "flex",
+          alignItems:     "center",
+          justifyContent: "center",
+          cursor:         isTap ? "pointer" : undefined,
         }}
-        onMouseEnter={handleMouseEnter}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
+        onMouseEnter={isHover ? handleMouseEnter : undefined}
+        onMouseMove={isHover ? handleMouseMove : undefined}
+        onMouseLeave={isHover ? handleMouseLeave : undefined}
+        onClick={isTap ? handleClick : undefined}
       >
         <svg
           viewBox={viewBox}
@@ -350,7 +384,7 @@ export default function Iris({
           <ApertureStrip
             defaultFStop={rawConfig.defaultFStop}
             fStop={currentFStop}
-            animating={initAnimating}
+            animating={isAnimating}
             onDrive={driveToFStop}
           />
         </div>

--- a/src/config/iris-config.ts
+++ b/src/config/iris-config.ts
@@ -17,20 +17,55 @@ import type { StoredIrisParams } from "@/lib/iris-kinematics";
 
 export const R_HOUSING = 100;
 
-// ── IrisInitAnimation ─────────────────────────────────────────────────────────
+// ── IrisAnimation ─────────────────────────────────────────────────────────────
 //
-// Timing config for the two-phase mount animation:
+// Animations are identified by a `type` discriminant so new variants can be
+// added to the union without touching existing callsites.
+//
+// Currently the only variant is "sweep": a two-phase aperture sweep:
 //   Phase 1 (0 → sweepMs):       open → closedFStop  (linear target drive)
-//   Phase 2 (sweepMs → totalMs): closedFStop → defaultFStop  (linear, chase smooths it)
-//
-// Presence of this object on IrisConfig enables the animation; absence disables it.
+//   Phase 2 (sweepMs → totalMs): closedFStop → defaultFStop  (chase-smoothed)
 
-export interface IrisInitAnimation {
+export interface IrisSweepAnimation {
+  type: "sweep";
   /** Duration of the open → closed sweep (ms). */
   sweepMs: number;
   /** Total duration including the closed → defaultFStop ease-back (ms). */
   totalMs: number;
 }
+
+// Extend this union when new animation types are added.
+export type IrisAnimation = IrisSweepAnimation;
+
+// ── IrisInteractiveMode ───────────────────────────────────────────────────────
+//
+// Discriminated union controlling how users interact with an Iris instance.
+// The two modes are mutually exclusive — an instance is either hover-driven
+// or tap-driven, never both.
+
+export interface IrisHoverMode {
+  type: "hover";
+  /**
+   * Horizontal scale factor applied to the iris diameter to compute the width
+   * of the mouse interaction hotzone. Values > 1 widen the area, making the
+   * control less sensitive.
+   */
+  hotzoneScaleH?: number;
+  /** Vertical scale factor applied to the iris diameter for the hotzone height. */
+  hotzoneScaleV?: number;
+  /** Duration of the cubic ease-out return after the pointer leaves (ms). */
+  easeOutMs?: number;
+  /** Duration over which the entry jump-offset decays to zero (ms). */
+  catchupMs?: number;
+}
+
+export interface IrisTapMode {
+  type: "tap";
+  /** Animation to play when the iris is clicked (desktop) or tapped (mobile). */
+  animation: IrisAnimation;
+}
+
+export type IrisInteractiveMode = IrisHoverMode | IrisTapMode;
 
 // ── IrisConfig ────────────────────────────────────────────────────────────────
 //
@@ -52,54 +87,49 @@ export interface IrisConfig extends StoredIrisParams {
   /** Blade gap stroke width in SVG units. */
   strokeWidth?: number;
 
-  // ── Interactive ─────────────────────────────────────────────────────────────
-  /** When true, aperture openness tracks horizontal mouse position. */
-  interactive?: boolean;
+  // ── Aperture limits ──────────────────────────────────────────────────────────
+  /**
+   * Hard stop for aperture — the minimum opening (maximum f-number) reachable
+   * by any interaction or animation. Applies globally: hover drag, tap animation
+   * end-point, and aperture strip. Defaults to 22 when absent.
+   */
+  closedFStop?: number;
+
+  // ── Interaction ─────────────────────────────────────────────────────────────
+  /**
+   * Interaction mode. Absent = no interaction.
+   * "hover" — aperture tracks horizontal mouse position across the hotzone.
+   * "tap"   — clicking (desktop) or touching (mobile) plays an animation.
+   * The two modes are mutually exclusive.
+   */
+  interactive?: IrisInteractiveMode;
   /**
    * When true, renders a mobile aperture-ring strip below the iris (hidden on
    * md+ screens). Lets touch users drag through f-stops; "A" snaps back to
    * defaultFStop via releaseControl.
    */
   apertureStrip?: boolean;
-  /**
-   * When present, plays an entry animation on mount: open → closedFStop →
-   * defaultFStop, using the exponential-smoothing chase. The object value
-   * controls the two-phase timing. Absence (undefined) disables the animation.
-   */
-  initAnimation?: IrisInitAnimation;
-  /**
-   * Hard stop for mouse interaction — the minimum aperture (maximum f-number)
-   * the pointer can reach. Paired with openFStop which anchors the open end.
-   * Only relevant when interactive is true.
-   */
-  closedFStop?: number;
-  /**
-   * Horizontal scale factor applied to the iris diameter to compute the width
-   * of the mouse interaction hotzone. Values > 1 widen the area, making the
-   * control less sensitive. Only relevant when interactive is true.
-   */
-  hotzoneScaleH?: number;
-  /**
-   * Vertical scale factor applied to the iris diameter to compute the height
-   * of the mouse interaction hotzone. Only relevant when interactive is true.
-   */
-  hotzoneScaleV?: number;
 
   // ── Animation ────────────────────────────────────────────────────────────────
-  /** Exponential-smoothing time constant for follow-mouse chase (ms). */
+  /**
+   * Animation to play on component mount. Absence disables the mount animation.
+   * Independent of the interaction mode — any Iris can have a mount animation
+   * regardless of whether it is interactive.
+   */
+  onMount?: IrisAnimation;
+  /**
+   * Exponential-smoothing time constant for the chase loop (ms). Shared by all
+   * animation systems: mount animation, hover tracking, and aperture strip drag.
+   */
   chaseTauMs?: number;
-  /** Duration of the cubic ease-out return after mouse leaves (ms). */
-  easeOutMs?: number;
-  /** Duration over which the entry jump-offset decays to zero (ms). */
-  catchupMs?: number;
 }
 
 // ── Named configs ─────────────────────────────────────────────────────────────
 //
 // Three optical-size tiers:
-//   IRIS_HERO  → homepage hero (large, interactive)
+//   IRIS_HERO  → homepage hero (large, mount animation + aperture strip)
 //   IRIS_NAV   → navbar icon, OG image, apple icon (small / static renders)
-//   IRIS_LAB   → Design Lab workspace (tunable copy of IRIS_HERO)
+//   IRIS_LAB   → Design Lab workspace (tunable copy of IRIS_HERO, hover mode)
 //
 // Every field used by the component must be listed explicitly — there is no
 // global defaults object. Optional fields absent from a config (e.g. IRIS_NAV
@@ -120,16 +150,17 @@ export const IRIS_HERO: IrisConfig = {
   bladeColor: "#181818",
   strokeColor: "#b3b3b3",
   strokeWidth: 1,
-  // Interactive
-  interactive: false,
-  apertureStrip: true,
-  initAnimation: { sweepMs: 800, totalMs: 1000 },
+  // Aperture limits
   closedFStop: 22,
-  hotzoneScaleH: 2,
-  hotzoneScaleV: 1.0,
+  // Interaction — tap triggers a sweep animation; hover is disabled on the homepage
+  interactive: {
+    type: "tap",
+    animation: { type: "sweep", sweepMs: 800, totalMs: 1000 },
+  },
+  apertureStrip: true,
+  // Animation
+  onMount: { type: "sweep", sweepMs: 800, totalMs: 1000 },
   chaseTauMs: 60,
-  easeOutMs: 700,
-  catchupMs: 300,
 };
 
 export const IRIS_NAV: IrisConfig = {
@@ -143,7 +174,7 @@ export const IRIS_NAV: IrisConfig = {
   defaultFStop: 4,
   // Size
   size: 26,
-  // Appearance — explicit colour required for Satori (OG/apple-icon) which
+  // Appearance — explicit colour required for resvg (OG/apple-icon) which
   // cannot evaluate Tailwind classes.
   bladeColor: "#181818",
   strokeColor: "#ffffff",
@@ -165,15 +196,19 @@ export const IRIS_LAB: IrisConfig = {
   bladeColor: "#181818",
   strokeColor: "#b3b3b3",
   strokeWidth: 1,
-  // Interactive
-  interactive: true,
-  initAnimation: { sweepMs: 800, totalMs: 1000 },
+  // Aperture limits
   closedFStop: 22,
-  hotzoneScaleH: 2,
-  hotzoneScaleV: 1.0,
+  // Interaction — hover mode for the Design Lab scrubbing experience
+  interactive: {
+    type: "hover",
+    hotzoneScaleH: 2,
+    hotzoneScaleV: 1.0,
+    easeOutMs: 700,
+    catchupMs: 300,
+  },
+  // Animation
+  onMount: { type: "sweep", sweepMs: 800, totalMs: 1000 },
   chaseTauMs: 60,
-  easeOutMs: 700,
-  catchupMs: 300,
 };
 
 // Site-level metadata (name, description, theme color, PWA display mode, etc.)


### PR DESCRIPTION
## Summary

- **fix(aperture-strip):** when the mouse is released outside the browser window, `pointerup` never fires on the capturing element, leaving `dragRef.current` set. Added `e.buttons === 0` check in `onPointerMove` to detect this and snap-to-nearest cleanly.

- **feat(iris):** replace `interactive: boolean` with a discriminated union `IrisInteractiveMode`:
  - `{ type: "hover" }` — aperture tracks horizontal mouse position; hover-specific fields (`hotzoneScaleH`, `hotzoneScaleV`, `easeOutMs`, `catchupMs`) co-located in this variant
  - `{ type: "tap", animation: IrisAnimation }` — click (desktop) or touch (mobile) triggers the configured animation; mutually exclusive with hover
  - `closedFStop` stays top-level as it applies to all systems
  - Rename `IrisInitAnimation` → `IrisSweepAnimation`; introduce `IrisAnimation` union type for future extensibility
  - Rename `initAnimation` config field → `onMount`
  - `IRIS_HERO` now has `interactive: { type: "tap", ... }` — clicking/tapping the homepage iris replays the sweep animation

## Test plan

- [ ] Drag aperture strip outside browser window, release, move back in — strip should not track cursor
- [ ] Click/tap the homepage iris — sweep animation should replay
- [ ] Design Lab hover interaction should be unaffected (`IRIS_LAB` uses `type: "hover"`)
- [ ] `IRIS_NAV` (navbar, OG image) has no `interactive` field — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)