### PR TITLE
fix(images): prevent redirect rule from intercepting static assets

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,15 +7,15 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       // Backward compat: old /lenses/[id] → /lenses/x/[id]
-      // Excludes known static paths (compare, x, gfx) to avoid redirect loops.
+      // Excludes known static paths (compare, x, gfx) and static assets (.webp etc.)
       {
-        source: "/lenses/:id((?!x$|gfx$|compare$).*)",
+        source: "/lenses/:id((?!x$|gfx$|compare$)[^.]+)",
         destination: "/lenses/x/:id",
         permanent: false,
       },
       // Same redirect but with locale prefix
       {
-        source: "/:locale(en|zh)/lenses/:id((?!x$|gfx$|compare$).*)",
+        source: "/:locale(en|zh)/lenses/:id((?!x$|gfx$|compare$)[^.]+)",
         destination: "/:locale/lenses/x/:id",
         permanent: false,
       },


### PR DESCRIPTION
## Summary
- All lens images on production returning **503** due to `_next/image` hitting an infinite redirect loop
- Root cause: `/lenses/:id` redirect regex used `.*` which matched static file paths like `/lenses/foo.webp`
- Fix: change `.*` to `[^.]+` so paths with file extensions (dots) are excluded from the redirect

## Test plan
- [ ] Verify `/lenses/*.webp` files load directly without redirect
- [ ] Verify `/_next/image?url=/lenses/...` returns 200 with optimized images
- [ ] Verify old bookmark redirects (`/lenses/some-lens-id` → `/lenses/x/some-lens-id`) still work
- [ ] Verify `/lenses/x`, `/lenses/gfx`, `/lenses/compare` are not redirected

🤖 Generated with [Claude Code](https://claude.com/claude-code)