### PR TITLE
fix(nav): hide mount switcher on non-scoped pages

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -90,6 +90,7 @@ export default function Nav() {
 
   const isBrowseActive = pathname.startsWith("/lenses") && !pathname.includes("/compare");
   const isCompareActive = pathname.includes("/compare");
+  const showMountSwitcher = pathname === "/" || pathname.startsWith("/lenses");
 
   return (
     <header
@@ -114,8 +115,12 @@ export default function Nav() {
             <Iris config={IRIS_NAV} uid="nav" size={16} />
             X-Glass
           </Link>
-          <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-lg px-0.5" aria-hidden="true">/</span>
-          <MountSwitcher />
+          {showMountSwitcher && (
+            <>
+              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-lg px-0.5" aria-hidden="true">/</span>
+              <MountSwitcher />
+            </>
+          )}
         </div>
 
         {/* Desktop nav links */}


### PR DESCRIPTION
## Summary

- The `MountSwitcher` dropdown in the navbar is now hidden on pages where mount selection has no content relevance: `/about`, `/get`, and `/design-lab/*`
- It remains visible on `/` (home) and all `/lenses/*` routes where the X Mount / G Mount scope is meaningful
- Implementation: a single `showMountSwitcher` boolean in `Nav.tsx` gates the `/ [mount ▾]` segment

## Why

The `X-Glass / [mount]` pattern borrows from GitHub's namespace metaphor. Showing it on About or Get App falsely implies those pages are scoped to a particular mount, adding visual noise without any functional value.

## Reviewer notes

No behaviour change on scoped pages. On non-scoped pages the left side of the navbar simply shows `X-Glass` with no separator or dropdown.