### PR TITLE
feat(hero): replay Iris animation on mount switch, enlarge [G] tag

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,9 +13,8 @@ export async function generateMetadata({
 import DataInfo from "@/components/DataFooter";
 import HomeCta from "@/components/HomeCta";
 import HeroBrand from "@/components/MountTag";
+import HeroIris from "@/components/HeroIris";
 import Tagline from "@/components/Tagline";
-import Iris from "@/components/Iris";
-import { IRIS_HERO } from "@/config/iris-config";
 
 export default function Home() {
   const t = useTranslations("Common");
@@ -24,7 +23,7 @@ export default function Home() {
     <div className="flex flex-col h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] overflow-clip">
       {/* Hero */}
       <section className="flex flex-col items-center justify-center text-center px-4 py-16 flex-1">
-        <Iris config={IRIS_HERO} uid="hero" />
+        <HeroIris />
         <h1 className="mt-8 text-5xl sm:text-6xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50 font-heading">
           <HeroBrand />
         </h1>

--- a/src/components/HeroIris.tsx
+++ b/src/components/HeroIris.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useEffectiveMount } from "@/hooks/useMountParam";
+import Iris from "@/components/Iris";
+import { IRIS_HERO } from "@/config/iris-config";
+
+export default function HeroIris() {
+  const mount = useEffectiveMount();
+  return <Iris config={IRIS_HERO} uid="hero" key={mount} />;
+}

--- a/src/components/MountTag.tsx
+++ b/src/components/MountTag.tsx
@@ -8,7 +8,7 @@ export default function HeroBrand() {
     <span className="relative">
       X-Glass
       {mount === "G" && (
-        <span className="absolute top-0 -right-1 -translate-y-1/3 text-[0.55rem] font-mono font-normal text-zinc-400 dark:text-zinc-500 leading-none tracking-normal select-none">
+        <span className="absolute top-0 left-full ml-1 -translate-y-1/3 text-[0.8rem] font-mono font-normal text-zinc-500 dark:text-zinc-400 leading-none tracking-normal select-none">
           [G]
         </span>
       )}

--- a/src/components/MountTag.tsx
+++ b/src/components/MountTag.tsx
@@ -8,7 +8,7 @@ export default function HeroBrand() {
     <span className="relative">
       X-Glass
       {mount === "G" && (
-        <span className="absolute top-0 left-full ml-1 -translate-y-1/3 text-[0.8rem] font-mono font-normal text-zinc-500 dark:text-zinc-400 leading-none tracking-normal select-none">
+        <span className="absolute top-0 left-full ml-px -translate-y-1/3 text-[0.8rem] font-mono font-normal text-zinc-500 dark:text-zinc-400 leading-none tracking-normal select-none">
           [G]
         </span>
       )}


### PR DESCRIPTION
## Summary

- **[G] tag visibility**: increased font size from `0.55rem` → `0.8rem`, repositioned from `-right-1` (floating) to `left-full ml-1` (flush against the right edge of "X-Glass"), and bumped light-mode contrast from `zinc-400` → `zinc-500`.
- **Iris animation replay**: added `HeroIris` — a thin client wrapper around `<Iris>` that passes `key={mount}`. When the user switches between X and G mounts on the homepage, React remounts the Iris component and the existing `onMount` sweep animation fires again naturally.

## What changed

| File | Change |
|---|---|
| `src/components/MountTag.tsx` | Larger, closer [G] superscript |
| `src/components/HeroIris.tsx` | New client wrapper with `key={mount}` |
| `src/app/[locale]/page.tsx` | Replace `<Iris config={IRIS_HERO}>` with `<HeroIris>` |

## Reviewer notes

- No changes to `Iris.tsx` itself — the remount-on-key-change pattern is the standard React approach and avoids adding imperative APIs to the component.
- The `key` forces a full remount (including `ApertureStrip`), which is intentional — it gives the user a clean reset of the aperture UI on each mount switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)