### PR TITLE
feat(schema): cine-aware aperture pair + fixed-aperture support

### DIFF
--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -539,9 +539,11 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                 {/* Aperture */}
                 <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}>
                   <span className={cn("font-semibold tabular-nums text-zinc-900 leading-none", apertureSize)}>
-                    {apertureDisplay(lens.maxAperture)}
+                    {lens.maxAperture !== undefined
+                      ? apertureDisplay(lens.maxAperture)
+                      : tStopDisplay(lens.maxTStop) ?? ""}
                   </span>
-                  {tStopDisplay(lens.maxTStop) && (
+                  {lens.maxAperture !== undefined && tStopDisplay(lens.maxTStop) && (
                     <span className="font-medium tabular-nums text-zinc-500 leading-none" style={{ fontSize: 11 }}>
                       {tStopDisplay(lens.maxTStop)}
                     </span>

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -10,10 +10,10 @@ import { cn } from "@/lib/utils";
 import { classifyFocusMotor } from "@/lib/lens";
 import { getLensImageUrl } from "@/lib/lens-image";
 import {
-  apertureDisplay,
   filterSizeDisplay,
   dimensionsPrimaryDisplay,
-  tStopDisplay,
+  primaryApertureDisplay,
+  secondaryApertureDisplay,
   specialtyTagsDisplay,
 } from "@/lib/lens.format";
 import type { SpecialtyTag, FieldNoteKey } from "@/lib/types";
@@ -539,13 +539,11 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                 {/* Aperture */}
                 <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}>
                   <span className={cn("font-semibold tabular-nums text-zinc-900 leading-none", apertureSize)}>
-                    {lens.maxAperture !== undefined
-                      ? apertureDisplay(lens.maxAperture)
-                      : tStopDisplay(lens.maxTStop) ?? ""}
+                    {primaryApertureDisplay(lens) ?? ""}
                   </span>
-                  {lens.maxAperture !== undefined && tStopDisplay(lens.maxTStop) && (
+                  {secondaryApertureDisplay(lens) && (
                     <span className="font-medium tabular-nums text-zinc-500 leading-none" style={{ fontSize: 11 }}>
-                      {tStopDisplay(lens.maxTStop)}
+                      {secondaryApertureDisplay(lens)}
                     </span>
                   )}
                   <span className="text-zinc-400" style={{ fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase" }}>

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -13,6 +13,8 @@ import {
   focalEquiv,
   focalRangeDisplay,
   apertureDisplay,
+  primaryApertureDisplay,
+  secondaryApertureDisplay,
 } from "../lens.format";
 import { lensSchema } from "../lens-schema";
 
@@ -97,6 +99,42 @@ describe("apertureDisplay", () => {
 
   it("shows a minimum aperture range when the zoom closes down differently", () => {
     expect(apertureDisplay([16, 22])).toBe("f/16–22");
+  });
+});
+
+describe("primaryApertureDisplay / secondaryApertureDisplay", () => {
+  it("non-cine lens shows f-stop primary, no secondary", () => {
+    const lens = makeLens({ focalLengthMin: 35, focalLengthMax: 35 });
+    expect(primaryApertureDisplay(lens)).toBe("f/1.4");
+    expect(secondaryApertureDisplay(lens)).toBeUndefined();
+  });
+
+  it("cine lens with only T-stop shows T-stop primary, no secondary", () => {
+    const lens = makeLens({
+      focalLengthMin: 35,
+      focalLengthMax: 35,
+      maxAperture: undefined,
+      minAperture: undefined,
+      maxTStop: 2.1,
+      minTStop: 16,
+      specialtyTags: ["cine"],
+    });
+    expect(primaryApertureDisplay(lens)).toBe("T2.1");
+    expect(secondaryApertureDisplay(lens)).toBeUndefined();
+  });
+
+  it("hybrid lens with both shows f-stop primary and T-stop secondary", () => {
+    const lens = makeLens({
+      focalLengthMin: 35,
+      focalLengthMax: 35,
+      maxAperture: 2.0,
+      minAperture: 16,
+      maxTStop: 2.1,
+      minTStop: 16,
+      specialtyTags: ["cine"],
+    });
+    expect(primaryApertureDisplay(lens)).toBe("f/2");
+    expect(secondaryApertureDisplay(lens)).toBe("T2.1");
   });
 });
 

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -155,6 +155,109 @@ describe("lensSchema aperture business rules", () => {
     expect(result.success).toBe(false);
     expect(result.error?.issues.some((issue) => issue.path.join(".") === "maxAperture")).toBe(true);
   });
+
+  it("accepts a cine lens that publishes only T-stop", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 35,
+        focalLengthMax: 35,
+        maxAperture: undefined,
+        minAperture: undefined,
+        maxTStop: 2.1,
+        minTStop: 16,
+        specialtyTags: ["cine"],
+      })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a lens that publishes both f-stop and T-stop pairs", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 35,
+        focalLengthMax: 35,
+        maxAperture: 2.0,
+        minAperture: 16,
+        maxTStop: 2.1,
+        minTStop: 16,
+        specialtyTags: ["cine"],
+      })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a lens with neither aperture pair fully populated", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 35,
+        focalLengthMax: 35,
+        maxAperture: undefined,
+        minAperture: undefined,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.error?.issues.some(
+        (issue) =>
+          issue.path.join(".") === "maxAperture" &&
+          issue.message.includes("must be fully populated")
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a lens with only one half of the f-stop pair (no T-stop)", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 35,
+        focalLengthMax: 35,
+        maxAperture: 1.4,
+        minAperture: undefined,
+      })
+    );
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("lensSchema apertureBladeCount", () => {
+  it("accepts a positive integer", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 35,
+        focalLengthMax: 35,
+        apertureBladeCount: 9,
+      })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the SPEC_NA sentinel for fixed-aperture lenses", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 24,
+        focalLengthMax: 24,
+        apertureBladeCount: "N/A",
+      })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 0 (would be ambiguous with missing data)", () => {
+    const result = lensSchema.safeParse(
+      makeLens({
+        focalLengthMin: 24,
+        focalLengthMax: 24,
+        apertureBladeCount: 0 as unknown as number,
+      })
+    );
+
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -153,6 +153,7 @@ const fieldNotesSchema = z.strictObject({
   ois: nonEmptyStringSchema.optional(),
   focusMotor: nonEmptyStringSchema.optional(),
   maxAperture: nonEmptyStringSchema.optional(),
+  minAperture: nonEmptyStringSchema.optional(),
   apertureBladeCount: nonEmptyStringSchema.optional(),
 });
 

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -23,6 +23,7 @@ const minApertureSchema = createApertureSchema("minAperture");
 const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
+export const specNaSchema = z.literal(SPEC_NA);
 
 export const focusDistanceVariantsSchema = z.strictObject({
   wide: positiveNumberSchema.optional(),
@@ -42,8 +43,8 @@ const lensBaseShape = {
   generation: z.number().int().positive().optional(),
   focalLengthMin: positiveNumberSchema,
   focalLengthMax: positiveNumberSchema,
-  maxAperture: maxApertureSchema,
-  minAperture: minApertureSchema,
+  maxAperture: maxApertureSchema.optional(),
+  minAperture: minApertureSchema.optional(),
   maxTStop: maxTStopSchema.optional(),
   minTStop: minTStopSchema.optional(),
   specialtyTags: z.array(specialtyTagSchema).min(1).optional(),
@@ -95,14 +96,12 @@ const lensBaseShape = {
       { message: "angleOfViewCalc tuple must be [wideEnd, teleEnd] with wide > tele" }
     ),
   ]).optional(),
-  apertureBladeCount: z.number().int().positive().optional(),
+  apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),
   lensMaterial: optionalNonEmptyStringSchema,
 } as const;
