### PR TITLE
Reorder and reword releaseYearLabelNote to emphasize data source reliability

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -167,7 +167,7 @@
     "motorStepping": "Stepping",
     "motorOther": "Other",
     "releaseYear": "Release Year",
-    "releaseYearLabelNote": "For lenses available in multiple mounts, this is the year the Fujifilm X mount version was released. Note: data coverage for this field is limited — some values may be inaccurate.",
+    "releaseYearLabelNote": "Note: values in this field may be inaccurate — the data is not sourced from official publications. For lenses available in multiple mounts, this is the year the Fujifilm X mount version was released.",
     "accessories": "Accessories",
     "yes": "Yes",
     "no": "No",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -167,7 +167,7 @@
     "motorStepping": "步进马达",
     "motorOther": "其他",
     "releaseYear": "发布年份",
-    "releaseYearLabelNote": "若该镜头同时拥有多个卡口版本，此处显示的是富士 X 卡口版本的发布年份。注意：该字段数据覆盖率较低，部分数值可能存在偏差。",
+    "releaseYearLabelNote": "注意：该字段数据来源不一定可靠，部分数值可能存在偏差。若该镜头同时拥有多个卡口版本，此处显示的是富士 X 卡口版本的发布年份。",
     "accessories": "附带配件",
     "yes": "有",
     "no": "无",


### PR DESCRIPTION
Swapped the two sentences so the reliability caveat comes first, and replaced
"data coverage is limited" with "data is not sourced from official publications"
to accurately describe why values may be inaccurate.

https://claude.ai/code/session_01RhHTAQjhEYsdYsqQsiGEUK