### PR TITLE
feat(data): publish lens data 2026.05.08 build 2

### DIFF
--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.08",
-  "lastUpdated": "2026-05-08T02:38:45.869Z",
+  "lastUpdated": "2026-05-08T03:58:58.383Z",
   "lensCount": 146,
-  "buildNumber": 1
+  "buildNumber": 2
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.08` build 2
- **X-mount lenses** (`lenses.json`): 145
- **G-mount lenses** (`lenses-g.json`): 1
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`