### PR TITLE
feat(feedback): enrich Report dialog — lens header, official link & image fields

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -195,9 +195,13 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   // Field options for the Report Dialog — taken directly from resolved values,
   // identical to what is rendered in the spec table below.
-  const reportableFields = resolvedGroups.flatMap((group) =>
-    group.rows.map((row) => ({ label: row.label, currentValue: row.plainText }))
-  );
+  const reportableFields = [
+    ...resolvedGroups.flatMap((group) =>
+      group.rows.map((row) => ({ label: row.label, currentValue: row.plainText }))
+    ),
+    ...(url ? [{ label: t("fieldOfficialLink"), currentValue: url }] : []),
+    { label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id) },
+  ];
 
   return (
     <div className="bg-background w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -195,12 +195,13 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   // Field options for the Report Dialog — taken directly from resolved values,
   // identical to what is rendered in the spec table below.
+  const mediaGroupLabel = t("fieldGroupMedia");
   const reportableFields = [
     ...resolvedGroups.flatMap((group) =>
-      group.rows.map((row) => ({ label: row.label, currentValue: row.plainText }))
+      group.rows.map((row) => ({ label: row.label, currentValue: row.plainText, group: group.label }))
     ),
-    ...(url ? [{ label: t("fieldOfficialLink"), currentValue: url }] : []),
-    { label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id) },
+    ...(url ? [{ label: t("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel }] : []),
+    { label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true },
   ];
 
   return (

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -253,7 +253,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
             </div>
             <FeedbackTrigger
               type="data_issue"
-              context={{ lensId: lens.id, lensModel: lens.model }}
+              context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
               fields={reportableFields}
               className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors self-start"
             >

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -132,9 +132,14 @@ export async function POST(req: Request) {
   }
 
   const token = process.env.GITHUB_TOKEN;
-  const repo = process.env.GITHUB_FEEDBACK_REPO;
+  // data_issue and missing_lens → pipeline repo (data source of truth)
+  // general → app repo (product/UI feedback)
+  const repo =
+    payload.type === "general"
+      ? process.env.GITHUB_APP_REPO
+      : process.env.GITHUB_FEEDBACK_REPO;
   if (!token || !repo) {
-    console.error("[feedback] missing GITHUB_TOKEN or GITHUB_FEEDBACK_REPO");
+    console.error("[feedback] missing GITHUB_TOKEN or target repo env var");
     return NextResponse.json(
       { error: "server_misconfigured" },
       { status: 500 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -132,14 +132,9 @@ export async function POST(req: Request) {
   }
 
   const token = process.env.GITHUB_TOKEN;
-  // data_issue and missing_lens → pipeline repo (data source of truth)
-  // general → app repo (product/UI feedback)
-  const repo =
-    payload.type === "general"
-      ? process.env.GITHUB_APP_REPO
-      : process.env.GITHUB_FEEDBACK_REPO;
+  const repo = process.env.GITHUB_FEEDBACK_REPO;
   if (!token || !repo) {
-    console.error("[feedback] missing GITHUB_TOKEN or target repo env var");
+    console.error("[feedback] missing GITHUB_TOKEN or GITHUB_FEEDBACK_REPO");
     return NextResponse.json(
       { error: "server_misconfigured" },
       { status: 500 }

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -381,10 +381,13 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
           if (resolved) fields.push({ label: resolved.label, currentValue: resolved.plainText });
         }
       }
+      const url = getLensUrl(lens);
+      if (url) fields.push({ label: t("fieldOfficialLink"), currentValue: url });
+      fields.push({ label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id) });
       map.set(lens.id, fields);
     }
     return map;
-  }, [resolvedPerLens, allGroups, orderedLenses]);
+  }, [resolvedPerLens, allGroups, orderedLenses, t]);
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const { lockNav } = useNavLock();

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -837,7 +837,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
                     )}
                     <FeedbackTrigger
                       type="data_issue"
