### PR TITLE
fix(filters): mirror filter state via history.replaceState, drop debounce

### DIFF
--- a/e2e/lens-list.spec.ts
+++ b/e2e/lens-list.spec.ts
@@ -60,4 +60,40 @@ test.describe("Lens list page", () => {
     // Detail page shows the lens model — at least one visible text element is present
     await expect(page.locator("body")).toBeVisible();
   });
+
+  // Regression guard: the URL must mirror the active filter state so that
+  // refresh and back-from-detail preserve filters. The filter state is
+  // synced via window.history.replaceState (not router.replace) to avoid
+  // an RSC round-trip on every keystroke; this test would catch any
+  // regression that drops the URL sync entirely.
+  test("applying a brand filter writes it into the URL synchronously", async ({
+    page,
+  }) => {
+    await expect(page).toHaveURL(/\/lenses\/x$/);
+
+    await page.getByRole("button", { name: "Sigma", exact: true }).click();
+
+    // URL should contain the brand param almost immediately (no debounce).
+    await expect(page).toHaveURL(/[?&]b=sigma\b/i, { timeout: 500 });
+
+    // And it should have arrived without triggering a navigation that pushes
+    // a new history entry: we should still be on the same path.
+    await expect(page).toHaveURL(/\/lenses\/x\?/);
+  });
+
+  test("filter state survives a page refresh", async ({ page }) => {
+    await page.getByRole("button", { name: "Sigma", exact: true }).click();
+    await expect(page).toHaveURL(/[?&]b=sigma\b/i);
+
+    await page.reload();
+
+    // After refresh, the Sigma chip should still appear pressed/active —
+    // we assert via the result count being the filtered count (smaller than
+    // the unfiltered total observed in the "brand filter narrows results"
+    // test above).
+    const filteredText = await page.getByText(/\d+ lenses/).textContent();
+    const filteredCount = parseInt(filteredText!.match(/\d+/)![0], 10);
+    expect(filteredCount).toBeGreaterThan(0);
+    expect(filteredCount).toBeLessThan(50);
+  });
 });

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { useRouter, usePathname, Link } from "@/i18n/navigation";
+import { usePathname, Link } from "@/i18n/navigation";
 import { motion, AnimatePresence } from "motion/react";
 import { useTranslations } from "next-intl";
 import type { Lens } from "@/lib/types";
@@ -42,9 +42,7 @@ export default function LensListClient({ lenses }: Props) {
   const t = useTranslations("LensList");
   const hookAttr = useUiHookAttr();
   const searchParams = useSearchParams();
-  const router = useRouter();
   const pathname = usePathname();
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggleCompare, canToggle } = useMountedCompare();
@@ -80,13 +78,9 @@ export default function LensListClient({ lenses }: Props) {
   function updateFilters(updater: FilterState | ((prev: FilterState) => FilterState)) {
     setFilters((prev) => {
       const next = typeof updater === "function" ? updater(prev) : updater;
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => {
-        const qs = serializeFilters(next).toString();
-        router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-      }, 300);
+      const qs = serializeFilters(next).toString();
+      const path = qs ? `${pathname}?${qs}` : pathname;
+      window.history.replaceState(null, "", path);
       return next;
     });
   }

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -78,8 +78,6 @@ export default function LensListClient({ lenses }: Props) {
   function updateFilters(updater: FilterState | ((prev: FilterState) => FilterState)) {
     const next = typeof updater === "function" ? updater(filters) : updater;
     setFilters(next);
-    // history.replaceState runs after setFilters (not inside its updater) to
-    // avoid a React warning about updating a component while rendering another.
     const qs = serializeFilters(next).toString();
     const path = qs ? `${pathname}?${qs}` : pathname;
     window.history.replaceState(null, "", path);

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -76,13 +76,13 @@ export default function LensListClient({ lenses }: Props) {
   ] as const satisfies readonly { value: SortKey; label: string }[];
 
   function updateFilters(updater: FilterState | ((prev: FilterState) => FilterState)) {
-    setFilters((prev) => {
-      const next = typeof updater === "function" ? updater(prev) : updater;
-      const qs = serializeFilters(next).toString();
-      const path = qs ? `${pathname}?${qs}` : pathname;
-      window.history.replaceState(null, "", path);
-      return next;
-    });
+    const next = typeof updater === "function" ? updater(filters) : updater;
+    setFilters(next);
+    // history.replaceState runs after setFilters (not inside its updater) to
+    // avoid a React warning about updating a component while rendering another.
+    const qs = serializeFilters(next).toString();
+    const path = qs ? `${pathname}?${qs}` : pathname;
+    window.history.replaceState(null, "", path);
   }
 
   function clearAllFilters() {


### PR DESCRIPTION
## Summary

Same anti-pattern as PR #121's compare-table fix, applied to the lens list filters: replace \`router.replace\` (which triggers a useless RSC round-trip) with \`window.history.replaceState\` (a pure address-bar update). The 300ms debounce that was masking the cost goes away with it.

## What was happening

\`LensListClient\`:

\`\`\`tsx
debounceRef.current = setTimeout(() => {
  const qs = serializeFilters(next).toString();
  router.replace(qs ? \`\${pathname}?\${qs}\` : pathname, { scroll: false });
}, 300);
\`\`\`

\`router.replace\` from next-intl triggers an RSC fetch every time it's called. But \`/lenses/[mount]/(browse)/page.tsx\` does **not** read \`searchParams\` — it just returns \`getLensesByMount(mount)\`. Filtering happens entirely on the client. So every URL update was paying for a server round-trip that returned the exact same RSC payload the client already had.

The 300ms debounce existed to limit how often that round-trip happened. With \`history.replaceState\` (purely local, ~0 cost), the debounce loses its reason to exist.

## Why URL persistence stays

The URL still mirrors filter state because that's what makes:
- page refresh preserve filters
- back-from-detail-page preserve filters
- copying/sharing a filtered URL work

What changes is just **how** the URL is kept in sync — no debounce, no RSC.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [ ] Apply a brand filter (e.g. Sigma) → URL updates within ~50ms with \`?b=sigma\`
- [ ] Refresh the page → Sigma filter is still active
- [ ] Apply a filter, click into a lens detail page, hit browser back → filter still applied
- [ ] Copy the filtered URL → opening it in a new tab shows the same filtered list

Adds two e2e regression guards in \`e2e/lens-list.spec.ts\`:
- applying a brand filter writes the param into the URL within 500ms
- filter state survives a full page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)