### PR TITLE
feat(data): publish lens data 2026.05.08 build 1

### DIFF
--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.07",
-  "lastUpdated": "2026-05-07T12:18:44.867Z",
+  "version": "2026.05.08",
+  "lastUpdated": "2026-05-08T00:06:16.015Z",
   "lensCount": 145,
-  "buildNumber": 4
+  "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.08` build 1
- **X-mount lenses** (`lenses.json`): 145
- **G-mount lenses** (`lenses-g.json`): 0
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`