### PR TITLE
feat(compare): trending presets, mobile carousel, and cold-start UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "nukedev": "rm -rf .next && next dev",
+    "nuke": "pkill -f 'next dev' 2>/dev/null; pkill -f 'next-server' 2>/dev/null; rm -rf .next; echo 'Cache cleared. Run npm run dev to restart.'",
+    "nukedev": "npm run nuke && next dev",
     "gen:icons": "tsx scripts/gen-icons.tsx",
     "validate:lenses": "node --experimental-strip-types scripts/validate-lenses.mts",
     "build": "npm run gen:icons && npm run validate:lenses && next build",

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -1,18 +1,32 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { parseLensIds } from "@/lib/lens";
+import { getPresetBySlug } from "@/lib/trending";
 import CompareTable from "@/components/CompareTable";
 import ComparePageHeader from "@/components/ComparePageHeader";
+import CuratedComparisons from "@/components/CuratedComparisons";
 import BackButton from "@/components/BackButton";
 
 export async function generateMetadata({
+  params,
   searchParams,
 }: {
-  searchParams: Promise<{ ids?: string }>;
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ ids?: string; preset?: string }>;
 }): Promise<Metadata> {
   const t = await getTranslations("Compare");
-  const { ids } = await searchParams;
+  const { locale } = await params;
+  const { ids, preset } = await searchParams;
   const lenses = parseLensIds(ids);
+
+  if (preset) {
+    const found = getPresetBySlug(preset);
+    if (found) {
+      const lang = locale === "zh" ? "zh" : "en";
+      const title = found.title[lang];
+      return { title, openGraph: { title: `${title} | X-Glass` } };
+    }
+  }
 
   if (lenses.length < 2) {
     return { title: t("title") };
@@ -26,12 +40,18 @@ export async function generateMetadata({
 }
 
 export default async function ComparePage({
+  params,
   searchParams,
 }: {
-  searchParams: Promise<{ ids?: string; from?: string; lensId?: string }>;
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ ids?: string; from?: string; lensId?: string; preset?: string }>;
 }) {
-  const { ids, from, lensId } = await searchParams;
+  const { locale } = await params;
+  const { ids, from, lensId, preset } = await searchParams;
   const lenses = parseLensIds(ids);
+
+  const lang = locale === "zh" ? "zh" : "en";
+  const presetTitle = preset ? (getPresetBySlug(preset)?.title[lang] ?? undefined) : undefined;
 
   // Determine back destination: lens detail page if navigated from one, else lens list
   const fallbackHref = from === "lens" && lensId ? `/lenses/${lensId}` : "/lenses";
@@ -39,7 +59,10 @@ export default async function ComparePage({
   return (
     <div className="bg-background w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
       {/* Header */}
-      <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} />
+      <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} presetTitle={presetTitle} />
+
+      {/* Curated presets — client component, self-hides when compare list is non-empty */}
+      <CuratedComparisons />
 
       {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns */}
       <CompareTable lenses={lenses} minColumns={2} />

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -67,7 +67,7 @@ export default async function ComparePage({
       {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns.
           hideBodyWhenEmpty keeps cold start compact: only the slot headers are shown,
           the spec rows appear once the user adds the first lens. */}
-      <CompareTable lenses={lenses} minColumns={2} hideBodyWhenEmpty />
+      <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
 
       {/* Curated presets — client component, self-hides when compare list is non-empty */}
       <CuratedComparisons />

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -44,7 +44,7 @@ export default async function ComparePage({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ ids?: string; from?: string; lensId?: string; preset?: string }>;
+  searchParams: Promise<{ ids?: string; from?: "lens" | "home"; lensId?: string; preset?: string }>;
 }) {
   const { locale } = await params;
   const { ids, from, lensId, preset } = await searchParams;
@@ -53,8 +53,11 @@ export default async function ComparePage({
   const lang = locale === "zh" ? "zh" : "en";
   const presetTitle = preset ? (getPresetBySlug(preset)?.title[lang] ?? undefined) : undefined;
 
-  // Determine back destination: lens detail page if navigated from one, else lens list
-  const fallbackHref = from === "lens" && lensId ? `/lenses/${lensId}` : "/lenses";
+  // Determine back destination based on referrer context
+  const fallbackHref =
+    from === "lens" && lensId ? `/lenses/${lensId}` :
+    from === "home" ? "/" :
+    "/lenses";
 
   return (
     <div className="bg-background w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -64,11 +64,13 @@ export default async function ComparePage({
       {/* Header */}
       <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} presetTitle={presetTitle} />
 
+      {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns.
+          hideBodyWhenEmpty keeps cold start compact: only the slot headers are shown,
+          the spec rows appear once the user adds the first lens. */}
+      <CompareTable lenses={lenses} minColumns={2} hideBodyWhenEmpty />
+
       {/* Curated presets — client component, self-hides when compare list is non-empty */}
       <CuratedComparisons />
-
-      {/* Table — minColumns=2 ensures cold start always shows 2 search-trigger columns */}
-      <CompareTable lenses={lenses} minColumns={2} />
 
       {lenses.length > 0 && (
         <BackButton fallbackHref={fallbackHref} />

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
               {h("cta")} →
             </Link>
             <Link
-              href="/lenses/compare"
+              href="/lenses/compare?from=home"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-medium text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900 transition-colors"
             >
               {h("ctaCompare")} →

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
               {h("cta")} →
             </Link>
             <Link
-              href="/lenses/compare?from=home"
+              href={{ pathname: "/lenses/compare", query: { from: "home" } }}
               className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-medium text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900 transition-colors"
             >
               {h("ctaCompare")} →

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
+import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { Popover } from "@base-ui/react/popover";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { MAX_COMPARE } from "@/lib/lens";
@@ -16,6 +17,7 @@ interface Props {
 export default function CompareAddLensButton({ lenses, triggerClassName }: Props) {
   const t = useTranslations("Compare");
   const router = useRouter();
+  const { buildCompareUrl } = useCompareUrl();
 
   const canAddMore = lenses.length < MAX_COMPARE;
   const currentIds = lenses.map((l) => l.id);
@@ -24,9 +26,9 @@ export default function CompareAddLensButton({ lenses, triggerClassName }: Props
     (lens: Lens) => {
       if (currentIds.includes(lens.id) || currentIds.length >= MAX_COMPARE) return;
       const nextIds = [...currentIds, lens.id];
-      router.replace(`/lenses/compare?ids=${nextIds.join(",")}`);
+      router.replace(buildCompareUrl(nextIds));
     },
-    [currentIds, router]
+    [currentIds, router, buildCompareUrl]
   );
 
   const getResultState = useCallback(

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -7,6 +7,7 @@ import { ShareButton } from "@/components/ShareButton";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
 import BackButton from "@/components/BackButton";
 import { useCompare } from "@/context/CompareProvider";
+import { useRouter } from "@/i18n/navigation";
 import type { Lens } from "@/lib/types";
 
 interface Props {
@@ -22,6 +23,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
   const t = useTranslations("Compare");
   const tList = useTranslations("LensList");
   const { clearCompare } = useCompare();
+  const router = useRouter();
   const headerRef = useRef<HTMLDivElement>(null);
   const [showFab, setShowFab] = useState(false);
   // Show the FAB when the header row scrolls behind the nav bar
@@ -46,7 +48,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
         {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
         {lenses.length > 0 && (
           <button
-            onClick={clearCompare}
+            onClick={() => { clearCompare(); router.replace("/lenses/compare"); }}
             className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
           >
             {tList("clearCompare")}

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -13,9 +13,11 @@ interface Props {
   fallbackHref: string;
   /** Matches CompareTable minColumns — button is hidden while empty slot columns are visible. */
   minColumns?: number;
+  /** Preset title to use as the default share poster title. */
+  presetTitle?: string;
 }
 
-export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0 }: Props) {
+export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0, presetTitle }: Props) {
   const t = useTranslations("Compare");
   const headerRef = useRef<HTMLDivElement>(null);
   const [showFab, setShowFab] = useState(false);
@@ -41,7 +43,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
         {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
         {lenses.length >= 1 && (
           <div className="ml-auto">
-            <ShareButton lenses={lenses} />
+            <ShareButton lenses={lenses} presetTitle={presetTitle} />
           </div>
         )}
       </div>
@@ -56,7 +58,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
         }`}
         aria-hidden={!showFab}
       >
-        <ShareButton lenses={lenses} variant="fab" />
+        <ShareButton lenses={lenses} variant="fab" presetTitle={presetTitle} />
       </div>
     </>
   );

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -5,8 +5,8 @@ import { Z } from "@/config/ui";
 import { useTranslations } from "next-intl";
 import { ShareButton } from "@/components/ShareButton";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
-import CuratedPresetsButton from "@/components/CuratedPresetsButton";
 import BackButton from "@/components/BackButton";
+import { useCompare } from "@/context/CompareProvider";
 import type { Lens } from "@/lib/types";
 
 interface Props {
@@ -20,6 +20,8 @@ interface Props {
 
 export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0, presetTitle }: Props) {
   const t = useTranslations("Compare");
+  const tList = useTranslations("LensList");
+  const { clearCompare } = useCompare();
   const headerRef = useRef<HTMLDivElement>(null);
   const [showFab, setShowFab] = useState(false);
   // Show the FAB when the header row scrolls behind the nav bar
@@ -42,7 +44,14 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
           {t("title")}
         </h1>
         {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
-        <CuratedPresetsButton />
+        {lenses.length > 0 && (
+          <button
+            onClick={clearCompare}
+            className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
+          >
+            {tList("clearCompare")}
+          </button>
+        )}
         {lenses.length >= 1 && (
           <div className="ml-auto">
             <ShareButton lenses={lenses} presetTitle={presetTitle} />

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -65,11 +65,11 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
       <div
         data-testid="compare-share-fab"
         className={`fixed bottom-6 right-4 ${Z.fixed} transition-all duration-200 sm:right-6 ${
-          showFab
+          showFab && lenses.length >= 1
             ? "opacity-100 translate-y-0 pointer-events-auto"
             : "opacity-0 translate-y-3 pointer-events-none"
         }`}
-        aria-hidden={!showFab}
+        aria-hidden={!(showFab && lenses.length >= 1)}
       >
         <ShareButton lenses={lenses} variant="fab" presetTitle={presetTitle} />
       </div>

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -5,6 +5,7 @@ import { Z } from "@/config/ui";
 import { useTranslations } from "next-intl";
 import { ShareButton } from "@/components/ShareButton";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
+import CuratedPresetsButton from "@/components/CuratedPresetsButton";
 import BackButton from "@/components/BackButton";
 import type { Lens } from "@/lib/types";
 
@@ -41,6 +42,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
           {t("title")}
         </h1>
         {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
+        <CuratedPresetsButton />
         {lenses.length >= 1 && (
           <div className="ml-auto">
             <ShareButton lenses={lenses} presetTitle={presetTitle} />

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -21,6 +21,7 @@ import { useRouter } from "@/i18n/navigation";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 import type { FeedbackField } from "@/components/FeedbackDialog";
 import { useCompare } from "@/context/CompareProvider";
+import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { allLenses, getLensUrl, MAX_COMPARE } from "@/lib/lens";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
@@ -171,6 +172,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const locale = useLocale();
   const router = useRouter();
   const { replaceCompare } = useCompare();
+  const { buildCompareUrl } = useCompareUrl();
   const initialLensIds = useMemo(
     () => initialLenses.map((lens) => lens.id),
     [initialLenses]
@@ -198,10 +200,10 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
       replaceCompare(nextIds);
       setOrderedIds(nextIds);
       startTransition(() => {
-        router.replace(`/lenses/compare?ids=${nextIds.join(",")}`);
+        router.replace(buildCompareUrl(nextIds));
       });
     },
-    [orderedIds, replaceCompare, router]
+    [orderedIds, replaceCompare, router, buildCompareUrl]
   );
 
   const getAddResultState = useCallback(
@@ -229,7 +231,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     replaceCompare(nextIds);
     setOrderedIds(nextIds);
     startTransition(() => {
-      router.replace(`/lenses/compare?ids=${nextIds.join(",")}`);
+      router.replace(buildCompareUrl(nextIds));
     });
   }
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -475,10 +475,12 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     </div>
     <div ref={containerRef} className="isolate overflow-x-auto overflow-y-clip rounded-xl border border-zinc-200 dark:border-zinc-800">
       <table
-        className="w-full min-w-max table-fixed text-sm border-collapse"
-        style={{
-          minWidth: `calc(${LABEL_COLUMN_WIDTH} + ${orderedLenses.length} * ${LENS_COLUMN_MIN_WIDTH})`,
-        }}
+        className={cn("w-full table-fixed text-sm border-collapse", orderedLenses.length > 0 && "min-w-max")}
+        style={
+          orderedLenses.length > 0
+            ? { minWidth: `calc(${LABEL_COLUMN_WIDTH} + ${orderedLenses.length} * ${LENS_COLUMN_MIN_WIDTH})` }
+            : undefined
+        }
       >
         <colgroup>
           <col style={{ width: LABEL_COLUMN_WIDTH }} />
@@ -486,7 +488,8 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
             <col key={lens.id} style={{ width: LENS_COLUMN_MIN_WIDTH }} />
           ))}
           {Array.from({ length: emptySlotCount }).map((_, i) => (
-            <col key={`empty-col-${i}`} style={{ width: LENS_COLUMN_MIN_WIDTH }} />
+            // Empty state: no fixed width — table-fixed distributes remaining space evenly
+            <col key={`empty-col-${i}`} style={orderedLenses.length > 0 ? { width: LENS_COLUMN_MIN_WIDTH } : undefined} />
           ))}
         </colgroup>
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -170,40 +170,19 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const tBrand = useTranslations("Brands");
   const locale = useLocale();
   const router = useRouter();
-  const { compareIds, replaceCompare } = useCompare();
+  const { replaceCompare } = useCompare();
   const initialLensIds = useMemo(
     () => initialLenses.map((lens) => lens.id),
     [initialLenses]
   );
   const [orderedIds, setOrderedIds] = useState(initialLensIds);
 
-  // Keep a ref to the latest compareIds so the init effect can read the
-  // current context value without re-running every time it changes.
-  const compareIdsRef = useRef(compareIds);
-  useEffect(() => { compareIdsRef.current = compareIds; }, [compareIds]);
-
+  // URL is the single source of truth. Sync context and local state whenever
+  // the server-rendered lens list changes (navigation, lens add/remove).
   useEffect(() => {
-    if (initialLensIds.length > 0) {
-      // URL has IDs — URL is the source of truth.
-      replaceCompare(initialLensIds);
-      setOrderedIds(initialLensIds);
-    } else {
-      const existing = compareIdsRef.current;
-      if (existing.length > 0) {
-        // URL has no IDs but context does (e.g. user navigated via a bare
-        // /compare link). Restore from context and sync the URL so the
-        // server can hydrate the correct lenses.
-        setOrderedIds(existing);
-        startTransition(() => {
-          router.replace(`/lenses/compare?ids=${existing.join(",")}`);
-        });
-      } else {
-        // Genuine cold start — nothing to restore.
-        replaceCompare([]);
-        setOrderedIds([]);
-      }
-    }
-  }, [initialLensIds, replaceCompare, router]);
+    replaceCompare(initialLensIds);
+    setOrderedIds(initialLensIds);
+  }, [initialLensIds, replaceCompare]);
 
   const orderedLenses = orderedIds
     .map((id) => allLenses.find((lens) => lens.id === id))

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -157,12 +157,14 @@ interface Props {
   lenses: Lens[];
   /** Minimum number of columns to display; empty slot headers fill the gap. */
   minColumns?: number;
+  /** When true and the compare list is empty, only the header row is rendered (no skeleton body). */
+  hideBodyWhenEmpty?: boolean;
 }
 
 const LABEL_COLUMN_WIDTH = "6rem";
 const LENS_COLUMN_MIN_WIDTH = "9rem";
 
-export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: Props) {
+export default function CompareTable({ lenses: initialLenses, minColumns = 0, hideBodyWhenEmpty = false }: Props) {
   const t = useTranslations("Compare");
   const td = useTranslations("LensDetail");
   const tBrand = useTranslations("Brands");
@@ -549,7 +551,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0 }: 
 
         <tbody>
           {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
-          {orderedLenses.length === 0 && allGroups.map((group) => (
+          {orderedLenses.length === 0 && !hideBodyWhenEmpty && allGroups.map((group) => (
             <React.Fragment key={group.label}>
               <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
                 <td colSpan={totalColSpan} className="h-8 text-center">

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -64,7 +64,21 @@ export default function CuratedComparisons() {
       <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-3">
         {t("curatedHint")}
       </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+      {/* Mobile: horizontal snap carousel showing ~1.5 cards to signal swipeability */}
+      <div className="sm:hidden -mx-4 overflow-x-auto snap-x snap-mandatory">
+        <div className="flex gap-2 px-4 pb-0.5">
+          {trendingPresets.map((preset) => (
+            <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
+              <PresetCard preset={preset} />
+            </div>
+          ))}
+          {/* Trailing spacer so the last card can reach its snap point */}
+          <div className="shrink-0 w-2" aria-hidden="true" />
+        </div>
+      </div>
+
+      {/* Desktop: grid */}
+      <div className="hidden sm:grid sm:grid-cols-2 lg:grid-cols-3 gap-2">
         {trendingPresets.map((preset) => (
           <PresetCard key={preset.slug} preset={preset} />
         ))}

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -24,7 +24,7 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
   return (
     <button
       onClick={handleClick}
-      className="group text-left w-full rounded-xl border border-zinc-200 bg-white px-4 py-3.5 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:hover:border-zinc-500 dark:hover:bg-zinc-900"
+      className="group text-left w-full h-full flex flex-col rounded-xl border border-zinc-200 bg-white px-4 py-3.5 transition-all hover:-translate-y-0.5 hover:border-zinc-400 hover:bg-zinc-50 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-950 dark:hover:border-zinc-500 dark:hover:bg-zinc-900"
     >
       <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 leading-snug">
         {preset.title[lang]}
@@ -46,6 +46,11 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
           )
         ))}
       </div>
+
+      {/* CTA — fades in on hover */}
+      <p className="mt-auto pt-3 text-xs font-medium text-zinc-400 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-500">
+        Compare Now →
+      </p>
     </button>
   );
 }
@@ -65,8 +70,8 @@ export default function CuratedComparisons() {
         {t("curatedHint")}
       </p>
       {/* Mobile: horizontal snap carousel showing ~1.5 cards to signal swipeability */}
-      <div className="sm:hidden -mx-4 overflow-x-auto snap-x snap-mandatory">
-        <div className="flex gap-2 px-4 pb-0.5">
+      <div className="sm:hidden -mx-4 overflow-x-auto snap-x snap-mandatory scroll-pl-4">
+        <div className="flex items-stretch gap-2 px-4 pb-0.5">
           {trendingPresets.map((preset) => (
             <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
               <PresetCard preset={preset} />

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCompare } from "@/context/CompareProvider";
 import { trendingPresets, type TrendingPreset } from "@/lib/trending";
 import { allLenses } from "@/lib/lens";
+import { cn } from "@/lib/utils";
 
 export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSelect?: () => void }) {
   const router = useRouter();
@@ -58,6 +61,36 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
 export default function CuratedComparisons() {
   const { compareIds } = useCompare();
   const t = useTranslations("Compare");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
+
+  function updateScrollState() {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 4);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 4);
+  }
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      ro.disconnect();
+    };
+  }, []);
+
+  function scrollToDir(dir: -1 | 1) {
+    const el = scrollRef.current;
+    if (!el) return;
+    const approxCardWidth = el.scrollWidth / trendingPresets.length;
+    el.scrollBy({ left: dir * approxCardWidth, behavior: "smooth" });
+  }
 
   if (compareIds.length > 0) return null;
 
@@ -69,17 +102,47 @@ export default function CuratedComparisons() {
       <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-3">
         {t("curatedHint")}
       </p>
-      {/* Mobile: horizontal snap carousel showing ~1.5 cards to signal swipeability */}
-      <div className="sm:hidden -mx-4 overflow-x-auto snap-x snap-mandatory scroll-pl-4">
-        <div className="flex items-stretch gap-2 px-4 pb-0.5">
-          {trendingPresets.map((preset) => (
-            <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
-              <PresetCard preset={preset} />
-            </div>
-          ))}
-          {/* Trailing spacer so the last card can reach its snap point */}
-          <div className="shrink-0 w-2" aria-hidden="true" />
+
+      {/* Mobile: horizontal snap carousel */}
+      <div className="sm:hidden relative -mx-4">
+        {/* Left chevron */}
+        <button
+          onClick={() => scrollToDir(-1)}
+          aria-label="Scroll left"
+          className={cn(
+            "absolute left-0 top-0 bottom-0 z-10 flex items-center pl-1 pr-6 bg-gradient-to-r from-white/90 to-transparent transition-opacity dark:from-zinc-950/90",
+            canScrollLeft ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+          )}
+        >
+          <ChevronLeft className="h-5 w-5 text-zinc-500 dark:text-zinc-400" />
+        </button>
+
+        {/* Scroll container — scrollbar hidden */}
+        <div
+          ref={scrollRef}
+          className="overflow-x-auto snap-x snap-mandatory scroll-pl-4 [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:none]"
+        >
+          <div className="flex items-stretch gap-2 px-4 pb-0.5">
+            {trendingPresets.map((preset) => (
+              <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
+                <PresetCard preset={preset} />
+              </div>
+            ))}
+            <div className="shrink-0 w-2" aria-hidden="true" />
+          </div>
         </div>
+
+        {/* Right chevron */}
+        <button
+          onClick={() => scrollToDir(1)}
+          aria-label="Scroll right"
+          className={cn(
+            "absolute right-0 top-0 bottom-0 z-10 flex items-center pl-6 pr-1 bg-gradient-to-l from-white/90 to-transparent transition-opacity dark:from-zinc-950/90",
+            canScrollRight ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+          )}
+        >
+          <ChevronRight className="h-5 w-5 text-zinc-500 dark:text-zinc-400" />
+        </button>
       </div>
 
       {/* Desktop: grid */}

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { useCompare } from "@/context/CompareProvider";
+import { trendingPresets, type TrendingPreset } from "@/lib/trending";
+import { allLenses } from "@/lib/lens";
+
+function PresetCard({ preset }: { preset: TrendingPreset }) {
+  const router = useRouter();
+  const locale = useLocale();
+  const lang = locale === "zh" ? "zh" : "en";
+
+  const lenses = preset.lensIds
+    .map((id) => allLenses.find((l) => l.id === id))
+    .filter(Boolean);
+
+  function handleClick() {
+    const idsParam = preset.lensIds.join(",");
+    router.replace(`/lenses/compare?ids=${idsParam}&preset=${preset.slug}`);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="group text-left w-full rounded-xl border border-zinc-200 bg-white px-4 py-3.5 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:hover:border-zinc-500 dark:hover:bg-zinc-900"
+    >
+      <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 leading-snug">
+        {preset.title[lang]}
+      </p>
+      <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400 leading-snug">
+        {preset.subtitle[lang]}
+      </p>
+
+      {/* Lens model badge strip */}
+      <div className="mt-2.5 flex flex-wrap gap-1">
+        {lenses.map((lens) => (
+          lens && (
+            <span
+              key={lens.id}
+              className="inline-block rounded-md bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+            >
+              {lens.model}
+            </span>
+          )
+        ))}
+      </div>
+    </button>
+  );
+}
+
+export default function CuratedComparisons() {
+  const { compareIds } = useCompare();
+  const t = useTranslations("Compare");
+
+  if (compareIds.length > 0) return null;
+
+  return (
+    <div className="mb-2">
+      <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-2 uppercase tracking-wide">
+        {t("curatedTitle")}
+      </p>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-3">
+        {t("curatedHint")}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {trendingPresets.map((preset) => (
+          <PresetCard key={preset.slug} preset={preset} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { useCompare } from "@/context/CompareProvider";
 import { trendingPresets, type TrendingPreset } from "@/lib/trending";
 import { allLenses } from "@/lib/lens";
@@ -13,14 +14,14 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
   const router = useRouter();
   const locale = useLocale();
   const lang = locale === "zh" ? "zh" : "en";
+  const { buildCompareUrl } = useCompareUrl();
 
   const lenses = preset.lensIds
     .map((id) => allLenses.find((l) => l.id === id))
     .filter(Boolean);
 
   function handleClick() {
-    const idsParam = preset.lensIds.join(",");
-    router.replace(`/lenses/compare?ids=${idsParam}&preset=${preset.slug}`);
+    router.replace(buildCompareUrl(preset.lensIds, { preset: preset.slug }));
     onSelect?.();
   }
 

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -6,7 +6,7 @@ import { useCompare } from "@/context/CompareProvider";
 import { trendingPresets, type TrendingPreset } from "@/lib/trending";
 import { allLenses } from "@/lib/lens";
 
-function PresetCard({ preset }: { preset: TrendingPreset }) {
+export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSelect?: () => void }) {
   const router = useRouter();
   const locale = useLocale();
   const lang = locale === "zh" ? "zh" : "en";
@@ -18,6 +18,7 @@ function PresetCard({ preset }: { preset: TrendingPreset }) {
   function handleClick() {
     const idsParam = preset.lensIds.join(",");
     router.replace(`/lenses/compare?ids=${idsParam}&preset=${preset.slug}`);
+    onSelect?.();
   }
 
   return (

--- a/src/components/CuratedPresetsButton.tsx
+++ b/src/components/CuratedPresetsButton.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Popover } from "@base-ui/react/popover";
+import { Drawer } from "@base-ui/react/drawer";
+import { LayoutGrid } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Z } from "@/config/ui";
+import { trendingPresets } from "@/lib/trending";
+import { PresetCard } from "@/components/CuratedComparisons";
+import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
+
+export default function CuratedPresetsButton() {
+  const t = useTranslations("Compare");
+  const [open, setOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(true);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const mq = window.matchMedia("(min-width: 640px)");
+    setIsDesktop(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const trigger = (
+    <span className={`${ICON_NAV_BTN_CLS} h-8 w-8`} title={t("curatedTitle")}>
+      <LayoutGrid className="h-4 w-4" />
+    </span>
+  );
+
+  const panelContent = (
+    <div className="p-3 flex flex-col gap-2">
+      <p className="px-1 text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wide">
+        {t("curatedTitle")}
+      </p>
+      {trendingPresets.map((preset) => (
+        <PresetCard
+          key={preset.slug}
+          preset={preset}
+          onSelect={() => setOpen(false)}
+        />
+      ))}
+    </div>
+  );
+
+  if (!mounted) {
+    return (
+      <button className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
+        <LayoutGrid className="h-4 w-4" />
+      </button>
+    );
+  }
+
+  if (isDesktop) {
+    return (
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
+          <LayoutGrid className="h-4 w-4" />
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner side="bottom" align="start" sideOffset={8}>
+            <Popover.Popup className="w-96 max-h-[calc(100svh-80px)] overflow-y-auto origin-(--transform-origin) rounded-xl bg-white shadow-lg ring-1 ring-zinc-200 duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-zinc-900 dark:ring-zinc-800">
+              {panelContent}
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    );
+  }
+
+  return (
+    <Drawer.Root open={open} onOpenChange={setOpen} swipeDirection="down">
+      <Drawer.Trigger className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
+        <LayoutGrid className="h-4 w-4" />
+      </Drawer.Trigger>
+      <Drawer.Portal>
+        <Drawer.Backdrop className={`fixed inset-0 ${Z.overlay} bg-black/40 transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`} />
+        <Drawer.Popup className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[var(--safe-inset-bottom)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}>
+          <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
+            <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
+          </div>
+          <div className="overflow-y-auto pb-8">
+            {panelContent}
+          </div>
+        </Drawer.Popup>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -139,7 +139,7 @@ export default function LensSearchDialog({
             ? "inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200 bg-white text-zinc-600 transition-colors hover:border-zinc-300 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:text-zinc-50"
             : triggerVariant === "button"
               ? "inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 transition-colors hover:border-zinc-300 hover:text-zinc-950 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:text-zinc-50"
-              : "flex w-full flex-col items-center justify-center gap-2 rounded-[28px] border border-dashed border-zinc-300 bg-zinc-50/60 text-center text-zinc-500 transition-colors hover:border-zinc-400 hover:bg-zinc-100/70 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/60 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:bg-zinc-900 dark:hover:text-zinc-50",
+              : "group flex w-full flex-col items-center justify-center gap-2 rounded-[28px] border border-dashed border-zinc-300 bg-zinc-50/60 text-center text-zinc-500 transition-colors hover:border-zinc-400 hover:bg-zinc-100/70 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/60 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:bg-zinc-900 dark:hover:text-zinc-50",
           triggerClassName
         )}
       >
@@ -154,8 +154,13 @@ export default function LensSearchDialog({
         )}
         {triggerVariant === "slot" && (
           <>
-            <Search className="h-5 w-5" />
-            <span className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
+            {/* Lens front-view icon: three concentric circles */}
+            <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8 opacity-40 transition-opacity group-hover:opacity-70" aria-hidden="true">
+              <circle cx="12" cy="12" r="9.5" stroke="currentColor" strokeWidth="1.25" />
+              <circle cx="12" cy="12" r="5" stroke="currentColor" strokeWidth="1.25" />
+              <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+            </svg>
+            <span className="text-xs font-medium">
               {triggerLabel ?? t("addLens")}
             </span>
           </>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -154,12 +154,7 @@ export default function LensSearchDialog({
         )}
         {triggerVariant === "slot" && (
           <>
-            {/* Lens front-view icon: three concentric circles */}
-            <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8 opacity-40 transition-opacity group-hover:opacity-70" aria-hidden="true">
-              <circle cx="12" cy="12" r="9.5" stroke="currentColor" strokeWidth="1.25" />
-              <circle cx="12" cy="12" r="5" stroke="currentColor" strokeWidth="1.25" />
-              <circle cx="12" cy="12" r="1.5" fill="currentColor" />
-            </svg>
+            <Search className="h-6 w-6 opacity-40 transition-opacity group-hover:opacity-70" />
             <span className="text-xs font-medium">
               {triggerLabel ?? t("addLens")}
             </span>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -37,9 +37,11 @@ interface ShareButtonProps {
   variant?: "default" | "fab";
   /** Override the default trigger button class (non-fab variant only). */
   triggerClassName?: string;
+  /** Pre-fill the poster title from a curated preset. User can still override in Customize. */
+  presetTitle?: string;
 }
 
-export function ShareButton({ lenses, variant = "default", triggerClassName }: ShareButtonProps) {
+export function ShareButton({ lenses, variant = "default", triggerClassName, presetTitle }: ShareButtonProps) {
   const t = useTranslations("Share");
   const tImage = useTranslations("ShareImage");
   const tBrand = useTranslations("Brands");
@@ -57,8 +59,8 @@ export function ShareButton({ lenses, variant = "default", triggerClassName }: S
   // Ref to the rendered <SharePoster /> root node
   const posterRef = useRef<HTMLDivElement>(null);
 
-  // Customization
-  const [customTitle, setCustomTitle] = useState("");
+  // Customization — preset title is used as the default if provided
+  const [customTitle, setCustomTitle] = useState(presetTitle ?? "");
   const [customSlogan, setCustomSlogan] = useState("");
   const [customOpen, setCustomOpen] = useState(false);
 

--- a/src/data/trending.json
+++ b/src/data/trending.json
@@ -1,0 +1,102 @@
+{
+  "presets": [
+    {
+      "slug": "standard-zoom-showdown",
+      "title": {
+        "zh": "APS-C 标准变焦：原厂 vs 副厂",
+        "en": "APS-C Standard Zooms: Fuji vs Third-party"
+      },
+      "subtitle": {
+        "zh": "轻便、光圈、防抖——四支标准变焦的取舍",
+        "en": "Weight, aperture, stabilization — four standard zooms compared"
+      },
+      "lensIds": [
+        "fujifilm-xf-18-55mmf28-4-r-lm-ois-xf",
+        "fujifilm-xf-16-50mmf28-48-r-lm-wr-xf",
+        "sigma-contemporary-18-50mm-f28-dc-dn-xf",
+        "tamron-17-70mm-f28-di-iii-a-vc-rxd-xf"
+      ]
+    },
+    {
+      "slug": "35mm-equiv-primes",
+      "title": {
+        "zh": "等效 35mm 定焦：23mm 焦段横评",
+        "en": "35mm-equiv Primes: 23mm Roundup"
+      },
+      "subtitle": {
+        "zh": "原厂大光圈、轻便版、适马与唯卓仕副厂——如何取舍？",
+        "en": "First-party large-aperture vs. compact vs. third-party alternatives"
+      },
+      "lensIds": [
+        "fujifilm-xf-23mmf14-r-lm-wr-xf",
+        "fujifilm-xf-23mmf2-r-wr-xf",
+        "sigma-contemporary-23mm-f14-dc-dn-xf",
+        "viltrox-af-25mm-f17-air-xf"
+      ]
+    },
+    {
+      "slug": "50mm-equiv-fuji-primes",
+      "title": {
+        "zh": "等效 50mm 定焦：富士 35mm / 33mm 焦段对比",
+        "en": "50mm-equiv Fuji Primes: 35/33mm Compared"
+      },
+      "subtitle": {
+        "zh": "老 35/1.4 的氛围感、新 33/1.4 的光学素质、35/2 的便携三防",
+        "en": "Old-school rendering vs. modern resolution vs. compact weather-resistant"
+      },
+      "lensIds": [
+        "fujifilm-xf-35mmf14-r-xf",
+        "fujifilm-xf-33mmf14-r-lm-wr-xf",
+        "fujifilm-xf-35mmf2-r-wr-xf"
+      ]
+    },
+    {
+      "slug": "portrait-56mm",
+      "title": {
+        "zh": "56mm 人像定焦：原厂 vs 副厂",
+        "en": "56mm Portrait Primes: Fuji vs Third-party"
+      },
+      "subtitle": {
+        "zh": "f/1.2 极致虚化 vs 副厂轻便性价比",
+        "en": "Ultimate bokeh at f/1.2 vs. lighter, more affordable alternatives"
+      },
+      "lensIds": [
+        "fujifilm-xf-56mmf12-r-wr-xf",
+        "sigma-contemporary-56mm-f14-dc-dn-xf",
+        "viltrox-af-56mm-f17-air-xf"
+      ]
+    },
+    {
+      "slug": "all-in-one-superzooms",
+      "title": {
+        "zh": "一镜走天下：超长焦变焦对比",
+        "en": "All-in-one Superzooms"
+      },
+      "subtitle": {
+        "zh": "旅游首选：适马、腾龙、富士原厂的焦段与画质取舍",
+        "en": "Sigma vs Tamron vs Fuji — focal range and image quality trade-offs"
+      },
+      "lensIds": [
+        "sigma-contemporary-16-300mm-f35-67-dc-os-xf",
+        "tamron-18-300mm-f35-63-di-iii-a-vc-vxd-xf",
+        "fujifilm-xf-18-135mmf35-56-r-lm-ois-wr-xf"
+      ]
+    },
+    {
+      "slug": "tele-zoom-entry",
+      "title": {
+        "zh": "长焦变焦入门：XC 50-230 vs XF 55-200 vs XF 70-300",
+        "en": "Entry Tele Zooms: XC 50-230 vs XF 55-200 vs XF 70-300"
+      },
+      "subtitle": {
+        "zh": "打鸟、演唱会、日常远摄——三支长焦变焦的价位与画质",
+        "en": "Wildlife, concerts, reach — comparing price and performance"
+      },
+      "lensIds": [
+        "fujifilm-xc-50-230mmf45-67-ois-ii-xf",
+        "fujifilm-xf-55-200mmf35-48-r-lm-ois-xf",
+        "fujifilm-xf-70-300mmf4-56-r-lm-ois-wr-xf"
+      ]
+    }
+  ]
+}

--- a/src/hooks/useCompareUrl.ts
+++ b/src/hooks/useCompareUrl.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+/**
+ * Builds compare page URLs while preserving back-navigation context
+ * (from / lensId) that was set when the user first entered the compare page.
+ * This prevents the context from being lost when the user adds lenses,
+ * selects presets, or reorders columns within the compare flow.
+ */
+export function useCompareUrl() {
+  const searchParams = useSearchParams();
+
+  function buildCompareUrl(ids: string[], extra?: { preset?: string }) {
+    const params = new URLSearchParams();
+    if (ids.length > 0) params.set("ids", ids.join(","));
+    if (extra?.preset) params.set("preset", extra.preset);
+
+    // Carry forward back-navigation context
+    const from = searchParams.get("from");
+    const lensId = searchParams.get("lensId");
+    if (from) params.set("from", from);
+    if (lensId) params.set("lensId", lensId);
+
+    const qs = params.toString();
+    return qs ? `/lenses/compare?${qs}` : "/lenses/compare";
+  }
+
+  return { buildCompareUrl };
+}

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -419,6 +419,48 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
     },
 
     // -----------------------------------------------------------------------
+    // Physical
+    // -----------------------------------------------------------------------
+    {
+      label: labels.groupPhysical,
+      rows: [
+        {
+          kind: "numeric",
+          label: labels.weight,
+          fieldNoteKey: "weightG" as FieldNoteKey,
+          hasData: (l) => l.weightG !== undefined,
+          getDisplayValue: (l) => fmt.weightDisplay(l.weightG, "g"),
+          toComparable: (l) =>
+            Array.isArray(l.weightG) ? l.weightG[0] : l.weightG,
+          bestDir: "min",
+        },
+        {
+          kind: "text",
+          label: labels.dimensions,
+          hasData: (l) =>
+            l.diameterMm !== undefined || l.length !== undefined,
+          getDisplayValue: (l) =>
+            fmt.dimensionsPrimaryDisplay(l.diameterMm, l.length),
+          getSubValue: (l) =>
+            fmt.dimensionsVariantsDisplay(l.length, { retracted, wide, tele }),
+        },
+        {
+          kind: "text",
+          label: labels.filterSize,
+          fieldNoteKey: "filterMm" as FieldNoteKey,
+          hasData: (l) => l.filterMm !== undefined,
+          getDisplayValue: (l) => fmt.filterSizeDisplay(l.filterMm),
+        },
+        {
+          kind: "text",
+          label: labels.lensMaterial,
+          hasData: (l) => l.lensMaterial !== undefined,
+          getDisplayValue: (l) => l.lensMaterial,
+        },
+      ] satisfies SpecRow[],
+    },
+
+    // -----------------------------------------------------------------------
     // Autofocus
     // -----------------------------------------------------------------------
     {
@@ -522,48 +564,6 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
             l.ois && l.oisStops !== undefined
               ? `${l.oisStops} stops`
               : undefined,
-        },
-      ] satisfies SpecRow[],
-    },
-
-    // -----------------------------------------------------------------------
-    // Physical
-    // -----------------------------------------------------------------------
-    {
-      label: labels.groupPhysical,
-      rows: [
-        {
-          kind: "numeric",
-          label: labels.weight,
-          fieldNoteKey: "weightG" as FieldNoteKey,
-          hasData: (l) => l.weightG !== undefined,
-          getDisplayValue: (l) => fmt.weightDisplay(l.weightG, "g"),
-          toComparable: (l) =>
-            Array.isArray(l.weightG) ? l.weightG[0] : l.weightG,
-          bestDir: "min",
-        },
-        {
-          kind: "text",
-          label: labels.dimensions,
-          hasData: (l) =>
-            l.diameterMm !== undefined || l.length !== undefined,
-          getDisplayValue: (l) =>
-            fmt.dimensionsPrimaryDisplay(l.diameterMm, l.length),
-          getSubValue: (l) =>
-            fmt.dimensionsVariantsDisplay(l.length, { retracted, wide, tele }),
-        },
-        {
-          kind: "text",
-          label: labels.filterSize,
-          fieldNoteKey: "filterMm" as FieldNoteKey,
-          hasData: (l) => l.filterMm !== undefined,
-          getDisplayValue: (l) => fmt.filterSizeDisplay(l.filterMm),
-        },
-        {
-          kind: "text",
-          label: labels.lensMaterial,
-          hasData: (l) => l.lensMaterial !== undefined,
-          getDisplayValue: (l) => l.lensMaterial,
         },
       ] satisfies SpecRow[],
     },

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -7,7 +7,7 @@ export type { SpecialtyTag };
 export const allLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
 export const meta = metaData;
 export const brandCount = new Set(allLenses.map((l) => l.brand)).size;
-export const MAX_COMPARE = 3;
+export const MAX_COMPARE = 4;
 
 export type LensType = "prime" | "zoom";
 export const LENS_TYPES = ["prime", "zoom"] as const satisfies readonly LensType[];

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -1,0 +1,22 @@
+import trendingData from "../data/trending.json";
+import { allLenses } from "./lens";
+import type { Lens } from "./types";
+
+export interface TrendingPreset {
+  slug: string;
+  title: { zh: string; en: string };
+  subtitle: { zh: string; en: string };
+  lensIds: string[];
+}
+
+export const trendingPresets: TrendingPreset[] = trendingData.presets;
+
+export function getPresetBySlug(slug: string): TrendingPreset | undefined {
+  return trendingPresets.find((p) => p.slug === slug);
+}
+
+export function getPresetLenses(preset: TrendingPreset): Lens[] {
+  return preset.lensIds
+    .map((id) => allLenses.find((l) => l.id === id))
+    .filter((l): l is Lens => l !== undefined);
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -110,7 +110,7 @@
     "groupOptics": "Optics",
     "groupFocus": "Autofocus",
     "groupStabilization": "Stabilization",
-    "groupPhysical": "Physical",
+    "groupPhysical": "Build",
     "groupFeatures": "Features",
     "groupRelease": "Release",
     "focalLength": "Focal Length",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -205,7 +205,7 @@
     "shiftLeft": "Move left",
     "shiftRight": "Move right",
     "curatedTitle": "Curated Comparisons",
-    "curatedHint": "Not sure where to start? Pick a common selection scenario."
+    "curatedHint": "Not sure what to compare? Try one of these curated scenarios."
   },
   "Share": {
     "button": "Share",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -203,7 +203,9 @@
     "fieldOfficialLink": "Official Link",
     "fieldLensImage": "Lens Image",
     "shiftLeft": "Move left",
-    "shiftRight": "Move right"
+    "shiftRight": "Move right",
+    "curatedTitle": "Curated Comparisons",
+    "curatedHint": "Not sure where to start? Pick a common selection scenario."
   },
   "Share": {
     "button": "Share",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -205,7 +205,7 @@
     "shiftLeft": "左移一列",
     "shiftRight": "右移一列",
     "curatedTitle": "精选对比",
-    "curatedHint": "不知从何开始？试试这些常见选型场景。"
+    "curatedHint": "还没想好比什么？先试试这些精选场景。"
   },
   "Share": {
     "button": "分享",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -110,7 +110,7 @@
     "groupOptics": "光学",
     "groupFocus": "对焦",
     "groupStabilization": "防抖",
-    "groupPhysical": "规格",
+    "groupPhysical": "外形规格",
     "groupFeatures": "特性",
     "groupRelease": "上市信息",
     "focalLength": "焦距",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -203,7 +203,9 @@
     "fieldOfficialLink": "官方链接",
     "fieldLensImage": "镜头图片",
     "shiftLeft": "左移一列",
-    "shiftRight": "右移一列"
+    "shiftRight": "右移一列",
+    "curatedTitle": "精选对比",
+    "curatedHint": "不知从何开始？试试这些常见选型场景。"
   },
   "Share": {
     "button": "分享",


### PR DESCRIPTION
## Summary

- Add curated/trending comparison presets for cold-start onboarding (data-driven via `src/data/trending.json`)
- Mobile: convert curated presets into a horizontal snap carousel with chevron navigation and hidden scrollbar
- Replace `CuratedPresetsButton` in header with a "Clear All" button; fix clear logic to reset URL so table and body both reset
- Fix hydration mismatch by removing context-restore `router.replace` from `CompareTable` render cycle
- Cold-start table now fills 100% width on mobile (no horizontal scroll for ≤2 lenses)
- Share FAB hidden in cold-start state (no lenses), matching header behavior
- Preserve `from`/`lensId` back-navigation context when adding lenses, selecting presets, or reordering — via new `useCompareUrl` hook
- Fix homepage Compare CTA using object-form `href` so `from=home` is reliably included
- Rename "Physical" spec group to "Build"; reorder sections (Optics → Build → AF → OIS → Features → Release)
- Add `npm run nuke` script to kill stale Next.js dev servers before clearing cache

## Test plan

- [ ] Cold-start: table fills full width, no horizontal scroll on mobile
- [ ] Cold-start: curated preset cards render as horizontal carousel on mobile, 2-col/3-col grid on desktop
- [ ] Carousel chevrons appear/disappear correctly at scroll boundaries
- [ ] Clicking a preset card navigates to compare with correct `ids` and `preset` params
- [ ] Clear All button resets both URL and table
- [ ] Share FAB does not appear when no lenses are selected
- [ ] Homepage Compare CTA navigates to `/lenses/compare?from=home`
- [ ] Adding lenses or selecting presets from within compare preserves `from`/`lensId` params
- [ ] No hydration mismatch errors in console on cold-start or navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)