### PR TITLE
refactor(pricing): rename PriceSourceKey→PriceSource, strict schema, drop url

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -81,7 +81,6 @@
           "price": 1299,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10038643493366.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -147,7 +146,6 @@
           "price": 939,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10187125174593.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -207,7 +205,6 @@
           "price": 599,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10212588856782.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -299,7 +296,6 @@
           "price": 699,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10144266042361.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -349,7 +345,6 @@
           "price": 599,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10212592143407.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -403,7 +398,6 @@
           "price": 599,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10213996269124.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -729,7 +723,6 @@
           "price": 670,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10062473752141.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -786,7 +779,6 @@
           "price": 1090,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10204898752312.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -848,7 +840,6 @@
           "price": 639,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10027028201649.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -907,7 +898,6 @@
           "price": 499,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10160933790025.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -963,7 +953,6 @@
           "price": 593,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10164361585110.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1020,7 +1009,6 @@
           "price": 270,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10068170968055.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1079,7 +1067,6 @@
           "price": 394,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/22071562982.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1135,7 +1122,6 @@
           "price": 369,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10023827550733.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1191,7 +1177,6 @@
           "price": 329,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10200036685867.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1251,7 +1236,6 @@
           "price": 969,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10160356865706.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1305,7 +1289,6 @@
           "price": 299,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/23196870151.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1356,7 +1339,6 @@
           "price": 494,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/23702204564.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1416,7 +1398,6 @@
           "price": 899,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10034452578266.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1525,7 +1506,6 @@
           "price": 999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10210192269614.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1640,7 +1620,6 @@
           "price": 899,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10109759393601.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1750,7 +1729,6 @@
           "price": 259,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10039170180560.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1812,7 +1790,6 @@
           "price": 529,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10206375369431.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1871,7 +1848,6 @@
           "price": 799,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10100484539176.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -1963,7 +1939,6 @@
           "price": 999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10161505403978.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2057,7 +2032,6 @@
           "price": 379,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/35521215376.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2106,7 +2080,6 @@
           "price": 999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10120084186243.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2165,7 +2138,6 @@
           "price": 509,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10136248141644.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2215,7 +2187,6 @@
           "price": 299,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10081229168136.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2287,7 +2258,6 @@
           "price": 8800,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2366,7 +2336,6 @@
           "price": 7666,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2449,7 +2418,6 @@
           "price": 2550,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100239539021.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2888,7 +2856,6 @@
           "price": 5490,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10076684016873.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -2957,7 +2924,6 @@
           "price": 1725,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3026,7 +2992,6 @@
           "price": 6990,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10025233765523.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3082,7 +3047,6 @@
           "price": 1098,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3147,7 +3111,6 @@
           "price": 4990,
           "currency": "CNY",
           "source": "tmall",
-          "url": "https://fujifilm.tmall.com/category-1106901591.htm",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3227,7 +3190,6 @@
           "price": 5600,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3295,7 +3257,6 @@
           "price": 8100,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3373,7 +3334,6 @@
           "price": 2640,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3436,7 +3396,6 @@
           "price": 6620,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33779863063.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3496,7 +3455,6 @@
           "price": 2680,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/41634837954.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3580,7 +3538,6 @@
           "price": 1565,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3646,7 +3603,6 @@
           "price": 5990,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10060482260075.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3720,7 +3676,6 @@
           "price": 2700,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3777,7 +3732,6 @@
           "price": 6490,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10031234224839.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3836,7 +3790,6 @@
           "price": 1600,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3892,7 +3845,6 @@
           "price": 1599,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -3951,7 +3903,6 @@
           "price": 5840,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10045634723640.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4008,7 +3959,6 @@
           "price": 1274,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4068,7 +4018,6 @@
           "price": 2890,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10199711725340.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4131,7 +4080,6 @@
           "price": 1519,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4188,7 +4136,6 @@
           "price": 2690,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10026515405137.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4247,7 +4194,6 @@
           "price": 4190,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10065781422895.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4304,7 +4250,6 @@
           "price": 5190,
           "currency": "CNY",
           "source": "tmall",
