### PR TITLE
feat(lens-list): add release year sort and fix mobile card overlap

### DIFF
--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -107,7 +107,7 @@ export default function LensCard({
           className="flex flex-1 flex-col gap-2 p-3 sm:gap-2.5 sm:p-4"
         >
           <div className="flex flex-col gap-1">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400 truncate">
+            <p className="text-[11px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400 truncate max-[499px]:pr-9">
               {tBrand(lens.brand)}
               {lens.series ? ` · ${lens.series}` : ""}
               {lens.releaseYear ? ` · ${lens.releaseYear}` : ""}

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -110,8 +110,12 @@ export default function LensCard({
             <p className="text-[11px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400 truncate max-[499px]:pr-9">
               {tBrand(lens.brand)}
               {lens.series ? ` · ${lens.series}` : ""}
-              {lens.releaseYear ? ` · ${lens.releaseYear}` : ""}
             </p>
+            {lens.releaseYear ? (
+              <p className="text-[11px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+                {lens.releaseYear}
+              </p>
+            ) : null}
             <h3
               className="font-semibold text-sm text-zinc-900 dark:text-zinc-50 leading-snug line-clamp-2 min-h-[2.5rem]"
               title={lens.model}

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -104,7 +104,7 @@ export default function LensCard({
 
         <div
           {...hookAttr("cardBody")}
-          className="flex flex-1 flex-col gap-2 p-3 sm:gap-2.5 sm:p-4"
+          className="flex flex-1 flex-col gap-2 p-3 sm:gap-2.5 sm:p-4 max-[499px]:min-w-0"
         >
           <div className="flex flex-col gap-1">
             <p className="text-[11px] uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400 truncate max-[499px]:pr-9">

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -64,6 +64,7 @@ export default function LensListClient({ lenses }: Props) {
     filters.features.length > 0;
     
   const sortOptions = [
+    { value: "releaseYear", label: t("sortReleaseYear") },
     { value: "focalLength", label: t("sortFocalLength") },
     { value: "maxAperture", label: t("sortAperture") },
     { value: "weightG", label: t("sortWeight") },
@@ -116,7 +117,7 @@ export default function LensListClient({ lenses }: Props) {
                   onValueChange={(value) =>
                     setFilters((current) => ({
                       ...current,
-                      sort: (value ?? "focalLength") as SortKey,
+                      sort: (value ?? "releaseYear") as SortKey,
                     }))
                   }
                   items={sortOptions.map((option) => ({ ...option }))}

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -130,8 +130,8 @@ export const defaultFilters: FilterState = {
   focusMotorClass: null,
   features: [],
   focalCategories: [],
-  sort: "focalLength",
-  sortDir: "asc",
+  sort: "releaseYear",
+  sortDir: "desc",
 };
 
 export function filterLenses(lenses: Lens[], filters: FilterState): Lens[] {
@@ -195,7 +195,7 @@ export function parseLensIds(ids: string | undefined): Lens[] {
     .filter((l): l is Lens => l !== undefined);
 }
 
-export type SortKey = "focalLength" | "maxAperture" | "weightG";
+export type SortKey = "focalLength" | "maxAperture" | "weightG" | "releaseYear";
 
 function getSortableMaxAperture(lens: Lens): number {
   return Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
@@ -209,6 +209,13 @@ export function sortLenses(
   return [...lenses].sort((a, b) => {
     if (key === "maxAperture") {
       const delta = getSortableMaxAperture(a) - getSortableMaxAperture(b);
+      return dir === "asc" ? delta : -delta;
+    }
+
+    if (key === "releaseYear") {
+      const aYear = a.releaseYear ?? 0;
+      const bYear = b.releaseYear ?? 0;
+      const delta = aYear - bYear;
       return dir === "asc" ? delta : -delta;
     }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -74,6 +74,7 @@
     "featureWrDesc": "Weather-resistant construction.",
     "featureApertureRingDesc": "Has a physical aperture ring.",
     "sortBy": "Sort",
+    "sortReleaseYear": "Release Year",
     "sortFocalLength": "Focal Length",
     "sortAperture": "Max Aperture",
     "sortWeight": "Weight",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -74,6 +74,7 @@
     "featureWrDesc": "具备防滴防尘设计",
     "featureApertureRingDesc": "带实体光圈环",
     "sortBy": "排序方式",
+    "sortReleaseYear": "发布年份",
     "sortFocalLength": "焦距",
     "sortAperture": "最大光圈",
     "sortWeight": "重量",


### PR DESCRIPTION
## Summary

- Fix mobile card header text overlapping the compare `+` button by adding `pr-9` padding on screens ≤499px, allowing truncation to kick in before the button
- Add **Release Year** as a sort option in the lens list
- Change default sort from Focal Length (asc) to **Release Year (desc)** — newest lenses first is more natural for product browsing

## Test plan

- [ ] On a narrow mobile viewport (≤499px), verify brand · series · year text truncates cleanly without overlapping the `+` button
- [ ] Long series names (e.g. "SIGMA · CONTEMPORARY · 2024") also truncate correctly
- [ ] "Release Year" appears as the first option in the Sort dropdown
- [ ] Lens list loads with newest lenses at the top by default
- [ ] Switching sort to other options (Focal Length, Aperture, Weight) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)