### PR TITLE
fix(pricing): narrow priceTier return before passing to formatTierRange

### DIFF
--- a/src/components/PriceBand.tsx
+++ b/src/components/PriceBand.tsx
@@ -27,7 +27,7 @@ function PriceInfoPopover({
   const t = useTranslations("Pricing");
   const { entry, condition } = selection;
   const isUsed = condition === "used";
-  const symbol = locale === "zh" ? "¥" : "$";
+  const symbol = t("tierSymbol");
   const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
   const rangeDisplay = formatTierRange(tier, entry.currency, locale);
   const sourceDisplay = formatSource(entry.source, t);
@@ -100,7 +100,7 @@ export function PriceBand({ lens, compact = false }: Props) {
     return null;
   }
   const isUsed = condition === "used";
-  const symbol = locale === "zh" ? "¥" : "$";
+  const symbol = t("tierSymbol");
 
   return (
     <div className="inline-flex items-center gap-1.5">

--- a/src/components/PriceBand.tsx
+++ b/src/components/PriceBand.tsx
@@ -18,13 +18,14 @@ import { cn } from "@/lib/utils";
 function PriceInfoPopover({
   selection,
   locale,
+  tier,
 }: {
   selection: PriceSelection;
   locale: string;
+  tier: 1 | 2 | 3 | 4 | 5;
 }) {
   const t = useTranslations("Pricing");
   const { entry, condition } = selection;
-  const tier = priceTier(entry.price, entry.currency);
   const isUsed = condition === "used";
   const symbol = locale === "zh" ? "¥" : "$";
   const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
@@ -91,7 +92,13 @@ export function PriceBand({ lens, compact = false }: Props) {
   }
 
   const { entry, condition } = selection;
+  // priceTier returns undefined for unknown currency (defensive switch/case in
+  // lens.ts). The schema constrains currency to "CNY" | "USD" so this is
+  // unreachable at runtime, but the narrowing is needed for type safety.
   const tier = priceTier(entry.price, entry.currency);
+  if (tier === undefined) {
+    return null;
+  }
   const isUsed = condition === "used";
   const symbol = locale === "zh" ? "¥" : "$";
 
@@ -114,7 +121,7 @@ export function PriceBand({ lens, compact = false }: Props) {
           {t("usedBadge")}
         </span>
       )}
-      <PriceInfoPopover selection={selection} locale={locale} />
+      <PriceInfoPopover selection={selection} locale={locale} tier={tier} />
     </div>
   );
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -418,6 +418,7 @@
     "conditionNew": "New",
     "conditionUsed": "Used",
     "cnyAmount": "¥{value}",
+    "tierSymbol": "$",
     "source": {
       "jd": "Official store (JD.com)",
       "tmall": "Official store (Tmall)",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -418,6 +418,7 @@
     "conditionNew": "新品",
     "conditionUsed": "二手",
     "cnyAmount": "{value} 元",
+    "tierSymbol": "¥",
     "source": {
       "jd": "官方店（京东）",
       "tmall": "官方店（天猫）",


### PR DESCRIPTION
## Summary

Fixes the prod build failure on \`main\` (54f31ff). PR #116 and the parallel refactor in 157b882 (\`priceTier\` rewritten with switch/case + \`default: return undefined\`) each pass independently, but the merged tree breaks type-checking:

\`\`\`
./src/components/PriceBand.tsx:31:40
Type error: Argument of type '1 | 2 | 3 | 4 | 5 | undefined' is not
assignable to parameter of type '1 | 2 | 3 | 4 | 5'.
\`\`\`

## Why this is a real fix and not a cast

The new \`priceTier\` adds a \`default\` branch returning \`undefined\` for unknown currency strings. \`Lens.pricing.*.currency\` is constrained to \`'CNY' | 'USD'\` by the schema, so the branch is unreachable at runtime — but the type checker can't see that, and \`as\` casts hide invariant violations rather than express them. So I keep the defensive contract intact and add a matching narrowing on the consumer side: an early \`return null\` if \`tier === undefined\` (consistent with the existing \`if (!selection) return null\` directly above), then pass the now-narrowed \`tier\` into \`PriceInfoPopover\` as a prop. The popover stops re-deriving \`tier\` itself.

## Verification

- \`npx tsc --noEmit\` — clean
- \`npx next build\` — clean (locally reproduced the failure first, then confirmed the fix unblocks it)

## Test plan
- [ ] Vercel preview build succeeds on this PR
- [ ] PriceBand still renders correctly on a zh lens detail page (e.g. \`/zh/lenses/x/7artisans-25mm-f095-x\`)
- [ ] Compare table at \`/zh/lenses/x/compare\` still shows the price row