### PR TITLE
feat(data): publish lens data 2026.05.08 build 4

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -78,7 +78,6 @@
     "pricing": {
       "cn": {
         "price": 1299,
-        "buyUrl": "https://item.jd.com/10038643493366.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -141,7 +140,6 @@
     "pricing": {
       "cn": {
         "price": 939,
-        "buyUrl": "https://item.jd.com/10187125174593.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -198,7 +196,6 @@
     "pricing": {
       "cn": {
         "price": 599,
-        "buyUrl": "https://item.jd.com/10212588856782.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -287,7 +284,6 @@
     "pricing": {
       "cn": {
         "price": 699,
-        "buyUrl": "https://item.jd.com/10144266042361.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -334,7 +330,6 @@
     "pricing": {
       "cn": {
         "price": 599,
-        "buyUrl": "https://item.jd.com/10212592143407.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -385,7 +380,6 @@
     "pricing": {
       "cn": {
         "price": 599,
-        "buyUrl": "https://item.jd.com/10213996269124.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -708,7 +702,6 @@
     "pricing": {
       "cn": {
         "price": 670,
-        "buyUrl": "https://item.jd.com/10062473752141.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -762,7 +755,6 @@
     "pricing": {
       "cn": {
         "price": 1090,
-        "buyUrl": "https://item.jd.com/10204898752312.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -821,7 +813,6 @@
     "pricing": {
       "cn": {
         "price": 639,
-        "buyUrl": "https://item.jd.com/10027028201649.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -877,7 +868,6 @@
     "pricing": {
       "cn": {
         "price": 499,
-        "buyUrl": "https://item.jd.com/10160933790025.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -930,7 +920,6 @@
     "pricing": {
       "cn": {
         "price": 593,
-        "buyUrl": "https://item.jd.com/10164361585110.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -984,7 +973,6 @@
     "pricing": {
       "cn": {
         "price": 270,
-        "buyUrl": "https://item.jd.com/10068170968055.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1040,7 +1028,6 @@
     "pricing": {
       "cn": {
         "price": 394,
-        "buyUrl": "https://item.jd.com/22071562982.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1093,7 +1080,6 @@
     "pricing": {
       "cn": {
         "price": 369,
-        "buyUrl": "https://item.jd.com/10023827550733.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1146,7 +1132,6 @@
     "pricing": {
       "cn": {
         "price": 329,
-        "buyUrl": "https://item.jd.com/10200036685867.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1203,7 +1188,6 @@
     "pricing": {
       "cn": {
         "price": 969,
-        "buyUrl": "https://item.jd.com/10160356865706.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1254,7 +1238,6 @@
     "pricing": {
       "cn": {
         "price": 299,
-        "buyUrl": "https://item.jd.com/23196870151.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1302,7 +1285,6 @@
     "pricing": {
       "cn": {
         "price": 494,
-        "buyUrl": "https://item.jd.com/23702204564.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }
@@ -1359,7 +1341,6 @@
     "pricing": {
       "cn": {
         "price": 899,
-        "buyUrl": "https://item.jd.com/10034452578266.html",
         "sampledAt": "2026-05-08",
         "currency": "CNY"
       }

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.08",
-  "lastUpdated": "2026-05-08T08:57:22.550Z",
+  "lastUpdated": "2026-05-08T09:04:36.886Z",
   "lensCount": 171,
-  "buildNumber": 3
+  "buildNumber": 4
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.08` build 4
- **X-mount lenses** (`lenses.json`): 152
- **G-mount lenses** (`lenses-g.json`): 19
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`