### PR TITLE
fix(ApertureStrip): sync strip with tap animation after user interaction

### DIFF
--- a/src/components/ApertureStrip.tsx
+++ b/src/components/ApertureStrip.tsx
@@ -131,9 +131,14 @@ export default function ApertureStrip({
     setOffset(target);
   }, [animating, fStop, defaultIdx, minOffset, maxOffset]);
 
-  // When init animation ends, snap back to A (resting position).
+  // Track animation start/end transitions.
+  // On start (false → true): release user-hold so the strip follows the animation.
+  // On end   (true → false): snap back to A if the user hasn't re-grabbed the strip.
   const prevAnimatingRef = useRef(animating);
   useEffect(() => {
+    if (!prevAnimatingRef.current && animating) {
+      userHasInteractedRef.current = false;
+    }
     if (prevAnimatingRef.current && !animating && !userHasInteractedRef.current) {
       setOffset(maxOffset);
     }


### PR DESCRIPTION
## Summary

- **Bug**: After the user drags the aperture strip, clicking the iris to trigger a tap animation no longer moves the strip — it stays frozen wherever the user left it.
- **Root cause**: `userHasInteractedRef` is set to `true` on the first strip drag and never cleared. The sync effect that drives the strip position during animation guards on this ref, so all subsequent tap animations are silently ignored.
- **Fix**: Reset `userHasInteractedRef` when a new animation begins (`animating` transitions false → true), so the strip always follows the iris animation regardless of prior user interaction. The strip snaps back to A when the animation ends; the user can re-grab it at any time.

## Test plan

- [ ] Load homepage, wait for mount animation — strip follows iris ✓
- [ ] Drag strip to a non-A position, then click the iris — strip now follows the tap animation ✓
- [ ] During animation, grab the strip — user input takes priority, strip doesn't snap to A on animation end ✓
- [ ] Multiple tap cycles — strip consistently follows each animation ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)