### PR TITLE
fix(mobile): fix iOS PWA bottom safe-area white bar

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -6,5 +6,9 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default function AboutPage() {
-  return <AboutContent />;
+  return (
+    <div className="bg-background">
+      <AboutContent />
+    </div>
+  );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -70,8 +70,11 @@ export default async function LocaleLayout({
           <ScrollContainerProvider>
             <ConsoleEgg />
             <Nav />
-            {/* Offset fixed nav; respect home indicator in PWA mode. */}
-            <div className="pt-[var(--nav-height)] pb-[env(safe-area-inset-bottom,0px)] bg-background">
+            {/* Offset fixed nav; respect home indicator in PWA mode.
+                No background here — body stone-100 shows through the bottom
+                padding zone, so safe-area always matches the page canvas color
+                regardless of whether the page content is short or non-scrolling. */}
+            <div className="pt-[var(--nav-height)] pb-[env(safe-area-inset-bottom,0px)]">
               {TESTHOOK_ALLOWED ? (
                 <TestHookProvider>
                   {children}

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -199,7 +199,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   );
 
   return (
-    <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+    <div className="bg-background w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
       {/* Back button */}
       <BackButton fallbackHref="/lenses" />
 

--- a/src/app/[locale]/lenses/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/page.tsx
@@ -16,5 +16,9 @@ export async function generateMetadata({
 }
 
 export default function LensesPage() {
-  return <LensListClient lenses={allLenses} />;
+  return (
+    <div className="bg-background">
+      <LensListClient lenses={allLenses} />
+    </div>
+  );
 }

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -35,7 +35,7 @@ export default async function ComparePage({
   const fallbackHref = from === "lens" && lensId ? `/lenses/${lensId}` : "/lenses";
 
   return (
-    <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
+    <div className="bg-background w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
       {/* Header */}
       <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,11 +136,11 @@
   }
   body {
     @apply text-foreground;
-    /* stone-100 fills the canvas visible behind iOS Safari's transparent
-       bottom toolbar. The layout wrapper sets bg-background (white) for
-       page content, so only the narrow toolbar zone shows this color.
-       overflow-x: hidden clips horizontal overflow without creating a
-       vertical scroll container (unlike overflow-x: hidden on a div). */
+    /* stone-100 fills the safe-area zones visible in iOS Safari (bottom toolbar)
+       and iOS PWA standalone (home indicator zone). The layout wrapper has no
+       background, so stone-100 shows through the pt/pb padding zones regardless
+       of whether the page content is short or non-scrolling. Each page that
+       needs white sets bg-background on its own root element. */
     @apply bg-stone-100;
     /* clip avoids the CSS spec side effect where overflow-x: hidden promotes
        overflow-y to auto, turning body into a scroll container. clip trims


### PR DESCRIPTION
## Summary

- Remove `bg-background` from the layout wrapper div so the body's `stone-100` shows through the `pb-safe-area-inset-bottom` padding zone
- The layout wrapper's bottom padding (home indicator zone) now always shows `stone-100` regardless of whether page content fills the screen
- Pages that need a white canvas declare `bg-background` on their own root element: browse, compare, detail, about

## Root Cause

In iOS PWA standalone mode, `100svh` may not equal the physical screen height, so short/non-scrolling pages (homepage, about) don't fill all the way to the bottom. The wrapper's white `bg-background` was leaking into the 34px home indicator zone, showing a white bar at the bottom.

## Test plan

- [ ] iOS PWA (Chrome or Safari "Add to Home Screen") — no white bar at bottom on any page
- [ ] Homepage: stone-100 background fills seamlessly to bottom
- [ ] About page (short content, non-scrolling on large screens) — no white bar
- [ ] Browse/Compare/Detail pages: white content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)