### PR TITLE
fix(detail): reserve bottom padding so CompareBar doesn't cover spec table

### DIFF
--- a/src/app/[locale]/lenses/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/(browse)/[id]/page.tsx
@@ -210,7 +210,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   return (
     <>
-    <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 flex flex-col gap-8">
+    <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-24 flex flex-col gap-8">
       {/* Back button */}
       <BackButton fallbackHref="/lenses" />
 


### PR DESCRIPTION
## Summary

Lens detail page's root container used \`py-8\`, which left no room for the fixed \`CompareBar\` once a lens was added to compare — the last spec rows (Release / Accessories) sat hidden behind it.

Switch to \`pt-8 pb-24\` to match the convention already used by \`LensListClient\` (which has the same bar / same problem and reserved space the same way).

## Why this is its own PR

This change was originally bundled into the (now-closed) where-to-buy PR #80. That PR was abandoned for unrelated reasons but this fix is a real, independent bug worth shipping.

## Test plan

- [x] Visual: detail page bottom no longer covered by CompareBar when comparing lenses
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)