### PR TITLE
refactor(routes): centralize route path construction in routes.ts

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from "next-intl/server";
 import { Flag } from "lucide-react";
 import { getLensesByMount, getLensUrl } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
+import { lensListPath } from "@/lib/routes";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens-spec-groups";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens-spec-groups";
@@ -222,7 +223,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     <>
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
       {/* Back button */}
-      <BackButton fallbackHref={`/lenses/${mount}`} />
+      <BackButton fallbackHref={lensListPath(mount)} />
 
       {/* Header: image + key info side by side */}
       <div className="flex flex-col sm:flex-row gap-8">

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { comparePath } from "@/lib/routes";
 
 export default async function CompareRedirect({
   params,
@@ -15,5 +16,5 @@ export default async function CompareRedirect({
   if (sp.lensId) qs.set("lensId", sp.lensId);
   if (sp.preset) qs.set("preset", sp.preset);
   const query = qs.toString();
-  redirect(`/${locale}/lenses/x/compare${query ? `?${query}` : ""}`);
+  redirect(`/${locale}${comparePath("x")}${query ? `?${query}` : ""}`);
 }

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { SITE } from "@/config/site";
+import { lensListPath, comparePath } from "@/lib/routes";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
@@ -30,14 +31,14 @@ export default function manifest(): MetadataRoute.Manifest {
         name: "Browse Lenses",
         short_name: "Browse",
         description: "Browse and filter all X Mount and G Mount lenses",
-        url: "/lenses/x",
+        url: lensListPath("x"),
         icons: [{ src: "/icons/icon-192.png", sizes: "192x192" }],
       },
       {
         name: "Compare Lenses",
         short_name: "Compare",
         description: "Compare lenses side by side",
-        url: "/lenses/x/compare",
+        url: comparePath("x"),
         icons: [{ src: "/icons/icon-192.png", sizes: "192x192" }],
       },
     ],

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import { SITE } from "@/config/site";
 import { routing } from "@/i18n/routing";
 import xLensesData from "@/data/lenses.json";
 import gfxLensesData from "@/data/lenses-g.json";
+import { lensListPath, comparePath, lensDetailPath } from "@/lib/routes";
 
 const LOCALES = routing.locales;
 
@@ -13,10 +14,10 @@ function url(path: string): string {
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPaths = [
     "/lenses",
-    "/lenses/x",
-    "/lenses/x/compare",
-    "/lenses/gfx",
-    "/lenses/gfx/compare",
+    lensListPath("x"),
+    comparePath("x"),
+    lensListPath("gfx"),
+    comparePath("gfx"),
     "/about",
     "/get",
   ];
@@ -37,7 +38,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const xLensEntries: MetadataRoute.Sitemap = (xLensesData as { id: string }[]).flatMap(
     (lens) =>
       LOCALES.map((locale) => ({
-        url: url(`/${locale}/lenses/x/${lens.id}`),
+        url: url(`/${locale}${lensDetailPath("x", lens.id)}`),
         changeFrequency: "monthly" as const,
         priority: 0.6,
       }))
@@ -46,7 +47,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const gfxLensEntries: MetadataRoute.Sitemap = (gfxLensesData as { id: string }[]).flatMap(
     (lens) =>
       LOCALES.map((locale) => ({
-        url: url(`/${locale}/lenses/gfx/${lens.id}`),
+        url: url(`/${locale}${lensDetailPath("gfx", lens.id)}`),
         changeFrequency: "monthly" as const,
         priority: 0.6,
       }))

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -7,6 +7,7 @@ import { getLensesByMount } from "@/lib/lens";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
+import { comparePath } from "@/lib/routes";
 import { motion, AnimatePresence } from "motion/react";
 import { spring } from "@/lib/animation";
 import { X } from "lucide-react";
@@ -65,7 +66,7 @@ export default function CompareBar() {
     const ids = selectedLenses.map((l) => l.id).join(",");
     const seg = mountToUrlSegment(mount);
     const fromParam = currentLensId ? `&from=lens&lensId=${currentLensId}` : "";
-    router.push(`/lenses/${seg}/compare?ids=${ids}${fromParam}`);
+    router.push(`${comparePath(seg)}?ids=${ids}${fromParam}`);
   }
 
   return (

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -9,6 +9,7 @@ import BackButton from "@/components/BackButton";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
+import { comparePath } from "@/lib/routes";
 import { useRouter } from "@/i18n/navigation";
 import type { Lens } from "@/lib/types";
 
@@ -51,7 +52,7 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
         {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
         {lenses.length > 0 && (
           <button
-            onClick={() => { clearCompare(); router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`); }}
+            onClick={() => { clearCompare(); router.replace(comparePath(mountToUrlSegment(mount))); }}
             className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
           >
             {tList("clearCompare")}

--- a/src/components/HomeCta.tsx
+++ b/src/components/HomeCta.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
+import { lensListPath, comparePath } from "@/lib/routes";
 
 export default function HomeCta() {
   const h = useTranslations("Home");
@@ -13,13 +14,13 @@ export default function HomeCta() {
   return (
     <>
       <Link
-        href={`/lenses/${seg}`}
+        href={lensListPath(seg)}
         className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 font-medium text-sm hover:opacity-90 transition-opacity"
       >
         {h("cta")} →
       </Link>
       <Link
-        href={`/lenses/${seg}/compare`}
+        href={comparePath(seg)}
         className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-medium text-sm hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
       >
         {h("ctaCompare")}

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Aperture, Plus, Check } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
+import { lensDetailPath } from "@/lib/routes";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
 import { ACTION_PRIMARY_CLS, CARD_SELECTED_BORDER_CLS } from "@/lib/ui-tokens";
 import type { Lens } from "@/lib/types";
@@ -77,7 +78,7 @@ export default function LensCard({
     >
       {/* Clickable detail area */}
       <Link
-        href={`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`}
+        href={lensDetailPath(mountToUrlSegment(lens.mount), lens.id)}
         className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors max-[499px]:flex-row"
       >
         <div

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { getLensesByMount } from "@/lib/lens";
 import { mountToUrlSegment } from "@/lib/mount";
+import { lensDetailPath } from "@/lib/routes";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens-search";
 import type { Lens } from "@/lib/types";
@@ -105,7 +106,7 @@ export default function LensSearchDialog({
       return;
     }
 
-    router.push(`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`);
+    router.push(lensDetailPath(mountToUrlSegment(lens.mount), lens.id));
   }
 
   function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "@/i18n/navigation";
 import { useMountParam, useEffectiveMount } from "@/hooks/useMountParam";
 import { useMountPreference } from "@/context/MountPreferenceProvider";
 import { mountToUrlSegment } from "@/lib/mount";
+import { lensListPath } from "@/lib/routes";
 import type { Mount } from "@/lib/types";
 
 
@@ -41,7 +42,7 @@ export default function MountSwitcher() {
     setPreference(mount);
     setOpen(false);
     if (urlMount !== null) {
-      router.push(`/lenses/${mountToUrlSegment(mount)}`);
+      router.push(lensListPath(mountToUrlSegment(mount)));
     }
   };
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,6 +9,7 @@ import { IRIS_NAV } from "@/config/iris-config";
 import { useCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
+import { lensListPath, comparePath } from "@/lib/routes";
 import { useNavLock } from "@/context/ScrollContainerContext";
 import { usePwa } from "@/lib/usePwa";
 import { cn } from "@/lib/utils";
@@ -69,10 +70,10 @@ export default function Nav() {
 
   const compareIds = compareState[effectiveMount];
   const seg = mountToUrlSegment(effectiveMount);
-  const browseHref = `/lenses/${seg}`;
+  const browseHref = lensListPath(seg);
   const compareHref = compareIds.length > 0
-    ? `/lenses/${seg}/compare?ids=${compareIds.join(",")}`
-    : `/lenses/${seg}/compare`;
+    ? `${comparePath(seg)}?ids=${compareIds.join(",")}`
+    : comparePath(seg);
 
   const linkCls = (active: boolean) =>
     `text-xs sm:text-sm transition-colors px-1.5 sm:px-2 ${

--- a/src/hooks/useCompareUrl.ts
+++ b/src/hooks/useCompareUrl.ts
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useLocale } from "next-intl";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
+import { comparePath } from "@/lib/routes";
 
 /**
  * Builds mount-aware compare page URLs while preserving back-navigation context
@@ -45,13 +46,13 @@ export function useCompareUrl() {
   function buildCompareUrl(ids: string[], extra?: { preset?: string }) {
     const seg = mountToUrlSegment(mount);
     const qs = buildQuery(ids, extra);
-    return qs ? `/lenses/${seg}/compare?${qs}` : `/lenses/${seg}/compare`;
+    return qs ? `${comparePath(seg)}?${qs}` : comparePath(seg);
   }
 
   function buildLocalizedCompareUrl(ids: string[], extra?: { preset?: string }) {
     const seg = mountToUrlSegment(mount);
     const qs = buildQuery(ids, extra);
-    const path = `/${locale}/lenses/${seg}/compare`;
+    const path = `/${locale}${comparePath(seg)}`;
     return qs ? `${path}?${qs}` : path;
   }
 

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,3 @@
+export const lensListPath = (seg: string) => `/lenses/${seg}`;
+export const comparePath = (seg: string) => `/lenses/${seg}/compare`;
+export const lensDetailPath = (seg: string, id: string) => `/lenses/${seg}/${id}`;


### PR DESCRIPTION
## Summary

- Route paths like `/lenses/x/compare` were assembled via template literals scattered across 12+ files with no shared definition
- Add `src/lib/routes.ts` with three path builder functions: `lensListPath`, `comparePath`, `lensDetailPath`
- Update all 12 call sites: `useCompareUrl`, `Nav`, `CompareBar`, `ComparePageHeader`, `HomeCta`, `LensCard`, `LensSearchDialog`, `MountSwitcher`, detail page, `sitemap`, `manifest`, compare redirect

## Test plan

- [ ] `npx tsc --noEmit` passes (already verified)
- [ ] Nav browse/compare links work
- [ ] LensCard links navigate to detail page
- [ ] CompareBar "Compare" button navigates correctly
- [ ] Sitemap and manifest URLs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)