### PR TITLE
feat(types): change PriceSource from enum to string

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SPEC_NA, SPECIALTY_TAGS, PRICE_SOURCES } from "./types.ts";
+import { SPEC_NA, SPECIALTY_TAGS } from "./types.ts";
 import type { ApertureValue, Lens } from "./types.ts";
 
 const positiveNumberSchema = z.number().positive();
@@ -27,7 +27,7 @@ export const specNaSchema = z.literal(SPEC_NA);
 const lensPriceEntrySchema = z.strictObject({
   price: z.number().positive(),
   currency: z.enum(["CNY", "USD"]),
-  source: z.enum(PRICE_SOURCES),
+  source: z.string().min(1),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 const pricingMarketSchema = z.strictObject({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,13 +270,11 @@ export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
  */
 export type Mount = "X" | "G";
 
-export type PriceSource = string;
-
 /** A single price observation — shared by new and used entries across all markets. */
 export interface LensPriceEntry {
   price: number;
   currency: "CNY" | "USD";
-  source: PriceSource;
+  source: string;
   /** ISO date YYYY-MM-DD when sampled. */
   sampledAt: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,12 +270,7 @@ export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
  */
 export type Mount = "X" | "G";
 
-export const PRICE_SOURCES = [
-  "jd",
-  "tmall",
-  "xianyu",
-] as const;
-export type PriceSource = (typeof PRICE_SOURCES)[number];
+export type PriceSource = string;
 
 /** A single price observation — shared by new and used entries across all markets. */
 export interface LensPriceEntry {


### PR DESCRIPTION
## Summary

- Remove `PRICE_SOURCES` const array and enum-based `PriceSource` type from `types.ts`
- `PriceSource` is now `string` to support `display_name` values from `pricing-sources.yaml` (e.g. `"京东·富士影像旗舰店"`, `"ttartisan.store"`, `"Amazon · TTARTISAN"`)
- `lens-schema.ts`: replace `z.enum(PRICE_SOURCES)` with `z.string().min(1)`

**Depends on:** sentacraft/x-glass-pipeline#61 which introduces the `display_name` field and migrates all `pricing.*.source` values to human-readable strings.

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Existing lenses with CN pricing data (`source: "jd"` etc.) will need to be re-published after pipeline migrates source values to display_name format

🤖 Generated with [Claude Code](https://claude.com/claude-code)