### PR TITLE
feat(nav): replace Get App text link with smartphone icon

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -118,11 +118,12 @@ export default function Nav() {
               aria-label={t("getApp")}
               className={`transition-colors ${
                 pathname === "/get"
-                  ? "text-zinc-900 dark:text-zinc-50"
-                  : "text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50"
+                  ? "text-zinc-900 dark:text-zinc-50 font-medium"
+                  : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50"
               }`}
             >
-              <Smartphone width={17} height={17} />
+              <Smartphone width={17} height={17} className="sm:hidden" />
+              <span className="hidden sm:inline text-sm">{t("getApp")}</span>
             </Link>
           )}
           <a

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
+import { Smartphone } from "lucide-react";
 import { Link, usePathname } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import Iris from "@/components/Iris";
@@ -114,13 +115,14 @@ export default function Nav() {
           {!isPwa && (
             <Link
               href="/get"
-              className={`text-sm transition-colors ${
+              aria-label={t("getApp")}
+              className={`transition-colors ${
                 pathname === "/get"
-                  ? "text-zinc-900 dark:text-zinc-50 font-medium"
-                  : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50"
+                  ? "text-zinc-900 dark:text-zinc-50"
+                  : "text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50"
               }`}
             >
-              {t("getApp")}
+              <Smartphone width={17} height={17} />
             </Link>
           )}
           <a


### PR DESCRIPTION
## Summary

- Replace the "Get App" text link in the navbar with a `Smartphone` icon (17px, matching the existing GitHub icon size)
- Reduces nav crowding on narrow mobile screens
- `aria-label` preserved for accessibility

## Test plan

- [ ] Navbar on mobile (≤390px) shows: X-Glass · Browse · Compare · About · 📱 · GitHub — no crowding
- [ ] Hovering/tapping the smartphone icon navigates to `/get`
- [ ] Active state (on `/get` page) renders the icon in `zinc-900` instead of `zinc-400`
- [ ] Desktop layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)