### PR TITLE
refactor(types): align Lens.pricing with pipeline structure

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SPEC_NA, SPECIALTY_TAGS } from "./types.ts";
+import { SPEC_NA, SPECIALTY_TAGS, PRICE_SOURCE_KEYS } from "./types.ts";
 import type { ApertureValue, Lens } from "./types.ts";
 
 const positiveNumberSchema = z.number().positive();
@@ -27,8 +27,7 @@ export const specNaSchema = z.literal(SPEC_NA);
 const lensPriceEntrySchema = z.object({
   price: z.number().positive(),
   currency: z.enum(["CNY", "USD"]),
-  source: z.string().min(1).optional(),
-  url: z.string().url().optional(),
+  source: z.enum(PRICE_SOURCE_KEYS),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 const pricingMarketSchema = z.strictObject({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,14 +270,18 @@ export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
  */
 export type Mount = "X" | "G";
 
+export const PRICE_SOURCE_KEYS = [
+  "jd",
+  "tmall",
+  "xianyu",
+] as const;
+export type PriceSourceKey = (typeof PRICE_SOURCE_KEYS)[number];
+
 /** A single price observation — shared by new and used entries across all markets. */
 export interface LensPriceEntry {
   price: number;
   currency: "CNY" | "USD";
-  /** Platform the price was sampled from, e.g. "jd", "tmall", "xianyu". */
-  source?: string;
-  /** Store listing or search-result URL where the price was observed. */
-  url?: string;
+  source: PriceSourceKey;
   /** ISO date YYYY-MM-DD when sampled. */
   sampledAt: string;
 }
@@ -669,30 +673,12 @@ export interface Lens {
    */
   pricing?: {
     cn?: {
-      /** Retail price in CNY at time of sampling. */
-      price: number;
-      currency: "CNY";
-      /** Whether the price reflects a new (official store) or used (secondary market) listing. */
-      condition: "new" | "used";
-      /** Platform the price was sampled from, e.g. "jd", "tmall", "xianyu". */
-      source?: string;
-      /** Store listing or search-result URL where the price was observed. */
-      url?: string;
-      /** ISO date YYYY-MM-DD when sampled. */
-      sampledAt: string;
+      new?: LensPriceEntry;
+      used?: LensPriceEntry;
     };
     global?: {
-      /** Retail price in USD at time of sampling. */
-      price: number;
-      currency: "USD";
-      /** Whether the price reflects a new (official store) or used (secondary market) listing. */
-      condition: "new" | "used";
-      /** Platform the price was sampled from. */
-      source?: string;
-      /** Store listing or search-result URL where the price was observed. */
-      url?: string;
-      /** ISO date YYYY-MM-DD when sampled. */
-      sampledAt: string;
+      new?: LensPriceEntry;
+      used?: LensPriceEntry;
     };
   };
 


### PR DESCRIPTION
## Summary

- `Lens.pricing` restructured to nested `cn.new / cn.used / global.new / global.used`, matching the pipeline's `PricingData` shape
- `LensPriceEntry`: removed `url` and `condition`; `source` is now required and typed as `PriceSourceKey` enum
- New `PRICE_SOURCE_KEYS = ["jd", "tmall", "xianyu"] as const` and derived `PriceSourceKey` type (same pattern as `SPECIALTY_TAGS`)
- `lens-schema.ts`: `source` validated against `PRICE_SOURCE_KEYS` enum; compile-time assertion passes

## Test plan

- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)