-          "url": "https://fujifilm.tmall.com/category-1106914229.htm",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4360,7 +4305,6 @@
           "price": 3890,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33787100217.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4424,7 +4368,6 @@
           "price": 3390,
           "currency": "CNY",
           "source": "tmall",
-          "url": "https://fujifilm.tmall.com/category-1106914229.htm",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4496,7 +4439,6 @@
           "price": 9990,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33782092981.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4561,7 +4503,6 @@
           "price": 10490,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10021170089659.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4618,7 +4559,6 @@
           "price": 3590,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33782496055.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4698,7 +4638,6 @@
           "price": 4370,
           "currency": "CNY",
           "source": "tmall",
-          "url": "https://fujifilm.tmall.com/category-1106901591.htm",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4758,7 +4697,6 @@
           "price": 2350,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4818,7 +4756,6 @@
           "price": 2300,
           "currency": "CNY",
           "source": "xianyu",
-          "url": "https://www.goofish.com",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4879,7 +4816,6 @@
           "price": 6620,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10060490640801.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -4944,7 +4880,6 @@
           "price": 4280,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33785721932.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5019,7 +4954,6 @@
           "price": 5390,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10026515756821.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5080,7 +5014,6 @@
           "price": 7790,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33782885268.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5144,7 +5077,6 @@
           "price": 6320,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33783537607.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5216,7 +5148,6 @@
           "price": 12600,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/33786122769.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5286,7 +5217,6 @@
           "price": 13500,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10054683248070.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5352,7 +5282,6 @@
           "price": 33900,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/35290356605.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5416,7 +5345,6 @@
           "price": 21400,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10126095152653.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5475,7 +5403,6 @@
           "price": 558,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10099680846804.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5527,7 +5454,6 @@
           "price": 309,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10136094933725.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5586,7 +5512,6 @@
           "price": 512,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10158405812933.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5644,7 +5569,6 @@
           "price": 799,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10124734591556.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5697,7 +5621,6 @@
           "price": 568,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10100008898701.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5758,7 +5681,6 @@
           "price": 252,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10115511730826.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5817,7 +5739,6 @@
           "price": 283,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10099370400666.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5876,7 +5797,6 @@
           "price": 853,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10099433049702.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5934,7 +5854,6 @@
           "price": 444,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10099455378783.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -5993,7 +5912,6 @@
           "price": 283,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10098959961168.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6051,7 +5969,6 @@
           "price": 739,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10110017394939.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6131,7 +6048,6 @@
           "price": 4288,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100072186956.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6199,7 +6115,6 @@
           "price": 3699,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100274443690.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6268,7 +6183,6 @@
           "price": 3099,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100330541518.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6360,7 +6274,6 @@
           "price": 4110,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100172087733.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6431,7 +6344,6 @@
           "price": 2699,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100021314769.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6580,7 +6492,6 @@
           "price": 3499,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100047896457.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6646,7 +6557,6 @@
           "price": 2999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100068628585.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6712,7 +6622,6 @@
           "price": 1799,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100021314771.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6779,7 +6688,6 @@
           "price": 2143,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100037105170.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6862,7 +6770,6 @@
           "price": 5999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/100067255806.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -6943,7 +6850,6 @@
           "price": 3680,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10031655006587.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7022,7 +6928,6 @@
           "price": 3690,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10054566167214.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7106,7 +7011,6 @@
           "price": 3490,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10037876010935.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7192,7 +7096,6 @@
           "price": 9790,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10034053993321.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7717,7 +7620,6 @@
           "price": 649,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10033949140156.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7780,7 +7682,6 @@
           "price": 859,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10110060888492.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7843,7 +7744,6 @@
           "price": 483,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10041957148824.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -7959,7 +7859,6 @@
           "price": 960,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10066384828041.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8017,7 +7916,6 @@
           "price": 364,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10028349066041.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8084,7 +7982,6 @@
           "price": 547,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10037583292173.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8143,7 +8040,6 @@
           "price": 1056,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10052067280271.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8200,7 +8096,6 @@
           "price": 547,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10035387713862.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8261,7 +8156,6 @@
           "price": 1152,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10067041960631.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8324,7 +8218,6 @@
           "price": 940,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10154324990901.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8454,7 +8347,6 @@
           "price": 989,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10191680555976.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8510,7 +8402,6 @@
           "price": 2499,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10043014538126.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8578,7 +8469,6 @@
           "price": 1169,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10168304095945.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8638,7 +8528,6 @@
           "price": 1399,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10051437102084.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8705,7 +8594,6 @@
           "price": 889,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10134997624694.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8763,7 +8651,6 @@
           "price": 3099,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10083825353058.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8819,7 +8706,6 @@
           "price": 499,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10135735360417.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8877,7 +8763,6 @@
           "price": 1299,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10020003359669.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8938,7 +8823,6 @@
           "price": 889,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10130606883411.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -8993,7 +8877,6 @@
           "price": 3459,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10177532158029.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -9050,7 +8933,6 @@
           "price": 1299,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10021830637202.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -9112,7 +8994,6 @@
           "price": 889,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10099827998683.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -9167,7 +9048,6 @@
           "price": 2999,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/10067505672155.html",
           "sampledAt": "2026-05-08"
         }
       }