-
-export const specNaSchema = z.literal(SPEC_NA);
 
 export const officialLinksSchema = z
   .strictObject({
@@ -153,6 +152,8 @@ const fieldNotesSchema = z.strictObject({
   lensConfiguration: nonEmptyStringSchema.optional(),
   ois: nonEmptyStringSchema.optional(),
   focusMotor: nonEmptyStringSchema.optional(),
+  maxAperture: nonEmptyStringSchema.optional(),
+  apertureBladeCount: nonEmptyStringSchema.optional(),
 });
 
 const lensObjectSchema = z.strictObject({
@@ -243,6 +244,24 @@ function applyLensBusinessRules(
       code: "custom",
       message: "focalLengthMin cannot be greater than focalLengthMax",
       path: ["focalLengthMin"],
+    });
+  }
+
+  // At least one fully-populated aperture pair must be present. f-stop is the
+  // primary path for stills lenses; T-stop is allowed as the sole path for
+  // cine lenses whose source publishes only T-stop. Schema is intentionally
+  // tag-independent — the cine vs non-cine distinction is enforced by the
+  // pipeline's readiness gate, not here.
+  const hasFStopPair =
+    value.maxAperture !== undefined && value.minAperture !== undefined;
+  const hasTStopPair =
+    value.maxTStop !== undefined && value.minTStop !== undefined;
+  if (!hasFStopPair && !hasTStopPair) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "At least one of (maxAperture+minAperture) or (maxTStop+minTStop) must be fully populated",
+      path: ["maxAperture"],
     });
   }
 

