### PR TITLE
feat(lens): locale-aware official links

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -101,7 +101,7 @@ function renderRowValue(
 }
 
 export default async function LensDetailPage({ params }: { params: Params }) {
-  const { id } = await params;
+  const { id, locale } = await params;
   const lens = allLenses.find((l) => l.id === id);
 
   if (!lens) {
@@ -110,7 +110,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   const t = await getTranslations("LensDetail");
   const tBrand = await getTranslations("Brands");
-  const url = getLensUrl(lens);
+  const url = getLensUrl(lens, locale);
 
   const specGroups = buildSpecGroups({
     groupOptics: t("groupOptics"),

--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -245,10 +245,14 @@ export default async function LensDetailPage({ params }: { params: Params }) {
           <div className="flex flex-col gap-2">
             <div className="flex flex-wrap gap-3">
               <AddToCompareButton lensId={lens.id} />
-              {url && (
+              {url ? (
                 <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>
                   {t("officialSite")}
                 </ExternalLink>
+              ) : (
+                <span className={ACTION_OUTLINE_CLS + " cursor-not-allowed opacity-40"}>
+                  {t("officialSite")}
+                </span>
               )}
               <ShareButton lenses={[lens]} triggerClassName={ACTION_OUTLINE_CLS} />
             </div>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -829,13 +829,17 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
               return (
                 <td key={lens.id} className="px-3 py-2">
                   <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
-                    {url && (
+                    {url ? (
                       <ExternalLink
                         href={url}
                         className="inline-flex items-center gap-1 text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
                       >
                         {t("officialSite")}
                       </ExternalLink>
+                    ) : (
+                      <span className="inline-flex cursor-not-allowed items-center gap-1 text-xs text-zinc-300 dark:text-zinc-600">
+                        {t("officialSite")}
+                      </span>
                     )}
                     <FeedbackTrigger
                       type="data_issue"

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -11,7 +11,7 @@ import React, {
 import { useNavLock } from "@/context/ScrollContainerContext";
 import Image from "next/image";
 import { ExternalLink } from "@/components/ui/external-link";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { ChevronLeft, ChevronRight, Flag, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
@@ -166,6 +166,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
   const t = useTranslations("Compare");
   const td = useTranslations("LensDetail");
   const tBrand = useTranslations("Brands");
+  const locale = useLocale();
   const router = useRouter();
   const { compareIds, replaceCompare } = useCompare();
   const initialLensIds = useMemo(
@@ -382,7 +383,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
           if (resolved) fields.push({ label: resolved.label, currentValue: resolved.plainText, group: group.label });
         }
       }
-      const url = getLensUrl(lens);
+      const url = getLensUrl(lens, locale);
       if (url) fields.push({ label: td("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel });
       fields.push({ label: td("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true });
       map.set(lens.id, fields);
@@ -823,7 +824,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
           <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
             <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
             {orderedLenses.map((lens) => {
-              const url = getLensUrl(lens);
+              const url = getLensUrl(lens, locale);
               const fields = lensFields.get(lens.id);
               return (
                 <td key={lens.id} className="px-3 py-2">

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -517,27 +517,27 @@ describe("getUniqueBrands", () => {
 describe("getLensUrl", () => {
   const bothLinks = { cn: "https://example.com/cn-lens", global: "https://example.com/global-lens" };
 
-  it("returns global link for en locale when both links are present", () => {
+  it("returns global link for en locale", () => {
     const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
     expect(getLensUrl(lens, "en")).toBe("https://example.com/global-lens");
   });
 
-  it("returns cn link for zh locale when both links are present", () => {
+  it("returns cn link for zh locale", () => {
     const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
     expect(getLensUrl(lens, "zh")).toBe("https://example.com/cn-lens");
   });
 
-  it("falls back to global when zh locale but only global is present", () => {
+  it("returns undefined for zh locale when only global link is present (no fallback)", () => {
     const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: { global: "https://example.com/global-lens" } });
-    expect(getLensUrl(lens, "zh")).toBe("https://example.com/global-lens");
+    expect(getLensUrl(lens, "zh")).toBeUndefined();
   });
 
-  it("falls back to cn when en locale but only cn is present", () => {
+  it("returns undefined for en locale when only cn link is present (no fallback)", () => {
     const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: { cn: "https://example.com/cn-lens" } });
-    expect(getLensUrl(lens, "en")).toBe("https://example.com/cn-lens");
+    expect(getLensUrl(lens, "en")).toBeUndefined();
   });
 
-  it("defaults to global-first when no locale is provided", () => {
+  it("defaults to global when no locale is provided", () => {
     const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
     expect(getLensUrl(lens)).toBe("https://example.com/global-lens");
   });

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -515,41 +515,40 @@ describe("getUniqueBrands", () => {
 // getLensUrl
 // ---------------------------------------------------------------------------
 describe("getLensUrl", () => {
-  it("returns global official link when present", () => {
-    const lens = makeLens({
-      focalLengthMin: 35,
-      focalLengthMax: 35,
-      officialLinks: { global: "https://example.com/lens" },
-    });
-    expect(getLensUrl(lens)).toBe("https://example.com/lens");
+  const bothLinks = { cn: "https://example.com/cn-lens", global: "https://example.com/global-lens" };
+
+  it("returns global link for en locale when both links are present", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
+    expect(getLensUrl(lens, "en")).toBe("https://example.com/global-lens");
   });
 
-  it("falls back to cn official link when global link is absent", () => {
-    const lens = makeLens({
-      focalLengthMin: 35,
-      focalLengthMax: 35,
-      officialLinks: { cn: "https://example.com/cn-lens" },
-    });
-    expect(getLensUrl(lens)).toBe("https://example.com/cn-lens");
+  it("returns cn link for zh locale when both links are present", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
+    expect(getLensUrl(lens, "zh")).toBe("https://example.com/cn-lens");
   });
 
-  it("returns undefined for Fujifilm without official links", () => {
+  it("falls back to global when zh locale but only global is present", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: { global: "https://example.com/global-lens" } });
+    expect(getLensUrl(lens, "zh")).toBe("https://example.com/global-lens");
+  });
+
+  it("falls back to cn when en locale but only cn is present", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: { cn: "https://example.com/cn-lens" } });
+    expect(getLensUrl(lens, "en")).toBe("https://example.com/cn-lens");
+  });
+
+  it("defaults to global-first when no locale is provided", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35, officialLinks: bothLinks });
+    expect(getLensUrl(lens)).toBe("https://example.com/global-lens");
+  });
+
+  it("returns undefined when no official links exist", () => {
     const lens = makeLens({
       focalLengthMin: 35,
       focalLengthMax: 35,
-      brand: "Fujifilm",
       officialLinks: undefined as unknown as { global: string },
     });
-    expect(getLensUrl(lens)).toBeUndefined();
-  });
-
-  it("returns undefined for unknown brand without official links", () => {
-    const lens = makeLens({
-      focalLengthMin: 35,
-      focalLengthMax: 35,
-      brand: "UnknownBrand",
-      officialLinks: undefined as unknown as { global: string },
-    });
-    expect(getLensUrl(lens)).toBeUndefined();
+    expect(getLensUrl(lens, "zh")).toBeUndefined();
+    expect(getLensUrl(lens, "en")).toBeUndefined();
   });
 });

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -171,12 +171,13 @@ export function getUniqueBrands(lenses: Lens[]): string[] {
   return [...new Set(lenses.map((l) => l.brand))].sort();
 }
 
-// Returns the locale-appropriate official link: zh → cn first, others → global first.
+// Returns the locale-appropriate official link with no fallback:
+// zh → cn only, others → global only. Returns undefined if the locale's link is absent.
 export function getLensUrl(lens: Lens, locale?: string): string | undefined {
   if (locale === "zh") {
-    return lens.officialLinks?.cn ?? lens.officialLinks?.global;
+    return lens.officialLinks?.cn;
   }
-  return lens.officialLinks?.global ?? lens.officialLinks?.cn;
+  return lens.officialLinks?.global;
 }
 
 export function parseLensIds(ids: string | undefined): Lens[] {

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -171,8 +171,11 @@ export function getUniqueBrands(lenses: Lens[]): string[] {
   return [...new Set(lenses.map((l) => l.brand))].sort();
 }
 
-// Prioritize global official links for now. Can adjust logic later if we want to show region-specific links based on user locale or other signals.
-export function getLensUrl(lens: Lens): string | undefined {
+// Returns the locale-appropriate official link: zh → cn first, others → global first.
+export function getLensUrl(lens: Lens, locale?: string): string | undefined {
+  if (locale === "zh") {
+    return lens.officialLinks?.cn ?? lens.officialLinks?.global;
+  }
   return lens.officialLinks?.global ?? lens.officialLinks?.cn;
 }
 


### PR DESCRIPTION
## Summary

- `getLensUrl` now accepts a `locale` parameter: `zh` resolves to the `cn` link, all other locales resolve to `global`
- No fallback: if the locale-specific link is absent, returns `undefined`
- Detail page and Compare table both show a disabled (greyed-out, non-clickable) "Official site" label instead of hiding the element when the link is unavailable

## Test plan

- [ ] Visit a lens detail page on `/zh/lenses/...` — Official site button should link to the `cn` URL
- [ ] Visit the same lens on `/en/lenses/...` — Official site button should link to the `global` URL
- [ ] Check a lens that only has a `cn` link (e.g. `brightinstar-mf-25mm-f18-xf`) on `/en/` — button should appear disabled
- [ ] Same lens on `/zh/` — button should be clickable
- [ ] Verify the same behaviour in the Compare table footer row
- [ ] All unit tests pass: `npm test -- lenses.test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)