### PR TITLE
fix(feedback): include lensBrand in GitHub Issue Lens line

### DIFF
--- a/src/app/api/feedback/__tests__/route.test.ts
+++ b/src/app/api/feedback/__tests__/route.test.ts
@@ -120,6 +120,39 @@ describe("POST /api/feedback — description validation", () => {
   });
 });
 
+describe("POST /api/feedback — lensBrand", () => {
+  beforeAll(() => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ number: 1 }), { status: 201 })
+    );
+  });
+
+  it("includes brand and model together in the Lens line", async () => {
+    await POST(
+      makeRequest({
+        type: "data_issue",
+        description: "Wrong value",
+        context: { lensId: "l1", lensBrand: "Sony", lensModel: "FE 35mm F2.8" },
+      })
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { body: string };
+    expect(body.body).toContain("**Lens:** Sony FE 35mm F2.8");
+  });
+
+  it("shows only model when lensBrand is absent", async () => {
+    await POST(
+      makeRequest({
+        type: "data_issue",
+        description: "Wrong value",
+        context: { lensId: "l1", lensModel: "FE 35mm F2.8" },
+      })
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { body: string };
+    expect(body.body).toContain("**Lens:** FE 35mm F2.8");
+    expect(body.body).not.toMatch(/\*\*Lens:\*\* \S+ \S+ FE/);
+  });
+});
+
 describe("POST /api/feedback — replyEmail", () => {
   beforeAll(() => {
     mockFetch.mockResolvedValue(

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -8,6 +8,7 @@ interface FeedbackPayload {
   replyEmail?: string;
   context?: {
     lensId?: string;
+    lensBrand?: string;
     lensModel?: string;
     searchQuery?: string;
     field?: string;
@@ -55,7 +56,10 @@ function buildIssue(payload: FeedbackPayload): {
   if (type === "data_issue") {
     lines.push(`**Type:** Data issue`);
     if (context?.lensModel) {
-      lines.push(`**Lens:** ${context.lensModel}`);
+      const lensLabel = context.lensBrand
+        ? `${context.lensBrand} ${context.lensModel}`
+        : context.lensModel;
+      lines.push(`**Lens:** ${lensLabel}`);
     }
     if (context?.lensId) {
       lines.push(`**Lens ID:** \`${context.lensId}\``);


### PR DESCRIPTION
## Summary

- `lensBrand` was collected by the frontend (`FeedbackContext`) and sent in the request context, but `FeedbackPayload.context` in the API route had no `lensBrand` property — the value was silently discarded
- Added `lensBrand?: string` to the backend interface and updated `buildIssue` to prepend it to `lensModel` in the **Lens:** metadata line (e.g. `**Lens:** Sony FE 35mm F2.8`)
- Added two tests covering brand+model combined output and model-only fallback

## Test plan

- [ ] Submit a data issue feedback on any lens page and verify the GitHub Issue shows `**Lens:** <Brand> <Model>` instead of just the model
- [ ] Verify feedback submitted without a brand (e.g. missing_lens type) is unaffected

https://claude.ai/code/session_01J55JtYF7QG92U2Uec72etN

---
_Generated by [Claude Code](https://claude.ai/code/session_01J55JtYF7QG92U2Uec72etN)_