### PR TITLE
refactor: rename priceBand → pricing in types and schema

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -24,13 +24,13 @@ const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
 export const specNaSchema = z.literal(SPEC_NA);
-const priceBandEntryBaseSchema = z.object({
+const pricingEntryBaseSchema = z.object({
   price: z.number().positive(),
   buyUrl: z.string().url().optional(),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
-const priceBandCnSchema = priceBandEntryBaseSchema.extend({ currency: z.literal("CNY") });
-const priceBandGlobalSchema = priceBandEntryBaseSchema.extend({ currency: z.literal("USD") });
+const pricingCnSchema = pricingEntryBaseSchema.extend({ currency: z.literal("CNY") });
+const pricingGlobalSchema = pricingEntryBaseSchema.extend({ currency: z.literal("USD") });
 
 export const focusDistanceVariantsSchema = z.strictObject({
   wide: positiveNumberSchema.optional(),
@@ -106,9 +106,9 @@ const lensBaseShape = {
   ]).optional(),
   apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
-  priceBand: z.strictObject({
-    cn: priceBandCnSchema.optional(),
-    global: priceBandGlobalSchema.optional(),
+  pricing: z.strictObject({
+    cn: pricingCnSchema.optional(),
+    global: pricingGlobalSchema.optional(),
   }).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -658,7 +658,7 @@ export interface Lens {
    *
    * @example { cn: { price: 3746, currency: "CNY", sampledAt: "2026-05-08" } }
    */
-  priceBand?: {
+  pricing?: {
     cn?: {
       /** Retail price in CNY at time of sampling. */
       price: number;


### PR DESCRIPTION
## Summary

Renames `priceBand` → `pricing` in `types.ts` and `lens-schema.ts`.

These changes were pushed to the `worktree-price-band-schema-v2` branch after PR #97 was merged, so they never landed in main. This PR brings them in cleanly.

## Changes

- `Lens.priceBand` → `Lens.pricing`
- `priceBandEntryBaseSchema` → `pricingEntryBaseSchema`
- `priceBandCnSchema` → `pricingCnSchema`
- `priceBandGlobalSchema` → `pricingGlobalSchema`

## Test plan

- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)