@@ -9223,7 +9103,6 @@
           "price": 1699,
           "currency": "CNY",
           "source": "jd",
-          "url": "https://item.jd.com/43305473025.html",
           "sampledAt": "2026-05-08"
         }
       }

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SPEC_NA, SPECIALTY_TAGS, PRICE_SOURCE_KEYS } from "./types.ts";
+import { SPEC_NA, SPECIALTY_TAGS, PRICE_SOURCES } from "./types.ts";
 import type { ApertureValue, Lens } from "./types.ts";
 
 const positiveNumberSchema = z.number().positive();
@@ -24,10 +24,10 @@ const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
 export const specNaSchema = z.literal(SPEC_NA);
-const lensPriceEntrySchema = z.object({
+const lensPriceEntrySchema = z.strictObject({
   price: z.number().positive(),
   currency: z.enum(["CNY", "USD"]),
-  source: z.enum(PRICE_SOURCE_KEYS),
+  source: z.enum(PRICE_SOURCES),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 const pricingMarketSchema = z.strictObject({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,18 +270,18 @@ export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
  */
 export type Mount = "X" | "G";
 
-export const PRICE_SOURCE_KEYS = [
+export const PRICE_SOURCES = [
   "jd",
   "tmall",
   "xianyu",
 ] as const;
-export type PriceSourceKey = (typeof PRICE_SOURCE_KEYS)[number];
+export type PriceSource = (typeof PRICE_SOURCES)[number];
 
 /** A single price observation — shared by new and used entries across all markets. */
 export interface LensPriceEntry {
   price: number;
   currency: "CNY" | "USD";
-  source: PriceSourceKey;
+  source: PriceSource;
   /** ISO date YYYY-MM-DD when sampled. */
   sampledAt: string;
 }


### PR DESCRIPTION
## Summary

- Rename `PRICE_SOURCE_KEYS` → `PRICE_SOURCES` and `PriceSourceKey` → `PriceSource` — removes the redundant "Key" suffix
- Switch `lensPriceEntrySchema` from `z.object` to `z.strictObject` — unknown fields now error instead of being silently stripped
- Remove `url` field from all 121 pricing entries in `lenses.json` — url was present in data but absent from schema, causing silent data loss on parse

## Test plan

- [x] `npx tsx` schema validation: 152 lenses, 0 failures
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)