### PR TITLE
chore(turbopack): pin workspace root so dev server works inside worktrees

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,23 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Pin Turbopack's workspace root to the directory `next dev` was launched
+  // from. Without this, when running the dev server inside a git worktree
+  // located under `.claude/worktrees/<name>/`, Turbopack walks up the tree,
+  // finds the parent repo's package-lock.json, and picks the parent as the
+  // workspace root — leading to a "multiple lockfiles" warning and broken
+  // module resolution for files like the local fonts in `src/app/layout.tsx`
+  // (which use paths relative to the worktree's own node_modules).
+  //
+  // process.cwd() is the directory where `npm run dev` was invoked, which is
+  // always the worktree's own root, so this works for both the main repo
+  // and any worktree without further configuration.
+  //
+  // See: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory
+  turbopack: {
+    root: process.cwd(),
+  },
+};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary

Pins Turbopack's workspace root to \`process.cwd()\` so \`next dev\` works correctly inside git worktrees nested under \`.claude/worktrees/\`.

## What was happening

Running \`npm run dev\` from a worktree printed:

\`\`\`
⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
 We detected multiple lockfiles and selected the directory of
 /Users/<user>/repo/x-glass/package-lock.json as the root directory.
\`\`\`

Turbopack walked up the directory tree, found the parent repo's \`package-lock.json\`, and picked the parent as the workspace root — even though the worktree has its own lockfile and \`node_modules\`. This broke module resolution for files that resolve relative to the worktree's own \`node_modules\`, most visibly the local fonts in \`src/app/layout.tsx\` (path \`../../node_modules/@fontsource-variable/source-serif-4/...\`).

This is a known Next.js 15.4.1+ behavior: see [vercel/next.js#82689](https://github.com/vercel/next.js/issues/82689) and [#81864](https://github.com/vercel/next.js/issues/81864).

## Fix

\`process.cwd()\` is the directory \`next dev\` was launched from — always the worktree itself when running from a worktree, and the main repo when running from the main repo. So the same config works for both without further branching.

The [official workaround documented by Next.js](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory) is to set \`turbopack.root\` explicitly, which is what this PR does.

## Test plan

- [x] \`npm run dev\` from \`.claude/worktrees/<name>/\` no longer prints the multiple-lockfiles warning
- [x] Compare page \`/en/lenses/x/compare?ids=fujifilm-mkx-18-55mmt29-x,fujifilm-mkx-50-135mmt29-x\` renders both lens columns correctly
- [x] \`npx tsc --noEmit\` passes
- [ ] \`npm run dev\` from the main repo still works (no regression for the non-worktree case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)