### PR TITLE
fix: update pipeline diagram, tighten mobile nav, enlarge compare button

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ flowchart TD
 
     subgraph sp["Stage P · Publish Gate"]
       SP1["<b>Zod schema validation</b><br/>Intra-lens + cross-lens checks"]
+      SP_AUDIT["<b>Audit Agent · Independent Spec Audit</b><br/>Samples web blogs and community lens databases<br/>Cross-checks specs with zero pipeline context"]
       SP2["<b>Normalization + version stamp</b>"]
     end
   end
@@ -113,7 +114,8 @@ flowchart TD
   PRICING_SOURCES -->|"storefront search URLs"| SPrNew
   SPrUsed
   SPrNew & SPrUsed --> SP1
-  SP1 --> SP2
+  SP1 --> SP_AUDIT
+  SP_AUDIT --> SP2
   SP2 -->|"writes src/data/lenses.json"| DB[("x-glass<br/>(this repo)")]
 
   classDef script fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f
@@ -123,7 +125,7 @@ flowchart TD
   classDef config fill:#f1f5f9,stroke:#64748b,color:#1e293b
 
   class S0,S2b,S2c script
-  class S1p1,S1p2,S1b,S2a,SPrNew,SPrUsed agent
+  class S1p1,S1p2,S1b,S2a,SPrNew,SPrUsed,SP_AUDIT agent
   class S1r,S1h,SR human
   class SP1,SP2 gate
   class SOURCES,PRICING_SOURCES config

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -168,7 +168,7 @@ export default function LensCard({
         onClick={onToggle}
         disabled={selectionDisabled}
         aria-label={isSelected ? t("removeFromCompare") : t("addToCompare")}
-        className={`hidden max-[499px]:flex absolute top-2.5 right-2.5 z-10 items-center justify-center h-7 w-7 rounded-full transition-colors ${
+        className={`hidden max-[499px]:flex absolute top-2 right-2 z-10 items-center justify-center h-8 w-8 rounded-full transition-colors ${
           isSelected
             ? ACTION_PRIMARY_CLS
             : selectionDisabled
@@ -176,7 +176,7 @@ export default function LensCard({
               : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700"
         }`}
       >
-        {isSelected ? <Check className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+        {isSelected ? <Check className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
       </button>
 
       {/* Compare toggle */}

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -56,13 +56,13 @@ export default function MountSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="group flex items-center gap-0.5 font-heading font-medium text-base text-zinc-600 dark:text-zinc-400 tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800/60 px-1.5 py-0.5 -ml-1.5 rounded-md transition-all whitespace-nowrap"
+        className="group flex items-center gap-0.5 font-heading font-medium text-xs sm:text-base text-zinc-600 dark:text-zinc-400 tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800/60 px-1 py-0.5 -ml-1 sm:px-1.5 sm:-ml-1.5 rounded-md transition-all whitespace-nowrap"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}
       >
         {fullLabel}
-        <ChevronDown className="h-3.5 w-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
+        <ChevronDown className="h-3 w-3 sm:h-3.5 sm:w-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
       </button>
 
       {open && (

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -56,7 +56,7 @@ export default function MountSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="group flex items-center gap-0.5 font-heading font-medium text-xs sm:text-base text-zinc-600 dark:text-zinc-400 tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800/60 px-1 py-0.5 -ml-1 sm:px-1.5 sm:-ml-1.5 rounded-md transition-all whitespace-nowrap"
+        className="group flex items-center gap-0.5 font-heading font-medium text-sm sm:text-base text-zinc-600 dark:text-zinc-400 tracking-tight hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800/60 px-1 py-0.5 -ml-1 sm:px-1.5 sm:-ml-1.5 rounded-md transition-all whitespace-nowrap"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={t("label")}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -106,10 +106,10 @@ export default function Nav() {
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         {/* Left: brand / mount-scope path (GitHub namespace pattern) */}
-        <div className="flex items-center gap-1.5 shrink-0">
+        <div className="flex items-center gap-0.5 sm:gap-1.5 shrink-0">
           <Link
             href="/"
-            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-sm sm:text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
+            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-base sm:text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />
@@ -117,7 +117,7 @@ export default function Nav() {
           </Link>
           {showMountSwitcher && (
             <>
-              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-sm sm:text-lg px-0.5" aria-hidden="true">/</span>
+              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-base sm:text-lg px-0" aria-hidden="true">/</span>
               <MountSwitcher />
             </>
           )}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -75,7 +75,7 @@ export default function Nav() {
     : `/lenses/${seg}/compare`;
 
   const linkCls = (active: boolean) =>
-    `text-sm transition-colors px-2 ${
+    `text-xs sm:text-sm transition-colors px-1.5 sm:px-2 ${
       active
         ? "text-zinc-900 dark:text-zinc-50 font-medium"
         : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50"

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -109,7 +109,7 @@ export default function Nav() {
         <div className="flex items-center gap-1.5 shrink-0">
           <Link
             href="/"
-            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
+            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-sm sm:text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />
@@ -117,7 +117,7 @@ export default function Nav() {
           </Link>
           {showMountSwitcher && (
             <>
-              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-lg px-0.5" aria-hidden="true">/</span>
+              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-sm sm:text-lg px-0.5" aria-hidden="true">/</span>
               <MountSwitcher />
             </>
           )}


### PR DESCRIPTION
## Summary

- **README — pipeline diagram**: add `Audit Agent · Independent Spec Audit` node inside Publish Gate. This second agent has zero pipeline context and independently cross-checks specs against external web blogs and community lens databases, acting as a third-party auditor (prosecutor / separation-of-powers pattern).
- **Mobile NavBar**: switch `linkCls` from `text-sm px-2` to `text-xs sm:text-sm px-1.5 sm:px-2` so English nav links (Browse, Compare) don't crowd on narrow viewports — no locale-specific logic needed.
- **LensCard mobile compare button**: increase from `h-7 w-7` (28 px) to `h-8 w-8` (32 px), icon from 3.5 to 4, touch offset adjusted from `top-2.5 right-2.5` to `top-2 right-2` for a larger, easier-to-tap target.

## Test plan

- [ ] Render the README mermaid diagram and confirm the Audit Agent appears between Zod validation and normalization, styled yellow (agent class)
- [ ] Check mobile (≤499 px) NavBar in English — "Browse" and "Compare" should fit without overflow
- [ ] Tap the compare `+` button on mobile Lenses page — noticeably easier to hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)