### PR TITLE
refactor(pricing): single source of truth for price tier thresholds

### DIFF
--- a/src/lib/lens-pricing.ts
+++ b/src/lib/lens-pricing.ts
@@ -44,8 +44,8 @@ export function pickPriceEntry(
   return null;
 }
 
-const CNY_THRESHOLDS: readonly number[] = [0, 500, 1500, 5000, 15000];
-const USD_THRESHOLDS: readonly number[] = [0, 150, 400, 800, 1500];
+export const CNY_THRESHOLDS: readonly number[] = [0, 500, 1500, 5000, 15000];
+export const USD_THRESHOLDS: readonly number[] = [0, 150, 400, 800, 1500];
 
 export function tierRange(
   tier: 1 | 2 | 3 | 4 | 5,

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -3,6 +3,7 @@ import gfxLensesData from "../data/lenses-g.json";
 import metaData from "../data/meta.json";
 import { lensCatalogSchema } from "./lens-schema";
 import type { Lens, LensCatalog, Mount, SpecialtyTag } from "./types";
+import { CNY_THRESHOLDS, USD_THRESHOLDS } from "./lens-pricing";
 export type { SpecialtyTag };
 
 export const xLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
@@ -264,22 +265,11 @@ export function sortLenses(
 }
 
 export function priceTier(price: number, currency: "CNY" | "USD"): 1 | 2 | 3 | 4 | 5 | undefined {
-  switch (currency) {
-    case "CNY":
-      if (price < 500)   return 1;
-      if (price < 1500)  return 2;
-      if (price < 5000)  return 3;
-      if (price < 15000) return 4;
-      return 5;
-    case "USD":
-      if (price < 150)  return 1;
-      if (price < 400)  return 2;
-      if (price < 800)  return 3;
-      if (price < 1500) return 4;
-      return 5;
-    default:
-      return undefined;
+  const thresholds = currency === "CNY" ? CNY_THRESHOLDS : USD_THRESHOLDS;
+  for (let i = thresholds.length - 1; i >= 0; i--) {
+    if (price >= thresholds[i]) return (i + 1) as 1 | 2 | 3 | 4 | 5;
   }
+  return undefined;
 }
 
 export function defaultMarketForLocale(locale: string): "cn" | "global" {


### PR DESCRIPTION
## Summary

- `CNY_THRESHOLDS` and `USD_THRESHOLDS` were defined as private constants in `lens-pricing.ts` and also embedded as literal numbers in `priceTier()` in `lens.ts`
- Exported the arrays from `lens-pricing.ts` and rewrote `priceTier()` to iterate them — eliminating the duplicate

## Test plan

- [ ] `npx tsc --noEmit` passes (already verified)
- [ ] Lens list page — price filter chips show correct tier labels
- [ ] Compare page — price tier badges display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)