### PR TITLE
refactor(tokens): adopt ui-tokens in LensSearchDialog, NotFound, ShareButton

### DIFF
--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,5 +1,7 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
 
 export default function NotFound() {
   const t = useTranslations("NotFound");
@@ -17,7 +19,7 @@ export default function NotFound() {
       </p>
       <Link
         href="/"
-        className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        className={cn(ACTION_PRIMARY_CLS, "mt-4 inline-flex items-center gap-1.5 rounded-full px-5 py-2.5 text-sm font-medium")}
       >
         {t("home")}
       </Link>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import FeedbackTrigger from "./FeedbackTrigger";
+import { LIST_ITEM_ACTIVE_CLS } from "@/lib/ui-tokens";
 
 interface LensSearchResultState {
   actionLabel?: string;
@@ -271,7 +272,7 @@ export default function LensSearchDialog({
                         isDisabled
                           ? "cursor-not-allowed border-transparent bg-zinc-50/80 opacity-60 dark:bg-zinc-900/60"
                           : isActive
-                            ? "border-zinc-200 bg-zinc-50/80 dark:border-zinc-700 dark:bg-zinc-800/50"
+                            ? LIST_ITEM_ACTIVE_CLS
                             : "border-transparent bg-white hover:bg-zinc-50 dark:bg-zinc-950 dark:hover:bg-zinc-900"
                       )}
                     >

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -497,7 +497,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
                   <button
                     onClick={handleShareImage}
                     disabled={posterGenerating}
-                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-800 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Share2 className="size-4" />}
                     {t("posterShare")}
@@ -515,7 +515,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
                 <button
                   onClick={handleDownload}
                   disabled={posterGenerating}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-800 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
                 >
                   {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
                   {t("posterDownload")}


### PR DESCRIPTION
## Summary

- `LensSearchDialog`: active search result row was duplicating `LIST_ITEM_ACTIVE_CLS` verbatim — replaced with token import
- `not-found.tsx`: 404 page home button was hand-rolling the primary button colors — replaced with `cn(ACTION_PRIMARY_CLS, ...)`
- `ShareButton`: two poster action buttons had `hover:bg-zinc-700` instead of `hover:bg-zinc-800` — aligned to token

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] LensSearchDialog: active/hovered search result has correct highlight
- [ ] 404 page: home button renders with correct primary button style
- [ ] ShareButton: poster share/download buttons hover color is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)