-                      context={{ lensId: lens.id, lensModel: lens.model }}
+                      context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                       fields={fields}
                       className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
                     >

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -371,6 +371,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
   // what is rendered in the table cells.
   const lensFields = useMemo(() => {
     const map = new Map<string, FeedbackField[]>();
+    const mediaGroupLabel = td("fieldGroupMedia");
     for (const lens of orderedLenses) {
       const rowMap = resolvedPerLens.get(lens.id);
       if (!rowMap) continue;
@@ -378,16 +379,16 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
       for (const group of allGroups) {
         for (const row of group.rows) {
           const resolved = rowMap.get(row.label);
-          if (resolved) fields.push({ label: resolved.label, currentValue: resolved.plainText });
+          if (resolved) fields.push({ label: resolved.label, currentValue: resolved.plainText, group: group.label });
         }
       }
       const url = getLensUrl(lens);
-      if (url) fields.push({ label: t("fieldOfficialLink"), currentValue: url });
-      fields.push({ label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id) });
+      if (url) fields.push({ label: td("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel });
+      fields.push({ label: td("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true });
       map.set(lens.id, fields);
     }
     return map;
-  }, [resolvedPerLens, allGroups, orderedLenses, t]);
+  }, [resolvedPerLens, allGroups, orderedLenses, td]);
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const { lockNav } = useNavLock();

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -31,6 +31,7 @@ export interface FeedbackField {
 export interface FeedbackContext {
   lensId?: string;
   lensModel?: string;
+  lensBrand?: string;
   searchQuery?: string;
   field?: string;
 }
@@ -92,12 +93,17 @@ export default function FeedbackDialog({
         ? "descriptionMissingLens"
         : "descriptionGeneral";
 
-  const contextLine =
+  // Prominent lens header shown for data_issue when a specific lens is known.
+  const lensHeader =
     type === "data_issue" && context?.lensModel
-      ? t("contextLens", { model: context.lensModel })
-      : type === "missing_lens" && context?.searchQuery
-        ? t("contextQuery", { query: context.searchQuery })
-        : null;
+      ? { brand: context.lensBrand ?? "", model: context.lensModel }
+      : null;
+
+  // Subtle context note for other cases (e.g. missing_lens with a search query).
+  const contextLine =
+    type === "missing_lens" && context?.searchQuery
+      ? t("contextQuery", { query: context.searchQuery })
+      : null;
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -161,6 +167,24 @@ export default function FeedbackDialog({
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-2">
+            {lensHeader && (
+              <div className="flex flex-col gap-0.5 border-b border-zinc-200 dark:border-zinc-800 pb-3">
+                <span className="text-[11px] font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+                  {t("affectedLensLabel")}
+                </span>
+                <div className="flex items-baseline gap-1.5">
+                  {lensHeader.brand && (
+                    <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                      {lensHeader.brand}
+                    </span>
+                  )}
+                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                    {lensHeader.model}
+                  </span>
+                </div>
+              </div>
+            )}
+
             {contextLine && (
               <div className="rounded-lg bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 px-3 py-2 text-xs text-zinc-600 dark:text-zinc-400">
                 {contextLine}

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -14,7 +14,9 @@ import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -26,6 +28,10 @@ export interface FeedbackField {
   label: string;
   /** Current display value for this field on this lens, shown read-only after selection. */
   currentValue?: string;
+  /** Group label for the dropdown. Fields with the same group are rendered together. */
+  group?: string;
+  /** When true, the current value is not shown to the user (e.g. internal image paths). */
+  hideCurrentValue?: boolean;
 }
 
 export interface FeedbackContext {
@@ -68,6 +74,24 @@ export default function FeedbackDialog({
   const showFieldPicker = type === "data_issue" && fields && fields.length > 0;
 
   const selectedField = fields?.find((f) => f.label === selectedFieldLabel);
+
+  // Group fields by their `group` property, preserving insertion order.
+  const groupedFields = showFieldPicker
+    ? (() => {
+        const groups: { label: string; fields: FeedbackField[] }[] = [];
+        const index = new Map<string, number>();
+        for (const f of fields) {
+          const key = f.group ?? "";
+          if (!index.has(key)) {
+            index.set(key, groups.length);
+            groups.push({ label: key, fields: [f] });
+          } else {
+            groups[index.get(key)!].fields.push(f);
+          }
+        }
+        return groups;
+      })()
+    : [];
 
   useEffect(() => {
     if (!open) {
@@ -208,17 +232,22 @@ export default function FeedbackDialog({
                     <SelectValue placeholder={t("fieldPickerPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent portalContainer={dialogLayerRef}>
-                    {fields.map((f) => (
-                      <SelectItem key={f.label} value={f.label}>
-                        {f.label}
-                      </SelectItem>
+                    {groupedFields.map((group) => (
+                      <SelectGroup key={group.label}>
+                        {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                        {group.fields.map((f) => (
+                          <SelectItem key={f.label} value={f.label}>
+                            {f.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
                     ))}
                   </SelectContent>
                 </Select>
 
                 {selectedField && (
                   <div className="flex flex-col gap-2 rounded-lg bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 px-3 py-2.5">
-                    {selectedField.currentValue && (
+                    {selectedField.currentValue && !selectedField.hideCurrentValue && (
                       <div className="flex items-baseline gap-2">
                         <span className="shrink-0 text-xs text-zinc-400 dark:text-zinc-500">
                           {t("currentValueLabel")}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -171,6 +171,8 @@
     "removeFromCompare": "Remove",
     "officialSite": "Official site",
     "reportIssue": "Report a data issue",
+    "fieldOfficialLink": "Official Link",
+    "fieldLensImage": "Lens Image",
     "notFoundTitle": "Lens Not Found"
   },
   "Brands": {
@@ -196,6 +198,8 @@
     "compareFullHint": "All slots are filled. Remove a lens to add another.",
     "removeLens": "Remove {model}",
     "reportIssue": "Report",
+    "fieldOfficialLink": "Official Link",
+    "fieldLensImage": "Lens Image",
     "shiftLeft": "Move left",
     "shiftRight": "Move right"
   },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -313,7 +313,7 @@
     "descriptionDataIssue": "Wrong spec, broken image, typo, weird detail — tell us what you found. It goes straight to the maintainer.",
     "descriptionMissingLens": "Know an X-mount lens we're missing? Send it over and we'll add it to the queue.",
     "descriptionGeneral": "Thoughts, bug reports, and feature ideas are all welcome.",
-    "contextLens": "About: {model}",
+    "affectedLensLabel": "Affected lens",
     "contextQuery": "Search query: {query}",
     "fieldPickerLabel": "Affected field",
     "fieldPickerPlaceholder": "Choose a field…",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -173,6 +173,7 @@
     "reportIssue": "Report a data issue",
     "fieldOfficialLink": "Official Link",
     "fieldLensImage": "Lens Image",
+    "fieldGroupMedia": "Media & Links",
     "notFoundTitle": "Lens Not Found"
   },
   "Brands": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -313,7 +313,7 @@
     "descriptionDataIssue": "参数不对、图片不对、文案有误，都可以在这里告诉我们。你的反馈会直接发给维护者。",
     "descriptionMissingLens": "如果你发现有漏收录的 X 卡口镜头，发给我们，我们会加入处理队列。",
     "descriptionGeneral": "有想法、发现 Bug，或者想提功能建议，都欢迎。",
-    "contextLens": "相关镜头：{model}",
+    "affectedLensLabel": "相关镜头",
     "contextQuery": "搜索词：{query}",
     "fieldPickerLabel": "问题字段",
     "fieldPickerPlaceholder": "请选择字段…",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -173,6 +173,7 @@
     "reportIssue": "反馈参数问题",
     "fieldOfficialLink": "官方链接",
     "fieldLensImage": "镜头图片",
+    "fieldGroupMedia": "媒体与链接",
     "notFoundTitle": "未找到这支镜头"
   },
   "Brands": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -171,6 +171,8 @@
     "removeFromCompare": "移除",
     "officialSite": "官网页面",
     "reportIssue": "反馈参数问题",
+    "fieldOfficialLink": "官方链接",
+    "fieldLensImage": "镜头图片",
     "notFoundTitle": "未找到这支镜头"
   },
   "Brands": {
@@ -196,6 +198,8 @@
     "compareFullHint": "已达到最大数量，请先移除一个镜头再添加。",
     "removeLens": "移除 {model}",
     "reportIssue": "反馈问题",
+    "fieldOfficialLink": "官方链接",
+    "fieldLensImage": "镜头图片",
     "shiftLeft": "左移一列",
     "shiftRight": "右移一列"
   },


### PR DESCRIPTION
## Summary

- **Lens section header**: Replace the subtle `contextLine` info box in the Report dialog with a dedicated section header showing the affected lens's brand and model prominently (only when triggered from a specific lens).
- **Official Link & Lens Image as reportable fields**: Both are now available in the field picker so users can flag incorrect official links or wrong images.
- **All feedback routes to x-glass-pipeline repo** (no routing split for now; deferred to a future change).

## Test plan

- [ ] Open a lens detail page → click "Report a data issue" → confirm the dialog shows the lens brand + model header at the top, not an info box
- [ ] In the field picker, confirm "Official Link" and "Lens Image" appear at the bottom of the list with their current values shown
- [ ] Open the Compare page → click "Report" on any lens column → same header and field picker behavior
- [ ] Open the About page → click any feedback button → confirm no lens header appears (no lens context)
- [ ] For a lens with no official site, confirm "Official Link" does not appear in the field picker
- [ ] Submit a report and verify it lands in the x-glass-pipeline GitHub repo issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)