### PR TITLE
fix(feedback): include replyEmail in GitHub Issue body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7778,7 +7778,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -9234,6 +9234,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9745,7 +9756,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -9824,6 +9835,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10185,7 +10197,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -11118,7 +11130,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/src/app/api/feedback/__tests__/route.test.ts
+++ b/src/app/api/feedback/__tests__/route.test.ts
@@ -120,6 +120,28 @@ describe("POST /api/feedback — description validation", () => {
   });
 });
 
+describe("POST /api/feedback — replyEmail", () => {
+  beforeAll(() => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ number: 1 }), { status: 201 })
+    );
+  });
+
+  it("includes replyEmail in the issue body when provided", async () => {
+    await POST(
+      makeRequest({ type: "general", description: "Great app!", replyEmail: "user@example.com" })
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { body: string };
+    expect(body.body).toContain("**Reply-to:** user@example.com");
+  });
+
+  it("omits Reply-to line when replyEmail is not provided", async () => {
+    await POST(makeRequest({ type: "general", description: "Great app!" }));
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { body: string };
+    expect(body.body).not.toContain("Reply-to");
+  });
+});
+
 describe("POST /api/feedback — type validation", () => {
   it("rejects an invalid type", async () => {
     const res = await POST(makeRequest({ type: "unknown", description: "Test" }));

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -5,6 +5,7 @@ type FeedbackType = "data_issue" | "missing_lens" | "general";
 interface FeedbackPayload {
   type: FeedbackType;
   description: string;
+  replyEmail?: string;
   context?: {
     lensId?: string;
     lensModel?: string;
@@ -48,7 +49,7 @@ function buildIssue(payload: FeedbackPayload): {
   body: string;
   labels: string[];
 } {
-  const { type, description, context } = payload;
+  const { type, description, replyEmail, context } = payload;
   const lines: string[] = [];
 
   if (type === "data_issue") {
@@ -75,6 +76,10 @@ function buildIssue(payload: FeedbackPayload): {
     }
   } else {
     lines.push(`**Type:** General feedback`);
+  }
+
+  if (replyEmail) {
+    lines.push(`**Reply-to:** ${replyEmail}`);
   }
 
   if (description.trim()) {


### PR DESCRIPTION
The replyEmail field was collected in the UI and sent to the API, but
FeedbackPayload had no replyEmail property so the value was silently
discarded before reaching buildIssue. Added the field to the interface
and surface it as a Reply-to metadata line in the issue body.

Added two tests verifying the field is included when provided and
omitted when absent.

https://claude.ai/code/session_01J55JtYF7QG92U2Uec72etN