--- a/src/lib/lens-search.ts
+++ b/src/lib/lens-search.ts
@@ -104,6 +104,7 @@ function formatApertureNum(n: number): string {
 
 function apertureTokens(lens: Lens): string[] {
   const tokens: string[] = [];
+  if (lens.maxAperture === undefined) return tokens;
   for (const n of apertureNums(lens.maxAperture)) {
     const s = formatApertureNum(n);
     const noDot = s.replace(".", "");

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -1,4 +1,4 @@
-import type { Lens, FieldNoteKey, SpecialtyTag } from "./types";
+import { SPEC_NA, type Lens, type FieldNoteKey, type SpecialtyTag } from "./types";
 import type { LensConfigurationLabels } from "./lens.format";
 import { classifyFocusMotor, type FocusMotorClass } from "./lens";
 import * as fmt from "./lens.format";
@@ -381,17 +381,24 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
         {
           kind: "numeric",
           label: labels.maxAperture,
-          hasData: () => true,
-          getDisplayValue: (l) => fmt.apertureDisplay(l.maxAperture),
+          fieldNoteKey: "maxAperture" as FieldNoteKey,
+          hasData: (l) => l.maxAperture !== undefined,
+          getDisplayValue: (l) =>
+            l.maxAperture !== undefined ? fmt.apertureDisplay(l.maxAperture) : "",
           toComparable: (l) =>
-            Array.isArray(l.maxAperture) ? l.maxAperture[0] : l.maxAperture,
+            l.maxAperture === undefined
+              ? undefined
+              : Array.isArray(l.maxAperture)
+                ? l.maxAperture[0]
+                : l.maxAperture,
           bestDir: "min",
         },
         {
           kind: "text",
           label: labels.minAperture,
-          hasData: () => true,
-          getDisplayValue: (l) => fmt.apertureDisplay(l.minAperture),
+          hasData: (l) => l.minAperture !== undefined,
+          getDisplayValue: (l) =>
+            l.minAperture !== undefined ? fmt.apertureDisplay(l.minAperture) : "",
         },
         {
           kind: "text",
@@ -420,9 +427,16 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
         {
           kind: "numeric",
           label: labels.apertureBladeCount,
+          fieldNoteKey: "apertureBladeCount" as FieldNoteKey,
           hasData: (l) => l.apertureBladeCount !== undefined,
-          getDisplayValue: (l) => fmt.optionalNumber(l.apertureBladeCount, ""),
-          toComparable: (l) => l.apertureBladeCount,
+          getDisplayValue: (l) =>
+            l.apertureBladeCount === SPEC_NA
+              ? SPEC_NA
+              : fmt.optionalNumber(l.apertureBladeCount, ""),
+          toComparable: (l) =>
+            typeof l.apertureBladeCount === "number"
+              ? l.apertureBladeCount
+              : undefined,
           bestDir: "max",
         },
         {

--- a/src/lib/lens.format.ts
+++ b/src/lib/lens.format.ts
@@ -27,7 +27,7 @@ export function focalRangeDisplay(min: number, max: number): string {
   return min === max ? `${min}mm` : `${min}–${max}mm`;
 }
 
-export function apertureDisplay(aperture: Lens["maxAperture"]): string {
+export function apertureDisplay(aperture: NonNullable<Lens["maxAperture"]>): string {
   return Array.isArray(aperture)
     ? `f/${aperture[0]}–${aperture[1]}`
     : `f/${aperture}`;
@@ -38,6 +38,26 @@ export function tStopDisplay(
 ): string | undefined {
   if (tStop === undefined) return undefined;
   return Array.isArray(tStop) ? `T${tStop[0]}–${tStop[1]}` : `T${tStop}`;
+}
+
+/**
+ * Primary aperture string for prominent UI slots (card titles, posters).
+ * Cine lenses without a published f-stop show T-stop in the primary slot.
+ * Returns undefined when neither value is available.
+ */
+export function primaryApertureDisplay(lens: Lens): string | undefined {
+  if (lens.maxAperture !== undefined) return apertureDisplay(lens.maxAperture);
+  return tStopDisplay(lens.maxTStop);
+}
+
+/**
+ * Secondary aperture string shown beneath the primary slot when both an
+ * f-stop and a T-stop are published. Returns undefined when only one (or
+ * neither) is available, so callers can suppress the secondary line.
+ */
+export function secondaryApertureDisplay(lens: Lens): string | undefined {
+  if (lens.maxAperture === undefined) return undefined;
+  return tStopDisplay(lens.maxTStop);
 }
 
 export function optionalNumber(

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -217,7 +217,12 @@ export function parseLensIds(ids: string | undefined): Lens[] {
 export type SortKey = "focalLength" | "maxAperture" | "weightG";
 
 function getSortableMaxAperture(lens: Lens): number {
-  return Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
+  // Fall back to T-stop wide end when f-stop is unpublished (cine lenses).
+  // T-stop is numerically slightly larger than f-stop but ordering is preserved
+  // for sort purposes within the cine cohort.
+  const value = lens.maxAperture ?? lens.maxTStop;
+  if (value === undefined) return Number.POSITIVE_INFINITY;
+  return Array.isArray(value) ? value[0] : value;
 }
 
 export function sortLenses(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -255,6 +255,7 @@ export const FIELD_NOTE_KEYS = [
   "ois",
   "focusMotor",
   "maxAperture",
+  "minAperture",
   "apertureBladeCount",
 ] as const;
 export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,15 @@
 /**
- * Sentinel value for a field where the concept does not apply to this lens.
- * For example, filterMm is N/A on fisheye lenses that have no front filter thread.
+ * Sentinel value for a field where the concept does not apply to this lens
+ * (as opposed to "data missing"). Examples:
+ * - filterMm = "N/A" on bulbous fisheye lenses (no front filter thread)
+ * - focusMotor = "N/A" on manual-focus lenses (no AF motor)
+ * - apertureBladeCount = "N/A" on fixed-aperture lenses (no diaphragm at all)
+ *
+ * Use this whenever a structured field's domain is undefined for a class of
+ * lenses, rather than picking 0 / 1 / -1 placeholder values that would be
+ * ambiguous with real data. When a field uses "N/A", consider also adding
+ * an entry in {@link Lens.fieldNotes} to explain to the end user *why* the
+ * concept doesn't apply.
  */
 export const SPEC_NA = "N/A" as const;
 
@@ -245,6 +254,8 @@ export const FIELD_NOTE_KEYS = [
   "lensConfiguration",
   "ois",
   "focusMotor",
+  "maxAperture",
+  "apertureBladeCount",
 ] as const;
 export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
 
@@ -315,10 +326,14 @@ export interface Lens {
    *
    * Source text like "F1.4", "f/1.4", "1:1.4" should all be stored as 1.4.
    *
+   * Optional because some cine lenses publish only T-stop. Either this pair
+   * (maxAperture+minAperture) or the T-stop pair (maxTStop+minTStop) must be
+   * fully populated; both pairs together is also valid.
+   *
    * @example 1.4
    * @example [3.5, 6.3]
    */
-  maxAperture: ApertureValue;
+  maxAperture?: ApertureValue;
 
   /**
    * Smallest available aperture as a bare f-number (numeric value only, no
@@ -326,10 +341,12 @@ export interface Lens {
    * - Prime or constant-aperture zoom: single number (e.g. 16).
    * - Variable-aperture zoom: [wideEnd, teleEnd] tuple (e.g. [16, 22]).
    *
+   * Same population rules as {@link maxAperture}.
+   *
    * @example 16
    * @example [16, 22]
    */
-  minAperture: ApertureValue;
+  minAperture?: ApertureValue;
 
   /**
    * Largest available transmission stop as a bare T-number (numeric only).
@@ -584,9 +601,14 @@ export interface Lens {
 
   /**
    * Number of aperture blades.
+   * Use {@link SPEC_NA} for fixed-aperture lenses that have no diaphragm at
+   * all (pinhole, body cap, mirror/reflex, "shaped aperture" lenses). When
+   * using "N/A", add a {@link fieldNotes} entry for "apertureBladeCount"
+   * explaining why the concept does not apply.
    * @example 9
+   * @example "N/A"
    */
-  apertureBladeCount?: number;
+  apertureBladeCount?: number | typeof SPEC_NA;
 
   /**
    * Year the lens was first officially announced or released by the


### PR DESCRIPTION
## Summary

- **Schema relax**: `maxAperture` / `minAperture` are now optional. The new business rule requires *at least one* of (f-stop pair) or (T-stop pair) to be fully populated. Cine lenses that publish only T-stop no longer need a fabricated f-stop.
- **Fixed-aperture support**: `apertureBladeCount` accepts the `SPEC_NA` ("N/A") sentinel for lenses with no diaphragm at all (pinhole, body cap, shaped-aperture). Same pattern as existing `filterMm` / `focusMotor`.
- **UI helper**: new `primaryApertureDisplay(lens)` / `secondaryApertureDisplay(lens)` so prominent slots (poster, future cards) prefer T-stop for cine and show both when a hybrid lens publishes both. SharePoster routed through the helpers.
- **Docs**: `SPEC_NA` comment expanded to fix the "concept does not apply vs data missing" pattern as project convention.
- **Tag-independence**: schema is intentionally agnostic of `specialtyTags`. The cine vs non-cine distinction is enforced upstream by the pipeline's readiness gate (separate PR in `x-glass-pipeline`).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/lib/__tests__/lenses.test.ts` — 201 / 201 pass (5 new schema cases + 3 new display-helper cases)
- [x] Validated current 145 lenses against the new `lensCatalogSchema` — all pass (schema is a relaxation, no regressions)
- [ ] Manual: cine lens detail page + poster after pipeline backfill (depends on pipeline PR landing first)

## Companion PR

`x-glass-pipeline#<TBD>` — readiness gate + agent prompt updates so the pipeline produces data shaped for the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)