### PR TITLE
hide internalFocusing from all UI surfaces

### DIFF
--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -159,7 +159,7 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
 
   // ── Feature row visibility ─────────────────────────────────────
   // A feature row is shown only when at least one lens has a defined value.
-  const showInternalFocusing = lenses.some((l) => l.internalFocusing !== undefined);
+  // showInternalFocusing hidden — data quality issues, to be re-added later
 
   // ── Conditional Details visibility ────────────────────────────
   const focusMotorValues = lenses.map((l) => {
@@ -647,13 +647,6 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                   />
                   <PosterFeatureItem present={lens.af} label={labels.featureAF} icon={FEATURE_ICONS.af} />
                   <PosterFeatureItem present={lens.apertureRing} label={labels.featureApertureRing} icon={FEATURE_ICONS.apertureRing} />
-                  {showInternalFocusing && (
-                    <PosterFeatureItem
-                      present={lens.internalFocusing}
-                      label={labels.featureInternalFocusing}
-                      icon={FEATURE_ICONS.internalFocusing}
-                    />
-                  )}
                   </div>
                 </div>
               ))}

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -495,12 +495,7 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
           },
           getSubValue: (l) => l.focusMotor,
         },
-        {
-          kind: "bool",
-          label: labels.internalFocusing,
-          hasData: (l) => l.internalFocusing !== undefined,
-          getValue: (l) => l.internalFocusing,
-        },
+        // internalFocusing row hidden — data quality issues, to be re-added later
         {
           kind: "numeric",
           label: labels.minFocusDist,


### PR DESCRIPTION
Data quality issues — field hidden from Compare Table, lens detail page,
and Poster until data is regenerated. Field remains in schema and database.

https://claude.ai/code/session_016Yz23ZutRGGB8pkrkwnzR5