### PR TITLE
refactor(nav): restore primary mobile links and separate home from mount switcher

### DIFF
--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -38,13 +38,13 @@ export default function DataInfo() {
   return (
     <div className="flex flex-col items-center gap-0.5 mt-3">
       <p
-        className="text-xs text-zinc-400 dark:text-zinc-500 font-mono"
+        className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono"
         title={h("dataTooltip")}
       >
         {h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
       </p>
       <p
-        className="text-xs text-zinc-400 dark:text-zinc-500 font-mono cursor-pointer hover:text-zinc-300 dark:hover:text-zinc-400 transition-colors"
+        className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono cursor-pointer hover:text-zinc-300 dark:hover:text-zinc-400 transition-colors"
         onClick={cycle}
       >
         {dateLabel}

--- a/src/components/HomeCta.tsx
+++ b/src/components/HomeCta.tsx
@@ -20,7 +20,7 @@ export default function HomeCta() {
       </Link>
       <Link
         href={`/lenses/${seg}/compare`}
-        className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300 font-medium text-sm hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
+        className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-medium text-sm hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
       >
         {h("ctaCompare")}
       </Link>

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -50,7 +50,6 @@ export default function MountSwitcher() {
     { mount: "G", label: t("gfx") },
   ];
 
-  const shortLabel: Record<Mount, string> = { X: "X", G: "G" };
   const fullLabel = effectiveMount === "X" ? t("x") : t("gfx");
 
   return (
@@ -62,9 +61,7 @@ export default function MountSwitcher() {
         aria-expanded={open}
         aria-label={t("label")}
       >
-        {/* Abbreviated on mobile, full name on desktop */}
-        <span className="sm:hidden">{shortLabel[effectiveMount]}</span>
-        <span className="hidden sm:inline">{fullLabel}</span>
+        {fullLabel}
         <ChevronDown className="h-3.5 w-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
       </button>
 

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -57,7 +57,7 @@ export default function MountSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 font-bold font-heading text-zinc-500 dark:text-zinc-400 text-lg tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors whitespace-nowrap"
+        className="group flex items-center gap-0.5 font-heading font-medium text-base text-zinc-600 dark:text-zinc-400 tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800/60 px-1.5 py-0.5 -ml-1.5 rounded-md transition-all whitespace-nowrap"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
@@ -65,7 +65,7 @@ export default function MountSwitcher() {
         {/* Abbreviated on mobile, full name on desktop */}
         <span className="sm:hidden">{shortLabel[effectiveMount]}</span>
         <span className="hidden sm:inline">{fullLabel}</span>
-        <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+        <ChevronDown className="h-3.5 w-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
       </button>
 
       {open && (

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -50,18 +50,21 @@ export default function MountSwitcher() {
     { mount: "G", label: t("gfx") },
   ];
 
-  const currentLabel = effectiveMount === "X" ? t("x") : t("gfx");
+  const shortLabel: Record<Mount, string> = { X: "X", G: "GFX" };
+  const fullLabel = effectiveMount === "X" ? t("x") : t("gfx");
 
   return (
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 font-bold font-heading text-zinc-500 dark:text-zinc-400 text-lg tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+        className="flex items-center gap-1 font-bold font-heading text-zinc-500 dark:text-zinc-400 text-lg tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors whitespace-nowrap"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
       >
-        {currentLabel}
+        {/* Abbreviated on mobile, full name on desktop */}
+        <span className="sm:hidden">{shortLabel[effectiveMount]}</span>
+        <span className="hidden sm:inline">{fullLabel}</span>
         <ChevronDown className="h-3.5 w-3.5 opacity-60" />
       </button>
 

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -50,7 +50,7 @@ export default function MountSwitcher() {
     { mount: "G", label: t("gfx") },
   ];
 
-  const shortLabel: Record<Mount, string> = { X: "X", G: "GFX" };
+  const shortLabel: Record<Mount, string> = { X: "X", G: "G" };
   const fullLabel = effectiveMount === "X" ? t("x") : t("gfx");
 
   return (

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -45,6 +45,8 @@ export default function MountSwitcher() {
     }
   };
 
+  const mountLabel: Record<Mount, string> = { X: "X", G: "GFX" };
+
   const options: { mount: Mount; label: string }[] = [
     { mount: "X", label: t("x") },
     { mount: "G", label: t("gfx") },
@@ -54,12 +56,13 @@ export default function MountSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center p-0.5 text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-zinc-300 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors text-[11px] font-medium leading-none"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
       >
-        <ChevronDown className="h-3.5 w-3.5" />
+        {mountLabel[effectiveMount]}
+        <ChevronDown className="h-3 w-3 opacity-60" />
       </button>
 
       {open && (

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -54,20 +54,12 @@ export default function MountSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+        className="flex items-center p-0.5 text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
       >
-        <span className="relative">
-          X-Glass
-          {effectiveMount === "G" && (
-            <span className="absolute -top-2 -right-1.5 text-[0.5rem] font-semibold tracking-wider text-zinc-400 dark:text-zinc-500 uppercase">
-              GFX
-            </span>
-          )}
-        </span>
-        <ChevronDown className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500" />
+        <ChevronDown className="h-3.5 w-3.5" />
       </button>
 
       {open && (

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -45,24 +45,24 @@ export default function MountSwitcher() {
     }
   };
 
-  const mountLabel: Record<Mount, string> = { X: "X", G: "GFX" };
-
   const options: { mount: Mount; label: string }[] = [
     { mount: "X", label: t("x") },
     { mount: "G", label: t("gfx") },
   ];
 
+  const currentLabel = effectiveMount === "X" ? t("x") : t("gfx");
+
   return (
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-zinc-300 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors text-[11px] font-medium leading-none"
+        className="flex items-center gap-1 font-bold font-heading text-zinc-500 dark:text-zinc-400 text-lg tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
       >
-        {mountLabel[effectiveMount]}
-        <ChevronDown className="h-3 w-3 opacity-60" />
+        {currentLabel}
+        <ChevronDown className="h-3.5 w-3.5 opacity-60" />
       </button>
 
       {open && (

--- a/src/components/MountTag.tsx
+++ b/src/components/MountTag.tsx
@@ -1,96 +1,17 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { ChevronDown } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { useRouter } from "@/i18n/navigation";
-import { useMountParam, useEffectiveMount } from "@/hooks/useMountParam";
-import { useMountPreference } from "@/context/MountPreferenceProvider";
-import { mountToUrlSegment } from "@/lib/mount";
-import type { Mount } from "@/lib/types";
+import { useEffectiveMount } from "@/hooks/useMountParam";
 
 export default function HeroBrand() {
-  const t = useTranslations("MountSwitcher");
-  const router = useRouter();
-  const urlMount = useMountParam();
   const mount = useEffectiveMount();
-  const { setPreference } = useMountPreference();
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function onPointerDown(e: PointerEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("pointerdown", onPointerDown);
-    return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [open]);
-
-  const handleSelect = (m: Mount) => {
-    setPreference(m);
-    setOpen(false);
-    if (urlMount !== null) {
-      router.push(`/lenses/${mountToUrlSegment(m)}`);
-    }
-  };
-
-  const options: { mount: Mount; label: string }[] = [
-    { mount: "X", label: t("x") },
-    { mount: "G", label: t("gfx") },
-  ];
-
-  if (mount !== "G") {
-    return <span>X-Glass</span>;
-  }
-
   return (
-    <span>
+    <span className="relative">
       X-Glass
-      <span className="font-light text-zinc-200 dark:text-zinc-700 px-1">/</span>
-      {/* Inline scope selector — valid phrasing content inside <h1> */}
-      <span ref={ref} className="relative inline-block">
-        <button
-          onClick={() => setOpen((v) => !v)}
-          className="group inline-flex items-center gap-1.5 font-heading font-bold text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors cursor-pointer"
-          aria-haspopup="listbox"
-          aria-expanded={open}
-          aria-label={t("label")}
-        >
-          {" GFX"}
-          <ChevronDown className="h-5 w-5 opacity-30 group-hover:opacity-70 group-hover:translate-y-0.5 transition-all" />
-        </button>
-
-        {open && (
-          // Reset font — this span inherits text-5xl/font-bold from <h1>
-          <span
-            role="listbox"
-            className="absolute left-0 top-full mt-2 z-50 block min-w-[9rem] rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 py-1 overflow-hidden text-sm font-normal tracking-normal font-sans"
-          >
-            {options.map((opt) => (
-              <button
-                key={opt.mount}
-                type="button"
-                role="option"
-                aria-selected={opt.mount === mount}
-                onClick={() => handleSelect(opt.mount)}
-                className={`flex w-full items-center gap-2 px-3 py-2 transition-colors text-left ${
-                  opt.mount === mount
-                    ? "text-zinc-900 dark:text-zinc-50 font-medium bg-zinc-50 dark:bg-zinc-900"
-                    : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-50 dark:hover:bg-zinc-900"
-                }`}
-              >
-                {opt.label}
-                {opt.mount === mount && (
-                  <span className="ml-auto h-1.5 w-1.5 rounded-full bg-zinc-900 dark:bg-zinc-50" />
-                )}
-              </button>
-            ))}
-          </span>
-        )}
-      </span>
+      {mount === "G" && (
+        <span className="absolute top-0 -right-1 -translate-y-1/3 text-[0.55rem] font-mono font-normal text-zinc-400 dark:text-zinc-500 leading-none tracking-normal select-none">
+          [G]
+        </span>
+      )}
     </span>
   );
 }

--- a/src/components/MountTag.tsx
+++ b/src/components/MountTag.tsx
@@ -1,17 +1,96 @@
 "use client";
 
-import { useEffectiveMount } from "@/hooks/useMountParam";
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { useMountParam, useEffectiveMount } from "@/hooks/useMountParam";
+import { useMountPreference } from "@/context/MountPreferenceProvider";
+import { mountToUrlSegment } from "@/lib/mount";
+import type { Mount } from "@/lib/types";
 
 export default function HeroBrand() {
+  const t = useTranslations("MountSwitcher");
+  const router = useRouter();
+  const urlMount = useMountParam();
   const mount = useEffectiveMount();
+  const { setPreference } = useMountPreference();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const handleSelect = (m: Mount) => {
+    setPreference(m);
+    setOpen(false);
+    if (urlMount !== null) {
+      router.push(`/lenses/${mountToUrlSegment(m)}`);
+    }
+  };
+
+  const options: { mount: Mount; label: string }[] = [
+    { mount: "X", label: t("x") },
+    { mount: "G", label: t("gfx") },
+  ];
+
+  if (mount !== "G") {
+    return <span>X-Glass</span>;
+  }
+
   return (
-    <span className="relative">
+    <span>
       X-Glass
-      {mount === "G" && (
-        <span className="absolute top-0 -right-2 -translate-y-1/3 px-2 py-0.5 text-xs font-semibold tracking-wider leading-none rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 uppercase">
-          GFX
-        </span>
-      )}
+      <span className="font-light text-zinc-300 dark:text-zinc-600"> /</span>
+      {/* Inline scope selector — valid phrasing content inside <h1> */}
+      <span ref={ref} className="relative inline-block">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="group inline-flex items-center gap-1.5 font-medium text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors cursor-pointer"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-label={t("label")}
+        >
+          {" GFX"}
+          <ChevronDown className="h-5 w-5 opacity-20 group-hover:opacity-60 transition-opacity" />
+        </button>
+
+        {open && (
+          // Reset font — this span inherits text-5xl/font-bold from <h1>
+          <span
+            role="listbox"
+            className="absolute left-0 top-full mt-2 z-50 block min-w-[9rem] rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 py-1 overflow-hidden text-sm font-normal tracking-normal font-sans"
+          >
+            {options.map((opt) => (
+              <button
+                key={opt.mount}
+                type="button"
+                role="option"
+                aria-selected={opt.mount === mount}
+                onClick={() => handleSelect(opt.mount)}
+                className={`flex w-full items-center gap-2 px-3 py-2 transition-colors text-left ${
+                  opt.mount === mount
+                    ? "text-zinc-900 dark:text-zinc-50 font-medium bg-zinc-50 dark:bg-zinc-900"
+                    : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                }`}
+              >
+                {opt.label}
+                {opt.mount === mount && (
+                  <span className="ml-auto h-1.5 w-1.5 rounded-full bg-zinc-900 dark:bg-zinc-50" />
+                )}
+              </button>
+            ))}
+          </span>
+        )}
+      </span>
     </span>
   );
 }

--- a/src/components/MountTag.tsx
+++ b/src/components/MountTag.tsx
@@ -49,18 +49,18 @@ export default function HeroBrand() {
   return (
     <span>
       X-Glass
-      <span className="font-light text-zinc-300 dark:text-zinc-600"> /</span>
+      <span className="font-light text-zinc-200 dark:text-zinc-700 px-1">/</span>
       {/* Inline scope selector — valid phrasing content inside <h1> */}
       <span ref={ref} className="relative inline-block">
         <button
           onClick={() => setOpen((v) => !v)}
-          className="group inline-flex items-center gap-1.5 font-medium text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors cursor-pointer"
+          className="group inline-flex items-center gap-1.5 font-heading font-bold text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors cursor-pointer"
           aria-haspopup="listbox"
           aria-expanded={open}
           aria-label={t("label")}
         >
           {" GFX"}
-          <ChevronDown className="h-5 w-5 opacity-20 group-hover:opacity-60 transition-opacity" />
+          <ChevronDown className="h-5 w-5 opacity-30 group-hover:opacity-70 group-hover:translate-y-0.5 transition-all" />
         </button>
 
         {open && (

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
-import { Smartphone, EllipsisVertical } from "lucide-react";
+import { EllipsisVertical } from "lucide-react";
 import { Link, usePathname } from "@/i18n/navigation";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
@@ -104,14 +104,22 @@ export default function Nav() {
       style={{ paddingTop: "calc(var(--safe-inset-top) + var(--titlebar-height))" }}
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-        {/* Left: Iris home link + brand name (= mount switcher) */}
-        <div className="flex items-center gap-1.5">
+        {/* Left: brand = home link, then standalone mount switcher */}
+        <div className="flex items-center gap-1">
           <Link
             href="/"
-            className="flex items-center text-zinc-900 dark:text-zinc-50"
+            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />
+            <span className="relative">
+              X-Glass
+              {effectiveMount === "G" && (
+                <span className="absolute -top-2 -right-1.5 text-[0.5rem] font-semibold tracking-wider text-zinc-400 dark:text-zinc-500 uppercase">
+                  GFX
+                </span>
+              )}
+            </span>
           </Link>
           <MountSwitcher />
         </div>
@@ -148,43 +156,45 @@ export default function Nav() {
           </a>
         </div>
 
-        {/* Mobile menu trigger */}
-        <div ref={menuRef} className="relative sm:hidden">
-          <button
-            onClick={() => setMobileMenuOpen((v) => !v)}
-            className="p-2 -mr-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
-            aria-label="Menu"
-            aria-expanded={mobileMenuOpen}
-          >
-            <EllipsisVertical className="h-5 w-5" />
-          </button>
+        {/* Mobile: primary links inline + secondary in overflow menu */}
+        <div className="flex items-center sm:hidden gap-0.5">
+          <Link href={browseHref} className={linkCls(isBrowseActive)}>
+            {t("lenses")}
+          </Link>
+          <Link href={compareHref} className={linkCls(isCompareActive)}>
+            {t("compare")}
+          </Link>
+          <div ref={menuRef} className="relative">
+            <button
+              onClick={() => setMobileMenuOpen((v) => !v)}
+              className="p-2 -mr-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+              aria-label="Menu"
+              aria-expanded={mobileMenuOpen}
+            >
+              <EllipsisVertical className="h-5 w-5" />
+            </button>
 
-          {mobileMenuOpen && (
-            <div className="absolute right-0 top-full mt-1.5 w-48 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 py-1 overflow-hidden">
-              <Link href={browseHref} className={mobileLinkCls(isBrowseActive)}>
-                {t("lenses")}
-              </Link>
-              <Link href={compareHref} className={mobileLinkCls(isCompareActive)}>
-                {t("compare")}
-              </Link>
-              <Link href="/about" className={mobileLinkCls(pathname === "/about")}>
-                {t("about")}
-              </Link>
-              {!isPwa && (
-                <Link href="/get" className={mobileLinkCls(pathname === "/get")}>
-                  {t("getApp")}
+            {mobileMenuOpen && (
+              <div className="absolute right-0 top-full mt-1.5 w-48 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 py-1 overflow-hidden">
+                <Link href="/about" className={mobileLinkCls(pathname === "/about")}>
+                  {t("about")}
                 </Link>
-              )}
-              <a
-                href="https://github.com/sentacraft/x-glass"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={mobileLinkCls(false)}
-              >
-                GitHub
-              </a>
-            </div>
-          )}
+                {!isPwa && (
+                  <Link href="/get" className={mobileLinkCls(pathname === "/get")}>
+                    {t("getApp")}
+                  </Link>
+                )}
+                <a
+                  href="https://github.com/sentacraft/x-glass"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={mobileLinkCls(false)}
+                >
+                  GitHub
+                </a>
+              </div>
+            )}
+          </div>
         </div>
       </nav>
     </header>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -105,10 +105,10 @@ export default function Nav() {
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         {/* Left: brand / mount-scope path (GitHub namespace pattern) */}
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5 shrink-0">
           <Link
             href="/"
-            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -112,14 +112,7 @@ export default function Nav() {
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />
-            <span className="relative">
-              X-Glass
-              {effectiveMount === "G" && (
-                <span className="absolute -top-2 -right-1.5 text-[0.5rem] font-semibold tracking-wider text-zinc-400 dark:text-zinc-500 uppercase">
-                  GFX
-                </span>
-              )}
-            </span>
+            X-Glass
           </Link>
           <MountSwitcher />
         </div>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -114,7 +114,7 @@ export default function Nav() {
             <Iris config={IRIS_NAV} uid="nav" size={16} />
             X-Glass
           </Link>
-          <span className="text-zinc-300 dark:text-zinc-700 select-none font-light text-lg" aria-hidden="true">/</span>
+          <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-lg px-0.5" aria-hidden="true">/</span>
           <MountSwitcher />
         </div>
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -104,8 +104,8 @@ export default function Nav() {
       style={{ paddingTop: "calc(var(--safe-inset-top) + var(--titlebar-height))" }}
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-        {/* Left: brand = home link, then standalone mount switcher */}
-        <div className="flex items-center gap-1">
+        {/* Left: brand / mount-scope path (GitHub namespace pattern) */}
+        <div className="flex items-center gap-1.5">
           <Link
             href="/"
             className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
@@ -114,6 +114,7 @@ export default function Nav() {
             <Iris config={IRIS_NAV} uid="nav" size={16} />
             X-Glass
           </Link>
+          <span className="text-zinc-300 dark:text-zinc-700 select-none font-light text-lg" aria-hidden="true">/</span>
           <MountSwitcher />
         </div>
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -36,8 +36,8 @@
   },
   "MountSwitcher": {
     "label": "Switch mount system",
-    "x": "X Series",
-    "gfx": "GFX Series"
+    "x": "X Mount",
+    "gfx": "G Mount"
   },
   "Home": {
     "cta": "Browse Lenses",
@@ -278,15 +278,12 @@
   },
   "About": {
     "pageTitle": "About X-Glass",
-
     "backgroundTitle": "Background",
     "backgroundBody1": "The Fujifilm X-mount lens ecosystem has grown from a handful of native options in its early days to today's landscape of dozens of brands and hundreds of lenses. Yet specs are scattered across brand websites and various platforms in inconsistent formats, making meaningful comparison a slow and frustrating exercise. X-Glass was built to pull all of that fragmented information into one place — a normalized, comparable database that lets the data speak for itself.",
     "backgroundBody2": "I'm a web front-end engineer, and X-Glass is a project I develop and maintain entirely on my own. I've always had a strong conviction and passion for building products that don't compromise on engineering quality, user experience, or aesthetic design — and that drive is one of the key forces behind why this project exists.",
-
     "coverageTitle": "Lens Coverage",
     "coverageBody": "X-Glass's vision is to cover every X-mount lens ever made, including discontinued models. Due to the enormous scale of the data pipeline, the current index starts from lenses listed on each brand's official website, so some discontinued lenses no longer featured there are temporarily missing. Eight major brands are covered in this first release; expanding to more active brands is on the roadmap for a future phase. Adapted lenses from other mounts are outside the current scope.",
     "coverageBrands": "Currently indexed brands",
-
     "dataAccuracyTitle": "Data & Accuracy",
     "dataAccuracyIntro": "For a database built on objective information, accuracy isn't a bonus — it's the foundation. If users can't trust the data, the site has no reason to exist.",
     "dataPrinciple1Title": "All data is sourced from official manufacturer information",
@@ -306,7 +303,6 @@
     "pipelinePDesc": "Data validity checks, normalization, and final merge into the database",
     "dataUpdateNote": "The database is updated when new lenses launch or when existing data needs correction.",
     "dataVersionNote": "The version number and last-updated timestamp in the footer reflect the latest published data release.",
-
     "faqTitle": "FAQ",
     "faq1Q": "A lens I'm looking for isn't here. Why?",
     "faq1A": "We're working toward complete X-mount coverage, but the database grows incrementally and some lenses may still be missing. Use the feedback links at the bottom of this page to suggest one. That's the fastest way to put it on our radar.",
@@ -316,24 +312,20 @@
     "faq3A": "A dash means the data hasn't been collected yet, or the manufacturer hasn't publicly published that spec.",
     "faq4Q": "Why is there no pricing information?",
     "faq4A": "Price data is extremely difficult to keep accurate: distributor networks vary by region, promotions frequently push actual prices well below list price, and prices change constantly. My principle is — if I can't guarantee the data quality of a field, I'd rather leave it out entirely. Inaccurate price data is more misleading than no data at all, and risks undermining trust in the database as a whole.",
-
     "disclaimerTitle": "Disclaimer",
     "disclaimerAccuracy": "X-Glass data is sourced from public materials and refined through manual review. We make every effort to keep specs accurate and up to date, but errors and delays are inevitable. Always verify key specifications on the manufacturer's official page before making a purchase decision.",
     "disclaimerLiability": "X-Glass is not responsible for any decisions made based on information presented here.",
     "disclaimerIndependent": "X-Glass is an independent third-party tool and is not affiliated with, endorsed by, or sponsored by Fujifilm or any lens manufacturer.",
     "disclaimerCopyright": "Product images and brand trademarks are the property of their respective owners. If you are a rights holder and believe your content has been used improperly, please contact xglass@sentacraft.com.",
-
     "privacyTitle": "Privacy",
     "privacyBody": "X-Glass does not require registration, does not collect personal information, and does not use cookies.",
     "privacyAnalytics": "This site uses Vercel Analytics to collect aggregated, anonymous data such as page views, referrers, and device types — solely to help improve the product. No personally identifiable information is collected.",
-
     "donationTitle": "Support the Project",
     "donationBody": "X-Glass is open source on GitHub. Every spec in this database went through tedious data extraction and manual cross-checking. If it helped you find the right lens — or saved you some time — consider supporting the project.",
     "donationComingSoon": "Sponsorship options are being set up — check back soon.",
     "donationKofi": "Support on Ko-fi",
     "donationWechatLabel": "WeChat Pay",
     "donationWechatQrAlt": "WeChat appreciation QR code",
-
     "ackTitle": "Acknowledgments",
     "ackBody": "Over the past year, large language models have shown capabilities that once felt out of reach. I could not have imagined completing a project at this scale on my own — let alone shipping it in under a month. Without large language models and AI coding agents, this project might have stayed an idea forever. I am grateful to live in an era where the technology dividend is real, and where a spark of inspiration can actually become something in the hands of a solo developer.",
     "ackStory1Tag": "Claude Code",
@@ -345,11 +337,9 @@
     "ackGeminiDesigner": "UX Designer",
     "ackGeminiBrandStrategist": "Brand Strategist",
     "ackClosing": "My deepest gratitude to the AI collaborators whose contributions were decisive in making this project a reality.",
-
     "installTitle": "Get the App",
     "installBody": "X-Glass is a web app — open it in any browser, no installation needed. It also supports installation as a Progressive Web App (PWA) for full-screen access, offline support, and a more native feel.",
     "installCta": "Install X-Glass →",
-
     "feedbackTitle": "Feedback & Contact",
     "feedbackBody": "Spotted incorrect data or a missing lens? Your report goes straight to the maintainer.",
     "feedbackReport": "Report an issue",
@@ -393,15 +383,12 @@
     "pageTitle": "Get the App",
     "headline": "Add X-Glass to your home screen",
     "subheadline": "Faster access, full-screen experience, works offline.",
-
     "installedTitle": "You're all set",
     "installedBody": "X-Glass is already installed on this device.",
     "openApp": "Open X-Glass",
-
     "promptTitle": "Install X-Glass",
     "promptBody": "X-Glass is a web app that also supports installation as a Progressive Web App (PWA) — no App Store needed. Add it to your home screen or app launcher for one-tap access and a more native feel.",
     "installButton": "Install",
-
     "iosTitle": "Add to Home Screen",
     "iosSubtitle": "Follow these steps in Safari:",
     "iosStep1": "Tap the Share button (the square with an arrow) at the bottom of Safari",
@@ -412,7 +399,6 @@
     "macosStep1": "Click the Share button (the square with an arrow) in the Safari toolbar",
     "macosStep2": "Choose \"Add to Dock\"",
     "macosStep3": "Click \"Add\" to confirm",
-
     "genericTitle": "Add to Home Screen",
     "genericBody": "X-Glass is a web app that also supports installation as a Progressive Web App (PWA) — no App Store needed. Open your browser menu and look for \"Add to Home Screen\" or \"Install app\"."
   }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -36,8 +36,8 @@
   },
   "MountSwitcher": {
     "label": "切换卡口系统",
-    "x": "X 系统",
-    "gfx": "GFX 系统"
+    "x": "X Mount",
+    "gfx": "G Mount"
   },
   "Home": {
     "cta": "浏览镜头",
@@ -278,15 +278,12 @@
   },
   "About": {
     "pageTitle": "关于 X-Glass",
-
     "backgroundTitle": "项目缘起",
     "backgroundBody1": "富士 X 卡口的镜头生态，已经从早年的原厂主导，成长为如今数十个品牌、上百颗镜头并存的繁荣局面。然而，镜头参数散落在各品牌官网与各类平台之间，格式不一，横向对比极其低效。X-Glass 的初衷，正是把这些碎片化的信息汇聚到一处，建立一个规范化、可横向对比的数据库，让选镜头这件事回归客观数据本身。",
     "backgroundBody2": "我是一名 Web 前端工程师，X-Glass 目前完全由我一人开发并维护。对打造一个在工程质量，用户体验和美学设计上都不妥协的产品，我一直有很强的执念与热情——这份热情，同样是这个项目得以实现的重要驱动力之一。",
-
     "coverageTitle": "收录范围",
     "coverageBody": "X-Glass 的愿景是收录富士 X 卡口有史以来的所有镜头，包括已经停产的型号。由于 data pipeline 的巨大工作量，目前以各品牌官网的在列镜头为索引起点，部分已下架的停产型号暂未纳入。当前已收录 8 个头部品牌；扩充更多活跃品牌的计划已列入 roadmap，将在后续阶段推进。其他卡口的转接镜头暂不在收录范围内。",
     "coverageBrands": "当前收录品牌",
-
     "dataAccuracyTitle": "数据与准确性",
     "dataAccuracyIntro": "对于以客观信息为核心的数据库，准确性不是加分项，而是一切的根基。一旦用户对数据失去信任，网站本身便失去了存在的意义。",
     "dataPrinciple1Title": "数据来源于厂商官方发布的信息",
@@ -306,7 +303,6 @@
     "pipelinePDesc": "数据合法性校验、归一化、合并写入",
     "dataUpdateNote": "新镜头上市或已有数据需要修正时，数据库将随之更新。",
     "dataVersionNote": "页面底部显示的版本号和更新时间，对应的是最近一次正式发布的数据版本。",
-
     "faqTitle": "常见问题",
     "faq1Q": "我找的镜头不在列表里，为什么？",
     "faq1A": "我们的目标是把 X 卡口镜头尽量收齐，但数据库还在持续补全中，有些镜头可能暂时还没录入。你可以通过页面底部的反馈入口告诉我们，这是最快的方式。",
@@ -316,24 +312,20 @@
     "faq3A": "「—」表示这项数据暂时还没采集到，或者厂商没有公开。",
     "faq4Q": "为什么没有价格信息？",
     "faq4A": "价格数据的准确性很难保证：各地区经销商网络复杂，平台促销活动频繁，实际成交价与标价往往相差悬殊，而且价格本身也在持续变动。我的原则是——对某个字段的数据质量没有足够的把握，宁可不放。标注不准确的价格，比没有价格更容易误导用户，也会动摇整个数据库的可信度。",
-
     "disclaimerTitle": "免责声明",
     "disclaimerAccuracy": "X-Glass 的数据来自公开资料，并经过人工校准。我们已尽力保证规格的时效性与准确性，但数据难免存在错误或滞后。涉及购买决策时，请务必在厂商官方页面核实关键参数。",
     "disclaimerLiability": "X-Glass 不对基于本站信息所做的任何决定承担责任。",
     "disclaimerIndependent": "X-Glass 是独立的第三方对比工具，与富士及任何镜头厂商无官方关联，未获其背书或赞助。",
     "disclaimerCopyright": "本站展示的产品图片及品牌商标，版权归各自所有者所有。如您是权利人并认为存在侵权问题，请联系 xglass@sentacraft.com。",
-
     "privacyTitle": "隐私",
     "privacyBody": "X-Glass 不要求注册，不收集任何个人信息，也不使用 Cookie。",
     "privacyAnalytics": "本站接入了 Vercel Analytics，用于统计页面访问量、来源及设备类型等聚合匿名数据，以便持续改善产品体验。这些数据不包含任何可识别个人身份的信息。",
-
     "donationTitle": "捐赠与支持",
     "donationBody": "X-Glass 代码已在 GitHub 开源。这里的每一组镜头参数，都经历了繁琐的数据抓取与人工交叉校准。如果你觉得这个数据库帮你选到了心仪的镜头，或者为你节省了时间，欢迎赞赏支持。",
     "donationComingSoon": "",
     "donationKofi": "Support on Ko-fi",
     "donationWechatLabel": "微信赞赏码",
     "donationWechatQrAlt": "微信赞赏码",
-
     "ackTitle": "致谢",
     "ackBody": "过去的这一年，大语言模型展现出了超凡的能力。过去，我很难想象仅凭一己之力就能完成如此规模的项目，更不敢奢望在不到一个月内将其落地。如果没有大语言模型和 AI Coding Agent，这个项目可能永远只会停留在构想阶段。感谢这个时代的技术红利，让那些曾经只是灵感火花的想法，能够在一个独立开发者手中真正变成现实。",
     "ackStory1Tag": "Claude Code",
@@ -345,11 +337,9 @@
     "ackGeminiDesigner": "UX 设计师",
     "ackGeminiBrandStrategist": "品牌策略师",
     "ackClosing": "向在这个项目开发过程中给予了决定性帮助的 AI 协作者们，致以最诚挚的感激。",
-
     "installTitle": "获取应用",
     "installBody": "X-Glass 是一款网页应用，在浏览器中打开即可直接使用。同时支持以 PWA（渐进式网页应用）形式安装，添加到手机主屏幕或电脑程序坞后，可全屏启动、支持离线，体验更接近原生 App。",
     "installCta": "安装 X-Glass →",
-
     "feedbackTitle": "反馈与联系",
     "feedbackBody": "如果你发现数据有误，或者想补充缺失镜头，可以直接在这里告诉我们。",
     "feedbackReport": "反馈问题",
@@ -393,15 +383,12 @@
     "pageTitle": "安装应用",
     "headline": "将 X-Glass 添加到主屏幕",
     "subheadline": "像 App 一样打开，全屏体验，支持离线使用。",
-
     "installedTitle": "已完成安装",
     "installedBody": "X-Glass 已安装在此设备上。",
     "openApp": "打开 X-Glass",
-
     "promptTitle": "安装 X-Glass",
     "promptBody": "X-Glass 是一款网页应用，同时支持 PWA 安装——无需通过 App Store，直接添加到设备，以后一键打开，体验更接近原生 App。",
     "installButton": "安装",
-
     "iosTitle": "添加到主屏幕",
     "iosSubtitle": "在 Safari 中按以下步骤操作：",
     "iosStep1": "点击 Safari 菜单中的「分享」按钮",
@@ -412,7 +399,6 @@
     "macosStep1": "点击 Safari 工具栏中的「分享」按钮（带箭头的方框图标）",
     "macosStep2": "选择「添加到程序坞」",
     "macosStep3": "点击「添加」确认",
-
     "genericTitle": "添加到主屏幕",
     "genericBody": "X-Glass 是一款网页应用，同时支持 PWA 安装，体验更接近原生 App。打开浏览器菜单，寻找「添加到主屏幕」或「安装应用」选项。"
   }


### PR DESCRIPTION
## What changed

**Mobile navigation**: Previously all nav items (Lenses, Compare, About, Get App, GitHub) were hidden behind the `⋮` overflow menu. Now Lenses and Compare are shown inline in the mobile nav bar — the two highest-frequency actions are always one tap away. About, Get App, and GitHub remain in the overflow menu as genuinely secondary items.

**Home / brand area**: The X-Glass brand text (and Iris icon) were previously part of the `MountSwitcher` component, meaning clicking the brand opened a mount-selection dropdown rather than navigating home. The only home entry point was the 16px Iris icon — too small a tap target. Now:
- Iris icon + X-Glass text together form a single `<Link href="/">` home link
- The ChevronDown is a standalone button that triggers the mount switcher dropdown
- GFX superscript badge stays on the brand text when GFX mount is active

**Cleanup**: Removed unused `Smartphone` import from `Nav.tsx`.

## Why

The original collapse of all items into `⋮` was driven by space pressure from a larger Dropdown Badge on the right side of the brand area. That badge has since been replaced by a small ChevronDown, freeing enough horizontal space to show the primary links directly. Hiding everything behind an overflow menu suppresses click frequency — users only visit overflow menus for things they rarely need.

## Files changed

- `src/components/Nav.tsx` — restructured mobile right side, split home link from mount switcher trigger
- `src/components/MountSwitcher.tsx` — trigger button reduced to ChevronDown only (brand text moved to Nav)