### PR TITLE
fix: apply font-heading to Navbar X-Glass logo

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -75,7 +75,7 @@ export default function Nav() {
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         <Link
           href="/"
-          className="flex items-center gap-1.5 font-bold text-zinc-900 dark:text-zinc-50 text-lg tracking-tight"
+          className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight"
         >
           <Iris config={IRIS_NAV} uid="nav" size={16} />
           X-Glass


### PR DESCRIPTION
Consistent with the home hero title which uses Source Serif 4 via
font-heading; the nav logo was inheriting font-sans by omission.

https://claude.ai/code/session_017omgqn2avX67btNwHeAQAG