### PR TITLE
feat(detail,compare): add info bubble to Release Year label

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -145,6 +145,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     powerZoom: t("powerZoom"),
     specialtyTags: t("specialtyTags"),
     releaseYear: t("releaseYear"),
+    releaseYearLabelNote: t("releaseYearLabelNote"),
     accessories: t("accessories"),
     yes: t("yes"),
     no: t("no"),
@@ -291,8 +292,11 @@ export default async function LensDetailPage({ params }: { params: Params }) {
                         key={resolved.label}
                         className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
                       >
-                        <td className="px-4 py-2.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/30 w-40 whitespace-nowrap align-top">
-                          {resolved.label}
+                        <td className="px-4 py-2.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/30 w-40 align-top">
+                          <div className="flex items-center gap-1">
+                            <span className="whitespace-nowrap">{resolved.label}</span>
+                            {resolved.labelNote && <FieldNotePopover note={resolved.labelNote} />}
+                          </div>
                         </td>
                         <td className="px-4 py-2.5 text-zinc-700 dark:text-zinc-300">
                           <div className="flex items-center gap-1.5">

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -283,6 +283,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
         powerZoom: td("powerZoom"),
         specialtyTags: td("specialtyTags"),
         releaseYear: td("releaseYear"),
+        releaseYearLabelNote: td("releaseYearLabelNote"),
         accessories: td("accessories"),
         yes: td("yes"),
         no: td("no"),
@@ -551,7 +552,10 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               {group.rows.map((row) => (
                 <tr key={row.label} className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
                   <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                    {row.label}
+                    <div className="flex items-center justify-end gap-1">
+                      {row.labelNote && <FieldNotePopover note={row.labelNote} />}
+                      <span>{row.label}</span>
+                    </div>
                   </td>
                   {Array.from({ length: emptySlotCount }).map((_, i) => (
                     <td key={i} className="px-3 py-3 text-center text-xs text-zinc-200 dark:text-zinc-800">
@@ -605,7 +609,10 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                     >
                       {/* Label cell */}
                       <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                        {row.label}
+                        <div className="flex items-center justify-end gap-1">
+                          {row.labelNote && <FieldNotePopover note={row.labelNote} />}
+                          <span>{row.label}</span>
+                        </div>
                       </td>
 
                       {/* Value cells — filled lenses */}

--- a/src/lib/__tests__/lens-spec-groups.test.ts
+++ b/src/lib/__tests__/lens-spec-groups.test.ts
@@ -34,6 +34,7 @@ const labels = {
   powerZoom: "Power Zoom",
   specialtyTags: "Specialty Tags",
   releaseYear: "Release Year",
+  releaseYearLabelNote: "For lenses available in multiple mounts, this is the year the Fujifilm X mount version was released.",
   accessories: "Accessories",
   yes: "Yes",
   no: "No",

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -24,6 +24,8 @@ export interface StructuredLine {
 interface BaseRow {
   /** Resolved label string (pre-translated by the caller). */
   label: string;
+  /** Static note shown in a ⓘ popover next to the label (not the value). Pre-translated by the caller. */
+  labelNote?: string;
   /** If set, look up lens.fieldNotes[fieldNoteKey] and show a ⓘ popover. */
   fieldNoteKey?: FieldNoteKey;
   /**
@@ -110,6 +112,8 @@ export interface SpecValueTextLabels {
 export interface ResolvedTextRow {
   kind: "text";
   label: string;
+  /** Static note shown in a ⓘ popover next to the label (not the value). */
+  labelNote?: string;
   /** Resolved note for the ⓘ popover, if any. */
   note?: string;
   displayValue?: string;
@@ -121,6 +125,7 @@ export interface ResolvedTextRow {
 export interface ResolvedNumericRow {
   kind: "numeric";
   label: string;
+  labelNote?: string;
   note?: string;
   displayValue?: string;
   subValue?: string;
@@ -134,6 +139,7 @@ export interface ResolvedNumericRow {
 export interface ResolvedBoolRow {
   kind: "bool";
   label: string;
+  labelNote?: string;
   note?: string;
   boolValue: boolean | "partial" | undefined;
   subValue?: string;
@@ -186,6 +192,7 @@ export interface SpecGroupLabels {
   powerZoom: string;
   specialtyTags: string;
   releaseYear: string;
+  releaseYearLabelNote: string;
   accessories: string;
 
   // Sub-labels used inside formatters
@@ -230,6 +237,8 @@ export function resolveSpecRow(
     (row.fieldNoteKey ? lens.fieldNotes?.[row.fieldNoteKey] : undefined) ??
     row.getNote?.(lens);
 
+  const labelNote = row.labelNote;
+
   if (row.kind === "bool") {
     const boolValue = row.getValue(lens);
     const subValue = row.getSubValue?.(lens);
@@ -244,6 +253,7 @@ export function resolveSpecRow(
     return {
       kind: "bool",
       label: row.label,
+      labelNote,
       note,
       boolValue,
       subValue,
@@ -264,6 +274,7 @@ export function resolveSpecRow(
     return {
       kind: "numeric",
       label: row.label,
+      labelNote,
       note,
       displayValue,
       subValue,
@@ -281,6 +292,7 @@ export function resolveSpecRow(
   return {
     kind: "text",
     label: row.label,
+    labelNote,
     note,
     displayValue,
     subValue,
@@ -612,6 +624,7 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
         {
           kind: "numeric",
           label: labels.releaseYear,
+          labelNote: labels.releaseYearLabelNote,
           hasData: (l) => l.releaseYear !== undefined,
           getDisplayValue: (l) => fmt.optionalNumber(l.releaseYear, ""),
           toComparable: (l) => l.releaseYear,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -162,6 +162,7 @@
     "motorStepping": "Stepping",
     "motorOther": "Other",
     "releaseYear": "Release Year",
+    "releaseYearLabelNote": "For lenses available in multiple mounts, this is the year the Fujifilm X mount version was released.",
     "accessories": "Accessories",
     "yes": "Yes",
     "no": "No",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -162,6 +162,7 @@
     "motorStepping": "步进马达",
     "motorOther": "其他",
     "releaseYear": "发布年份",
+    "releaseYearLabelNote": "若该镜头同时拥有多个卡口版本，此处显示的是富士 X 卡口版本的发布年份。",
     "accessories": "附带配件",
     "yes": "有",
     "no": "无",


### PR DESCRIPTION
## Summary

- Adds a `FieldNotePopover` (ⓘ) next to the **Release Year** label in both the lens detail page and compare table
- Clicking the icon shows: "For lenses available in multiple mounts, this is the year the Fujifilm X mount version was released." (zh: 若该镜头同时拥有多个卡口版本，此处显示的是富士 X 卡口版本的发布年份。)
- Introduces a generic `labelNote` field on `BaseRow` / `ResolvedSpecRow` so any future row can attach a label-side popover without one-off hacks

## Test plan

- [ ] Visit a lens detail page → Release Year row shows ⓘ icon; clicking opens popover with correct copy in zh/en
- [ ] Open compare table with 2+ lenses → same ⓘ icon appears next to Release Year label
- [ ] All other rows are unaffected (no extra icons)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)