### PR TITLE
refactor(schema): replace priceBand tier with explicit price + currency

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -24,13 +24,13 @@ const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
 export const specNaSchema = z.literal(SPEC_NA);
-const priceBandTierSchema = z.union([
-  z.literal(1),
-  z.literal(2),
-  z.literal(3),
-  z.literal(4),
-  z.literal(5),
-]);
+const priceBandEntryBaseSchema = z.object({
+  price: z.number().positive(),
+  buyUrl: z.string().url().optional(),
+  sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+const priceBandCnSchema = priceBandEntryBaseSchema.extend({ currency: z.literal("CNY") });
+const priceBandGlobalSchema = priceBandEntryBaseSchema.extend({ currency: z.literal("USD") });
 
 export const focusDistanceVariantsSchema = z.strictObject({
   wide: positiveNumberSchema.optional(),
@@ -107,8 +107,8 @@ const lensBaseShape = {
   apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
   priceBand: z.strictObject({
-    cn: priceBandTierSchema.optional(),
-    global: priceBandTierSchema.optional(),
+    cn: priceBandCnSchema.optional(),
+    global: priceBandGlobalSchema.optional(),
   }).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -246,3 +246,24 @@ export function sortLenses(
     return dir === "asc" ? delta : -delta;
   });
 }
+
+export function priceTier(price: number, currency: "CNY" | "USD"): 1 | 2 | 3 | 4 | 5 {
+  if (currency === "CNY") {
+    if (price < 500)   return 1;
+    if (price < 1500)  return 2;
+    if (price < 5000)  return 3;
+    if (price < 15000) return 4;
+    return 5;
+  } else {
+    if (price < 150)  return 1;
+    if (price < 400)  return 2;
+    if (price < 800)  return 3;
+    if (price < 1500) return 4;
+    return 5;
+  }
+}
+
+export function defaultMarketForLocale(locale: string): "cn" | "global" {
+  return locale === "zh" ? "cn" : "global";
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -640,29 +640,43 @@ export interface Lens {
   releaseYear?: number;
 
   /**
-   * Approximate price tier (1-5, log-scaled). Captures buying-intent class
-   * without committing to a specific day-to-day price. Markets are kept
-   * separate so the UI can localize tier display per audience.
+   * Sampled retail price per market. Each market entry records a price
+   * observed in an official brand store at a point in time.
    *
-   * Tier definitions are independently calibrated per market against the
-   * actual retail price distribution of X-mount lenses in that market:
+   * Markets are independent — `cn` and `global` may be sampled at different
+   * times and point to different stores. Omit a market entry when no reliable
+   * price source is available.
    *
-   *                  CNY (cn)         USD (global)
-   *   1: entry         < 500             < 150
-   *   2: budget        500 - 1,500       150 - 399
-   *   3: mid           1,500 - 5,000     400 - 799
-   *   4: premium       5,000 - 15,000    800 - 1,499
-   *   5: pro           > 15,000          ≥ 1,500
+   * The UI derives display tiers from `price` using these thresholds:
    *
-   * Currently only `cn` is populated by the pipeline; `global` is reserved
-   * for future per-market calibration. Both fields are optional — omit the
-   * tier (or the whole object) when no reliable price source is available.
+   *   tier  CNY (cn)            USD (global)
+   *   1     < 500               < 150
+   *   2     500 – 1,499         150 – 399
+   *   3     1,500 – 4,999       400 – 799
+   *   4     5,000 – 14,999      800 – 1,499
+   *   5     ≥ 15,000            ≥ 1,500
    *
-   * @example { cn: 3 }
+   * @example { cn: { price: 3746, currency: "CNY", sampledAt: "2026-05-08" } }
    */
   priceBand?: {
-    cn?: 1 | 2 | 3 | 4 | 5;
-    global?: 1 | 2 | 3 | 4 | 5;
+    cn?: {
+      /** Retail price in CNY at time of sampling. */
+      price: number;
+      currency: "CNY";
+      /** Direct purchase page URL (product page or in-store search result). */
+      buyUrl?: string;
+      /** ISO date YYYY-MM-DD when sampled. */
+      sampledAt: string;
+    };
+    global?: {
+      /** Retail price in USD at time of sampling. */
+      price: number;
+      currency: "USD";
+      /** Direct purchase page URL (product page or in-store search result). */
+      buyUrl?: string;
+      /** ISO date YYYY-MM-DD when sampled. */
+      sampledAt: string;
+    };
   };
 
   /**


### PR DESCRIPTION
## Summary

- `priceBand.cn/global` now stores `{ price, currency, buyUrl?, sampledAt }` instead of a bare tier integer (1-5)
- `currency` is always explicit (`"CNY"` for cn, `"USD"` for global) — prevents agent misassignment
- `buyUrl` replaces `sourceUrl` — direct purchase link, platform-agnostic
- UI derives display tiers from `price` at render time using documented thresholds

## Tier thresholds (for UI reference)

| tier | CNY | USD |
|---|---|---|
| 1 | < 500 | < 150 |
| 2 | 500 – 1,499 | 150 – 399 |
| 3 | 1,500 – 4,999 | 400 – 799 |
| 4 | 5,000 – 14,999 | 800 – 1,499 |
| 5 | ≥ 15,000 | ≥ 1,500 |

## Test plan

- [x] `tsc --noEmit` clean (zero errors)
- [x] All 145 existing lenses validate (priceBand absent ⇒ valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)