### PR TITLE
feat(typography): introduce Source Serif 4 for headings and story text

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -239,7 +239,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
               {tBrand(lens.brand)}
               {lens.series ? ` · ${lens.series}` : ""}
             </p>
-            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mt-1">
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mt-1 font-heading">
               {lens.model}
             </h1>
           </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
       {/* Hero */}
       <section className="flex flex-col items-center justify-center text-center px-4 py-16 flex-1">
         <Iris config={IRIS_HERO} uid="hero" />
-        <h1 className="mt-8 text-5xl sm:text-6xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+        <h1 className="mt-8 text-5xl sm:text-6xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50 font-heading">
           {t("appName")}
         </h1>
         <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400 max-w-sm">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,8 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-serif: var(--font-source-serif-4);
+  --font-heading: var(--font-serif);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -48,6 +49,7 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 }
+
 
 :root {
   /* ─── Device / PWA environment insets ───────────────────────────────────────

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+import { Source_Serif_4 } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
+
+const sourceSerif4 = Source_Serif_4({
+  subsets: ["latin"],
+  variable: "--font-source-serif-4",
+});
 
 export const metadata: Metadata = {
   metadataBase: process.env.VERCEL_PROJECT_PRODUCTION_URL
@@ -19,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html className={`${GeistSans.variable} ${GeistMono.variable} font-sans antialiased`}>
+    <html className={`${GeistSans.variable} ${GeistMono.variable} ${sourceSerif4.variable} font-sans antialiased`}>
       <body>
         {children}
         <RegisterSW />

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -98,7 +98,7 @@ export default async function AboutContent() {
   return (
     <div className="w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4 sm:pt-12 pb-12 flex flex-col gap-6">
       <div className="flex items-center gap-3">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 font-heading">
           {t("pageTitle")}
         </h1>
       </div>

--- a/src/components/AckCard.tsx
+++ b/src/components/AckCard.tsx
@@ -102,7 +102,7 @@ export default function AckCard({
               if (isClaudeCard && j === 0) {
                 const parts = para.split("Iris");
                 return (
-                  <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                  <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed font-heading italic">
                     {parts.map((part, k) => (
                       <span key={k}>
                         {part}
@@ -113,7 +113,7 @@ export default function AckCard({
                 );
               }
               return (
-                <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed font-heading italic">
                   {para}
                 </p>
               );


### PR DESCRIPTION
## Summary

- Add **Source Serif 4** via `next/font/google` as the site's serif typeface
- Wire it through a new `--font-serif` → `--font-heading` CSS variable chain, keeping the existing `--font-sans` for all UI/data elements
- Apply `font-heading` to large display headings: home page `h1`, lens detail model `h1`, About page `h1`
- Apply `font-heading italic` to AckCard story/narrative paragraphs for editorial distinction
- Body text, spec tables, nav, buttons, and small-size text remain Geist Sans

## Test plan

- [ ] Home page hero title renders in Source Serif 4
- [ ] Lens detail page model name renders in Source Serif 4
- [ ] About page title renders in Source Serif 4; body paragraphs remain sans-serif
- [ ] AckCard story paragraphs render in Source Serif 4 italic when expanded
- [ ] Dark mode looks correct across all changed elements
- [ ] No regressions in nav, spec table, or filter UI typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)