### PR TITLE
feat(schema): add priceBand tier (1-5) field to Lens

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -24,6 +24,13 @@ const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
 export const specNaSchema = z.literal(SPEC_NA);
+const priceBandTierSchema = z.union([
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+]);
 
 export const focusDistanceVariantsSchema = z.strictObject({
   wide: positiveNumberSchema.optional(),
@@ -99,6 +106,10 @@ const lensBaseShape = {
   ]).optional(),
   apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
+  priceBand: z.strictObject({
+    cn: priceBandTierSchema.optional(),
+    global: priceBandTierSchema.optional(),
+  }).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),
   lensMaterial: optionalNonEmptyStringSchema,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -640,6 +640,32 @@ export interface Lens {
   releaseYear?: number;
 
   /**
+   * Approximate price tier (1-5, log-scaled). Captures buying-intent class
+   * without committing to a specific day-to-day price. Markets are kept
+   * separate so the UI can localize tier display per audience.
+   *
+   * Tier definitions are calibrated to typical CN-market retail prices
+   * (CNY) and approximated to USD for the global market:
+   *
+   *                  CNY (cn)         USD (global, ≈ ¥7:$1)
+   *   1: entry         < 500             < 70
+   *   2: budget        500 - 1,500       70 - 200
+   *   3: mid           1,500 - 5,000     200 - 700
+   *   4: premium       5,000 - 15,000    700 - 2,000
+   *   5: pro           > 15,000          > 2,000
+   *
+   * Currently only `cn` is populated by the pipeline; `global` is reserved
+   * for future per-market calibration. Both fields are optional — omit the
+   * tier (or the whole object) when no reliable price source is available.
+   *
+   * @example { cn: 3 }
+   */
+  priceBand?: {
+    cn?: 1 | 2 | 3 | 4 | 5;
+    global?: 1 | 2 | 3 | 4 | 5;
+  };
+
+  /**
    * Mount systems this lens is available for, as stated by the manufacturer.
    * Use short canonical names to ensure consistency across all lenses:
    * "Fujifilm X", "Sony E", "Nikon Z", "Nikon F", "Canon RF", "Canon EF",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -644,15 +644,15 @@ export interface Lens {
    * without committing to a specific day-to-day price. Markets are kept
    * separate so the UI can localize tier display per audience.
    *
-   * Tier definitions are calibrated to typical CN-market retail prices
-   * (CNY) and approximated to USD for the global market:
+   * Tier definitions are independently calibrated per market against the
+   * actual retail price distribution of X-mount lenses in that market:
    *
-   *                  CNY (cn)         USD (global, ≈ ¥7:$1)
-   *   1: entry         < 500             < 70
-   *   2: budget        500 - 1,500       70 - 200
-   *   3: mid           1,500 - 5,000     200 - 700
-   *   4: premium       5,000 - 15,000    700 - 2,000
-   *   5: pro           > 15,000          > 2,000
+   *                  CNY (cn)         USD (global)
+   *   1: entry         < 500             < 150
+   *   2: budget        500 - 1,500       150 - 399
+   *   3: mid           1,500 - 5,000     400 - 799
+   *   4: premium       5,000 - 15,000    800 - 1,499
+   *   5: pro           > 15,000          ≥ 1,500
    *
    * Currently only `cn` is populated by the pipeline; `global` is reserved
    * for future per-market calibration. Both fields are optional — omit the


### PR DESCRIPTION
## Overview

Schema-only change introducing the optional `priceBand` field on `Lens`. This is **Phase A** of the price-band feature — pipeline populate and UI rendering ship in subsequent PRs.

## Files changed

| File | Change |
|---|---|
| `src/lib/types.ts` | Add `priceBand?: { cn?, global? }` to `Lens` interface with full JSDoc |
| `src/lib/lens-schema.ts` | Add `priceBandTierSchema` (z.union of literals 1–5) and wire into `lensBaseShape` |

## Schema

```ts
priceBand?: {
  cn?: 1 | 2 | 3 | 4 | 5;
  global?: 1 | 2 | 3 | 4 | 5;
};
```

Each market is an independent optional integer tier (1–5, log-scaled). Markets are kept separate because source stores, currencies, and sampling timing differ per region.

## Tier definitions

Tiers are independently calibrated per market against the actual retail price distribution of X-mount lenses — **not a currency conversion**.

### CN market (CNY)

| Tier | Range | Representative lenses |
|---|---|---|
| 1 | < ¥500 | TTArtisan / 7Artisans entry MF |
| 2 | ¥500 – 1,500 | 国产中阶 MF / Viltrox budget |
| 3 | ¥1,500 – 5,000 | Viltrox / Sigma / Tamron main lineup, Fujifilm XC + entry XF |
| 4 | ¥5,000 – 15,000 | Fujifilm XF core primes and zooms |
| 5 | > ¥15,000 | Fujifilm XF flagship telephoto |

### Global market (USD)

Calibrated against ~85 X-mount lens retail prices (B&H / brand sites, new, 2025–2026).

| Tier | Range | Representative lenses |
|---|---|---|
| 1 | < $150 | TTArtisan / 7Artisans entry MF — almost exclusively manual-focus |
| 2 | $150 – $399 | Viltrox Air AF, Rokinon / Samyang MF, Sigma 30mm f/1.4 |
| 3 | $400 – $799 | Sigma / Tamron main lineup, Fujifilm XC + entry XF (35mm f/2, 16-80mm) |
| 4 | $800 – $1,499 | Fujifilm XF flagship primes (56mm f/1.2, 90mm f/2, 80mm Macro, 50mm f/1.0) |
| 5 | ≥ $1,500 | Fujifilm XF pro zooms and telephoto (50-140mm, 100-400mm, 150-600mm, 500mm) |

## Why price-band, not exact price

Earlier approaches (search URL deep-links, affiliate APIs, third-party price sites) all hit structural blockers: recall noise, maintenance cost, and the site's "high confidence × intentional low precision" stance. Price-band tier sidesteps those by making a coarser commitment — buying-intent class instead of an exact daily price.

## Backward compatibility

- `priceBand` is fully optional — all 145 existing lenses in `lenses.json` validate cleanly with the field absent.
- `z.strictObject` on the inner shape prevents unknown keys from silently passing schema.
- Object shape `{ cn?, global? }` avoids a future migration when global sampling is added.

## What is NOT in this PR

- Pipeline populate logic (in `x-glass-pipeline`, already merged to its main)
- `publish.ts` integration (reading `priceBand.cn` from pipeline state into `lenses.json`)
- UI: tier badge, filter, sort

## Test plan

- [x] `tsc --noEmit` clean (two pre-existing errors in unrelated scripts excluded)
- [x] All 145 existing lenses in `src/data/lenses.json` validated against updated zod schema — `priceBand` absent ⇒ valid
- [x] No production code consumes `priceBand` yet — zero UI / runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)