### PR TITLE
refactor: remove legacy redirects, add custom 404 page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,20 +5,15 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   async redirects() {
+    // Backward compat: old /lenses/[id] → /lenses/x/[id].
+    // All lens IDs contain at least one hyphen (e.g. "fujifilm-xf-35mmf14-r-x"),
+    // while every reserved sub-path (x, gfx, compare) does not.
+    // Matching on "must contain a hyphen" is a safe whitelist that won't
+    // collide with static assets, mount segments, or future sub-routes.
+    const legacyLensId = ":id([a-z0-9]+-[a-z0-9-]+)";
     return [
-      // Backward compat: old /lenses/[id] → /lenses/x/[id]
-      // Excludes known static paths (compare, x, gfx) and static assets (.webp etc.)
-      {
-        source: "/lenses/:id((?!x$|gfx$|compare$)[^.]+)",
-        destination: "/lenses/x/:id",
-        permanent: false,
-      },
-      // Same redirect but with locale prefix
-      {
-        source: "/:locale(en|zh)/lenses/:id((?!x$|gfx$|compare$)[^.]+)",
-        destination: "/:locale/lenses/x/:id",
-        permanent: false,
-      },
+      { source: `/lenses/${legacyLensId}`, destination: "/lenses/x/:id", permanent: false },
+      { source: `/:locale(en|zh)/lenses/${legacyLensId}`, destination: "/:locale/lenses/x/:id", permanent: false },
     ];
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,19 +3,6 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
-const nextConfig: NextConfig = {
-  async redirects() {
-    // Backward compat: old /lenses/[id] → /lenses/x/[id].
-    // All lens IDs contain at least one hyphen (e.g. "fujifilm-xf-35mmf14-r-x"),
-    // while every reserved sub-path (x, gfx, compare) does not.
-    // Matching on "must contain a hyphen" is a safe whitelist that won't
-    // collide with static assets, mount segments, or future sub-routes.
-    const legacyLensId = ":id([a-z0-9]+-[a-z0-9-]+)";
-    return [
-      { source: `/lenses/${legacyLensId}`, destination: "/lenses/x/:id", permanent: false },
-      { source: `/:locale(en|zh)/lenses/${legacyLensId}`, destination: "/:locale/lenses/x/:id", permanent: false },
-    ];
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default withNextIntl(nextConfig);

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,26 @@
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+
+export default function NotFound() {
+  const t = useTranslations("NotFound");
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 px-4 py-32 text-center">
+      <h1 className="text-6xl font-bold text-zinc-200 dark:text-zinc-800 font-heading">
+        404
+      </h1>
+      <p className="text-lg font-medium text-zinc-900 dark:text-zinc-100">
+        {t("title")}
+      </p>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 max-w-sm">
+        {t("description")}
+      </p>
+      <Link
+        href="/"
+        className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {t("home")}
+      </Link>
+    </div>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -6,6 +6,11 @@
     "backToTop": "Back to top",
     "additionalInfo": "Additional information"
   },
+  "NotFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has been moved.",
+    "home": "Back to Home"
+  },
   "Metadata": {
     "seoTitle": "X-Glass | Fujifilm X-Mount Lens Database & Comparison",
     "seoDescription": "Every Fujifilm X-Mount lens, normalized and ready to compare — XF, XC, MK, Sigma, Tamron, Viltrox, TTArtisan, 7Artisans, Brightin Star, SG Image. One database, zero bias."

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -6,6 +6,11 @@
     "backToTop": "回到顶部",
     "additionalInfo": "补充说明"
   },
+  "NotFound": {
+    "title": "页面不存在",
+    "description": "你访问的页面不存在，或已被移动到其他位置。",
+    "home": "返回首页"
+  },
   "Metadata": {
     "seoTitle": "X-Glass | 富士 X 卡口镜头参数库",
     "seoDescription": "富士 X 卡口镜头数据库，收录富士 XF / XC / MK、适马、腾龙、唯卓仕、铭匠、七工匠、星曜、深光影像全品牌参数。规格统一标准，支持跨品牌横向对比。"


### PR DESCRIPTION
## Summary
- Remove all backward-compat redirect rules from `next.config.ts` — the fragile regex patterns caused the production 503 image outage (#101)
- `next.config.ts` is now back to a clean empty config
- Add a custom `not-found.tsx` with i18n support (en/zh) and a "Back to Home" button
- Old bookmarks like `/lenses/[id]` now show a proper 404 page instead of redirect loops

## Test plan
- [ ] Visit `/en/lenses/x` — lens list loads with images
- [ ] Visit `/en/lenses/x/fujifilm-xf-35mmf2-r-wr-x` — detail page renders
- [ ] Visit `/en/lenses/nonexistent-old-bookmark` — shows custom 404 with "Back to Home"
- [ ] Visit `/zh/lenses/nonexistent` — shows Chinese 404 page
- [ ] Visit `/en/lenses/compare` — redirects to `/en/lenses/x/compare` (app redirect preserved)
- [ ] Verify all lens images load (no 503s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)