### PR TITLE
chore(lint): fix repository lint

### DIFF
--- a/e2e/compare.spec.ts
+++ b/e2e/compare.spec.ts
@@ -12,20 +12,15 @@ test.describe("Compare flow", () => {
   }) => {
     await page.goto("/en/lenses");
 
-    // Add first lens — "Add to Compare" buttons are inside each card footer
-    const firstAddBtn = page
-      .locator('a[href*="/en/lenses/"]:not([href="/en/lenses"])')
-      .first()
-      .locator("..")  // card root
-      .getByRole("button", { name: /Add to Compare/i });
-
     // Simpler: find all "Add to Compare" buttons and click the first two
     const addButtons = page.getByRole("button", { name: /Add to Compare/i });
     await addButtons.nth(0).click();
     await addButtons.nth(1).click();
 
     // Compare bar should now show "Compare (2)"
-    await expect(page.getByRole("button", { name: /Compare \(2\)/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Compare \(2\)/i })
+    ).toBeVisible();
   });
 
   test("compare bar button navigates to compare page", async ({ page }) => {
@@ -41,9 +36,7 @@ test.describe("Compare flow", () => {
   });
 
   test("compare page via URL shows both lens columns", async ({ page }) => {
-    await page.goto(
-      `/en/lenses/compare?ids=${LENS_A},${LENS_B}`
-    );
+    await page.goto(`/en/lenses/compare?ids=${LENS_A},${LENS_B}`);
 
     await expect(page.getByText(LENS_A_MODEL).first()).toBeVisible();
     await expect(page.getByText(LENS_B_MODEL).first()).toBeVisible();
@@ -57,19 +50,25 @@ test.describe("Compare flow", () => {
     await expect(page.locator("body")).toBeVisible();
   });
 
-  test("removing a lens from the compare bar decrements count", async ({ page }) => {
+  test("removing a lens from the compare bar decrements count", async ({
+    page,
+  }) => {
     await page.goto("/en/lenses");
 
     const addButtons = page.getByRole("button", { name: /Add to Compare/i });
     await addButtons.nth(0).click();
     await addButtons.nth(1).click();
-    await expect(page.getByRole("button", { name: /Compare \(2\)/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Compare \(2\)/i })
+    ).toBeVisible();
 
     // Click the X button on the first chip in the compare bar
     const removeBtn = page.getByRole("button", { name: /^Remove /i }).first();
     await removeBtn.click();
 
-    await expect(page.getByRole("button", { name: /Compare \(1\)/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Compare \(1\)/i })
+    ).toBeVisible();
   });
 
   test("clear compare button dismisses the compare bar", async ({ page }) => {
@@ -78,12 +77,16 @@ test.describe("Compare flow", () => {
     const addButtons = page.getByRole("button", { name: /Add to Compare/i });
     await addButtons.nth(0).click();
     await addButtons.nth(1).click();
-    await expect(page.getByRole("button", { name: /Compare \(2\)/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Compare \(2\)/i })
+    ).toBeVisible();
 
     await page.getByRole("button", { name: /Clear/i }).click();
 
     // Compare bar should disappear entirely
-    await expect(page.getByRole("button", { name: /Compare \(/i })).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Compare \(/i })
+    ).not.toBeVisible();
   });
 
   test("adding from detail page then navigating to compare includes that lens", async ({
@@ -117,8 +120,9 @@ test.describe("Compare flow", () => {
 
     // Hover the second column header to reveal the controls (they're
     // sm:opacity-0 sm:group-hover:opacity-100 by default on desktop).
-    const secondColumnRemove = page
-      .getByRole("button", { name: new RegExp(`Remove ${LENS_B_MODEL}`, "i") });
+    const secondColumnRemove = page.getByRole("button", {
+      name: new RegExp(`Remove ${LENS_B_MODEL}`, "i"),
+    });
     await secondColumnRemove.click();
 
     // After removal, LENS_B should no longer be in the table headers.

--- a/e2e/dynamic-ui.spec.ts
+++ b/e2e/dynamic-ui.spec.ts
@@ -6,7 +6,9 @@ const LENS_B = "fujifilm-mkx-50-135mmt29-x";
 /** Returns the current --compare-bar-height CSS variable value in pixels (0 if unset). */
 async function getCompareBarHeightVar(page: Page): Promise<number> {
   return page.evaluate(() => {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue("--compare-bar-height").trim();
+    const raw = getComputedStyle(document.documentElement)
+      .getPropertyValue("--compare-bar-height")
+      .trim();
     return parseFloat(raw) || 0;
   });
 }
@@ -25,7 +27,10 @@ async function scrollToTop(page: import("@playwright/test").Page) {
 }
 
 // Waits until the document has enough content height to allow scrolling.
-async function waitForScrollable(page: import("@playwright/test").Page, minDelta = 200) {
+async function waitForScrollable(
+  page: import("@playwright/test").Page,
+  minDelta = 200
+) {
   await page.waitForFunction(
     (minY) => document.documentElement.scrollHeight > window.innerHeight + minY,
     minDelta,
@@ -48,7 +53,9 @@ test.describe("Nav auto-hide (mobile only)", () => {
 
   test("nav is visible on page load", async ({ page }) => {
     const header = page.locator("header").first();
-    const isOnScreen = await header.evaluate((el) => el.getBoundingClientRect().bottom > 0);
+    const isOnScreen = await header.evaluate(
+      (el) => el.getBoundingClientRect().bottom > 0
+    );
     expect(isOnScreen).toBe(true);
   });
 
@@ -58,27 +65,39 @@ test.describe("Nav auto-hide (mobile only)", () => {
     // waiting for the 300ms CSS transition and is unaffected by Playwright's synthetic
     // scroll event timing in mobile emulation.
     const header = page.locator("header").first();
-    await expect(header).toHaveAttribute("data-hidden", "true", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "true", {
+      timeout: 3000,
+    });
   });
 
   test("nav reappears after scrolling back up", async ({ page }) => {
     const header = page.locator("header").first();
 
     await scrollBy(page, 300);
-    await expect(header).toHaveAttribute("data-hidden", "true", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "true", {
+      timeout: 3000,
+    });
 
     await scrollBy(page, -400);
-    await expect(header).toHaveAttribute("data-hidden", "false", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "false", {
+      timeout: 3000,
+    });
   });
 
-  test("nav resets to visible when navigating to a new page", async ({ page }) => {
+  test("nav resets to visible when navigating to a new page", async ({
+    page,
+  }) => {
     const header = page.locator("header").first();
 
     await scrollBy(page, 300);
-    await expect(header).toHaveAttribute("data-hidden", "true", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "true", {
+      timeout: 3000,
+    });
 
     await page.goto("/en/about");
-    await expect(header).toHaveAttribute("data-hidden", "false", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "false", {
+      timeout: 3000,
+    });
   });
 });
 
@@ -88,11 +107,15 @@ test.describe("Compare table phantom header", () => {
   // (via lockNav) so two top-chrome elements never compete on mobile.
   test.beforeEach(async ({ page }) => {
     await page.goto(`/en/lenses/compare?ids=${LENS_A},${LENS_B}`);
-    await page.locator('[data-testid="compare-phantom-header"]').waitFor({ state: "attached" });
+    await page
+      .locator('[data-testid="compare-phantom-header"]')
+      .waitFor({ state: "attached" });
     await waitForScrollable(page, 200);
   });
 
-  test("phantom header is hidden when at the top of the page", async ({ page }) => {
+  test("phantom header is hidden when at the top of the page", async ({
+    page,
+  }) => {
     const phantom = page.locator('[data-testid="compare-phantom-header"]');
     await expect(phantom).toHaveAttribute("data-visible", "false");
   });
@@ -102,20 +125,30 @@ test.describe("Compare table phantom header", () => {
   }) => {
     await scrollBy(page, 400);
     const phantom = page.locator('[data-testid="compare-phantom-header"]');
-    await expect(phantom).toHaveAttribute("data-visible", "true", { timeout: 3000 });
+    await expect(phantom).toHaveAttribute("data-visible", "true", {
+      timeout: 3000,
+    });
   });
 
-  test("phantom header hides again after scrolling back to top", async ({ page }) => {
+  test("phantom header hides again after scrolling back to top", async ({
+    page,
+  }) => {
     const phantom = page.locator('[data-testid="compare-phantom-header"]');
 
     await scrollBy(page, 400);
-    await expect(phantom).toHaveAttribute("data-visible", "true", { timeout: 3000 });
+    await expect(phantom).toHaveAttribute("data-visible", "true", {
+      timeout: 3000,
+    });
 
     await scrollToTop(page);
-    await expect(phantom).toHaveAttribute("data-visible", "false", { timeout: 3000 });
+    await expect(phantom).toHaveAttribute("data-visible", "false", {
+      timeout: 3000,
+    });
   });
 
-  test("nav is locked hidden while phantom header is visible", async ({ page }) => {
+  test("nav is locked hidden while phantom header is visible", async ({
+    page,
+  }) => {
     // On mobile, the phantom header locks the nav so they don't both occupy the top
     const viewport = page.viewportSize();
     if (!viewport || viewport.width >= 640) {
@@ -126,10 +159,14 @@ test.describe("Compare table phantom header", () => {
 
     await scrollBy(page, 400);
     const phantom = page.locator('[data-testid="compare-phantom-header"]');
-    await expect(phantom).toHaveAttribute("data-visible", "true", { timeout: 3000 });
+    await expect(phantom).toHaveAttribute("data-visible", "true", {
+      timeout: 3000,
+    });
 
     const header = page.locator("header").first();
-    await expect(header).toHaveAttribute("data-hidden", "true", { timeout: 3000 });
+    await expect(header).toHaveAttribute("data-hidden", "true", {
+      timeout: 3000,
+    });
   });
 });
 
@@ -137,7 +174,9 @@ test.describe("Compare page share FAB", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`/en/lenses/compare?ids=${LENS_A},${LENS_B}`);
     // Wait for the FAB to be rendered before any interaction
-    await page.locator('[data-testid="compare-share-fab"]').waitFor({ state: "attached" });
+    await page
+      .locator('[data-testid="compare-share-fab"]')
+      .waitFor({ state: "attached" });
   });
 
   test("FAB is hidden when header is in view", async ({ page }) => {
@@ -149,14 +188,18 @@ test.describe("Compare page share FAB", () => {
     await scrollBy(page, 300);
 
     const fab = page.locator('[data-testid="compare-share-fab"]');
-    await expect(fab).toHaveAttribute("aria-hidden", "false", { timeout: 3000 });
+    await expect(fab).toHaveAttribute("aria-hidden", "false", {
+      timeout: 3000,
+    });
   });
 
   test("FAB hides again after scrolling back to top", async ({ page }) => {
     // Show FAB
     await scrollBy(page, 300);
     const fab = page.locator('[data-testid="compare-share-fab"]');
-    await expect(fab).toHaveAttribute("aria-hidden", "false", { timeout: 3000 });
+    await expect(fab).toHaveAttribute("aria-hidden", "false", {
+      timeout: 3000,
+    });
 
     // Hide FAB by returning to top
     await scrollToTop(page);
@@ -178,7 +221,9 @@ test.describe("Lens list scroll-to-top button", () => {
     await expect(btn).toBeHidden();
   });
 
-  test("scroll-to-top button appears after scrolling down", async ({ page }) => {
+  test("scroll-to-top button appears after scrolling down", async ({
+    page,
+  }) => {
     await scrollBy(page, 500);
     const btn = page.getByRole("button", { name: /back to top/i });
     await expect(btn).toBeVisible({ timeout: 3000 });
@@ -213,16 +258,28 @@ test.describe("CompareBar --compare-bar-height CSS variable", () => {
     expect(height).toBe(0);
   });
 
-  test("variable becomes positive once compare bar appears", async ({ page }) => {
-    await page.getByRole("button", { name: /add to compare/i }).first().click();
-    await page.locator('[data-testid="compare-bar"]').waitFor({ state: "visible" });
+  test("variable becomes positive once compare bar appears", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: /add to compare/i })
+      .first()
+      .click();
+    await page
+      .locator('[data-testid="compare-bar"]')
+      .waitFor({ state: "visible" });
 
     const height = await getCompareBarHeightVar(page);
     expect(height).toBeGreaterThan(0);
   });
 
-  test("variable resets to 0 after compare bar is dismissed", async ({ page }) => {
-    await page.getByRole("button", { name: /add to compare/i }).first().click();
+  test("variable resets to 0 after compare bar is dismissed", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: /add to compare/i })
+      .first()
+      .click();
     const bar = page.locator('[data-testid="compare-bar"]');
     await bar.waitFor({ state: "visible" });
 
@@ -231,7 +288,9 @@ test.describe("CompareBar --compare-bar-height CSS variable", () => {
     await page.waitForFunction(
       () =>
         parseFloat(
-          getComputedStyle(document.documentElement).getPropertyValue("--compare-bar-height")
+          getComputedStyle(document.documentElement).getPropertyValue(
+            "--compare-bar-height"
+          )
         ) === 0,
       { timeout: 3000 }
     );
@@ -240,15 +299,24 @@ test.describe("CompareBar --compare-bar-height CSS variable", () => {
     expect(height).toBe(0);
   });
 
-  test("variable accurately reflects the bar's rendered height", async ({ page }) => {
-    await page.getByRole("button", { name: /add to compare/i }).first().click();
+  test("variable accurately reflects the bar's rendered height", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: /add to compare/i })
+      .first()
+      .click();
     const bar = page.locator('[data-testid="compare-bar"]');
     await bar.waitFor({ state: "visible" });
 
     const [cssVar, domHeight] = await page.evaluate(() => {
-      const el = document.querySelector('[data-testid="compare-bar"]') as HTMLElement;
+      const el = document.querySelector(
+        '[data-testid="compare-bar"]'
+      ) as HTMLElement;
       const varVal = parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue("--compare-bar-height")
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--compare-bar-height"
+        )
       );
       return [varVal, el.getBoundingClientRect().height];
     });
@@ -259,14 +327,21 @@ test.describe("CompareBar --compare-bar-height CSS variable", () => {
 });
 
 test.describe("CompareBar does not obscure BackToTopButton or page content", () => {
-  test("BackToTopButton bottom edge stays above CompareBar when both visible", async ({ page }) => {
+  test("BackToTopButton bottom edge stays above CompareBar when both visible", async ({
+    page,
+  }) => {
     await page.goto("/en/lenses");
     await page.waitForLoadState("networkidle");
     await waitForScrollable(page, 200);
 
     // Trigger compare bar
-    await page.getByRole("button", { name: /add to compare/i }).first().click();
-    await page.locator('[data-testid="compare-bar"]').waitFor({ state: "visible" });
+    await page
+      .getByRole("button", { name: /add to compare/i })
+      .first()
+      .click();
+    await page
+      .locator('[data-testid="compare-bar"]')
+      .waitFor({ state: "visible" });
 
     // Scroll enough to reveal the BackToTopButton (threshold: 400px)
     await scrollBy(page, 500);
@@ -274,14 +349,19 @@ test.describe("CompareBar does not obscure BackToTopButton or page content", () 
     await expect(btn).toBeVisible({ timeout: 3000 });
 
     const [btnBottom, barTop] = await page.evaluate(() => {
-      const button = document.querySelector('[aria-label]') as Element;
       // Find the back-to-top button via aria-label text (locale-agnostic: any button near bottom-right)
-      const allBtns = Array.from(document.querySelectorAll("button[aria-label]"));
+      const allBtns = Array.from(
+        document.querySelectorAll("button[aria-label]")
+      );
       const backTop = allBtns.find((b) =>
         (b.getAttribute("aria-label") ?? "").toLowerCase().includes("top")
       );
-      const bar = document.querySelector('[data-testid="compare-bar"]') as HTMLElement;
-      if (!backTop || !bar) throw new Error("Elements not found");
+      const bar = document.querySelector(
+        '[data-testid="compare-bar"]'
+      ) as HTMLElement;
+      if (!backTop || !bar) {
+        throw new Error("Elements not found");
+      }
       return [
         backTop.getBoundingClientRect().bottom,
         bar.getBoundingClientRect().top,
@@ -291,12 +371,19 @@ test.describe("CompareBar does not obscure BackToTopButton or page content", () 
     expect(btnBottom).toBeLessThanOrEqual(barTop + 1); // +1 for sub-pixel tolerance
   });
 
-  test("lens list content padding-bottom exceeds compare bar height", async ({ page }) => {
+  test("lens list content padding-bottom exceeds compare bar height", async ({
+    page,
+  }) => {
     await page.goto("/en/lenses");
     await page.waitForLoadState("networkidle");
 
-    await page.getByRole("button", { name: /add to compare/i }).first().click();
-    await page.locator('[data-testid="compare-bar"]').waitFor({ state: "visible" });
+    await page
+      .getByRole("button", { name: /add to compare/i })
+      .first()
+      .click();
+    await page
+      .locator('[data-testid="compare-bar"]')
+      .waitFor({ state: "visible" });
 
     const barHeight = await getCompareBarHeightVar(page);
 
@@ -305,25 +392,33 @@ test.describe("CompareBar does not obscure BackToTopButton or page content", () 
     const paddingBottom = await page.evaluate(() => {
       // The lens list wrapper is the first div.max-w-7xl inside the page body
       const el = document.querySelector(".max-w-7xl") as HTMLElement;
-      if (!el) throw new Error("Lens list container not found");
+      if (!el) {
+        throw new Error("Lens list container not found");
+      }
       return parseFloat(getComputedStyle(el).paddingBottom);
     });
 
     expect(paddingBottom).toBeGreaterThan(barHeight);
   });
 
-  test("lens detail content padding-bottom exceeds compare bar height", async ({ page }) => {
+  test("lens detail content padding-bottom exceeds compare bar height", async ({
+    page,
+  }) => {
     await page.goto(`/en/lenses/${LENS_A}`);
     await page.waitForLoadState("networkidle");
 
     await page.getByRole("button", { name: /add to compare/i }).click();
-    await page.locator('[data-testid="compare-bar"]').waitFor({ state: "visible" });
+    await page
+      .locator('[data-testid="compare-bar"]')
+      .waitFor({ state: "visible" });
 
     const barHeight = await getCompareBarHeightVar(page);
 
     const paddingBottom = await page.evaluate(() => {
       const el = document.querySelector(".max-w-4xl") as HTMLElement;
-      if (!el) throw new Error("Lens detail container not found");
+      if (!el) {
+        throw new Error("Lens detail container not found");
+      }
       return parseFloat(getComputedStyle(el).paddingBottom);
     });
 

--- a/e2e/iris.spec.ts
+++ b/e2e/iris.spec.ts
@@ -30,7 +30,9 @@ const ANIMATION_SETTLE_MS = 3000;
 async function getIrisFStop(page: Page): Promise<number> {
   return page.evaluate(() => {
     const el = document.querySelector('[data-testid="iris"]');
-    if (!el) throw new Error("Iris element not found");
+    if (!el) {
+      throw new Error("Iris element not found");
+    }
     return parseFloat(el.getAttribute("data-fstop") ?? "NaN");
   });
 }
@@ -39,7 +41,9 @@ async function getIrisFStop(page: Page): Promise<number> {
 async function getIrisAnimating(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     const el = document.querySelector('[data-testid="iris"]');
-    if (!el) throw new Error("Iris element not found");
+    if (!el) {
+      throw new Error("Iris element not found");
+    }
     return el.getAttribute("data-animating") === "true";
   });
 }
@@ -56,16 +60,24 @@ test.describe("Hero Iris mount animation", () => {
     // The mount animation fires immediately — data-animating should be true
     // before totalMs (1500 ms) has elapsed. We check within the first second.
     const animating = await page.waitForFunction(
-      () => document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "true",
+      () =>
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "true",
       { timeout: 1000 }
     );
     expect(animating).toBeTruthy();
   });
 
-  test("iris returns to defaultFStop (f/4) after animation completes", async ({ page }) => {
+  test("iris returns to defaultFStop (f/4) after animation completes", async ({
+    page,
+  }) => {
     // Wait for animation to finish — data-animating transitions to "false".
     await page.waitForFunction(
-      () => document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "false",
+      () =>
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "false",
       { timeout: ANIMATION_SETTLE_MS }
     );
 
@@ -87,7 +99,9 @@ test.describe("Hero Iris mount animation", () => {
     // (when theta momentarily equalled thetaMax), leaving the iris at f/22.
     await page.waitForFunction(
       () =>
-        document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "false",
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "false",
       { timeout: ANIMATION_SETTLE_MS }
     );
     await page.waitForTimeout(300);
@@ -105,7 +119,9 @@ test.describe("Hero Iris mount animation", () => {
     // If the iris gets stuck or flickers, this sequence would be violated.
     await page.waitForFunction(
       () =>
-        document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "false",
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "false",
       { timeout: ANIMATION_SETTLE_MS }
     );
     // After settling, it must not re-enter animating state spontaneously.
@@ -123,27 +139,35 @@ test.describe("Hero Iris tap animation", () => {
     // Let the mount animation finish before testing tap.
     await page.waitForFunction(
       () =>
-        document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "false",
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "false",
       { timeout: ANIMATION_SETTLE_MS }
     );
     await page.waitForTimeout(300);
   });
 
-  test("tapping iris restarts animation and returns to defaultFStop", async ({ page }) => {
+  test("tapping iris restarts animation and returns to defaultFStop", async ({
+    page,
+  }) => {
     const iris = page.locator('[data-testid="iris"]');
     await iris.click();
 
     // Animation should start
     await page.waitForFunction(
       () =>
-        document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "true",
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "true",
       { timeout: 1000 }
     );
 
     // And must finish at defaultFStop, not stuck at f/22
     await page.waitForFunction(
       () =>
-        document.querySelector('[data-testid="iris"]')?.getAttribute("data-animating") === "false",
+        document
+          .querySelector('[data-testid="iris"]')
+          ?.getAttribute("data-animating") === "false",
       { timeout: ANIMATION_SETTLE_MS }
     );
     await page.waitForTimeout(300);

--- a/e2e/pwa-safe-area.spec.ts
+++ b/e2e/pwa-safe-area.spec.ts
@@ -31,11 +31,17 @@ async function simulateNotch(page: Page) {
 }
 
 /** Returns the computed numeric value (px) of a CSS property for a selector. */
-async function computedPx(page: Page, selector: string, property: string): Promise<number> {
+async function computedPx(
+  page: Page,
+  selector: string,
+  property: string
+): Promise<number> {
   return page.evaluate(
     ([sel, prop]) => {
       const el = document.querySelector(sel as string);
-      if (!el) throw new Error(`Element not found: ${sel}`);
+      if (!el) {
+        throw new Error(`Element not found: ${sel}`);
+      }
       return parseFloat(getComputedStyle(el).getPropertyValue(prop as string));
     },
     [selector, property]
@@ -54,13 +60,14 @@ test.describe("Nav top inset", () => {
     await simulateNotch(page);
   });
 
-  test("nav paddingTop equals --safe-inset-top when --titlebar-height is 0", async ({ page }) => {
+  test("nav paddingTop equals --safe-inset-top when --titlebar-height is 0", async ({
+    page,
+  }) => {
     // In a standalone PWA on iPhone there is no WCO, so --titlebar-height stays 0.
     // paddingTop should therefore equal exactly NOTCH_TOP.
     const paddingTop = await computedPx(page, "header", "padding-top");
     expect(paddingTop).toBe(NOTCH_TOP);
   });
-
 });
 
 // ─── Compare page phantom header ────────────────────────────────────────────
@@ -68,14 +75,22 @@ test.describe("Nav top inset", () => {
 test.describe("Compare phantom header top inset", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`/en/lenses/compare?ids=${LENS_A},${LENS_B}`);
-    await page.locator('[data-testid="compare-phantom-header"]').waitFor({ state: "attached" });
+    await page
+      .locator('[data-testid="compare-phantom-header"]')
+      .waitFor({ state: "attached" });
     await simulateNotch(page);
   });
 
-  test("sticky container top equals --safe-inset-top on mobile viewport", async ({ page }) => {
+  test("sticky container top equals --safe-inset-top on mobile viewport", async ({
+    page,
+  }) => {
     // On mobile (< 640px) the container uses top-[var(--safe-inset-top)].
     // Confirm the computed top matches our injected value.
-    const top = await computedPx(page, '[data-testid="compare-phantom-container"]', "top");
+    const top = await computedPx(
+      page,
+      '[data-testid="compare-phantom-container"]',
+      "top"
+    );
     expect(top).toBe(NOTCH_TOP);
   });
 });
@@ -89,17 +104,25 @@ test.describe("CompareBar bottom inset", () => {
     await simulateNotch(page);
   });
 
-  test("compare bar paddingBottom equals --safe-inset-bottom", async ({ page }) => {
+  test("compare bar paddingBottom equals --safe-inset-bottom", async ({
+    page,
+  }) => {
     // iPhone 15 viewport is 390px < 499px, so the icon button (max-[499px]:flex)
     // is visible. Use its aria-label to trigger the compare bar.
-    const addBtn = page.getByRole("button", { name: /add to compare/i }).first();
+    const addBtn = page
+      .getByRole("button", { name: /add to compare/i })
+      .first();
     await addBtn.waitFor({ state: "visible" });
     await addBtn.click();
 
     const bar = page.locator('[data-testid="compare-bar"]');
     await bar.waitFor({ state: "attached" });
 
-    const paddingBottom = await computedPx(page, '[data-testid="compare-bar"]', "padding-bottom");
+    const paddingBottom = await computedPx(
+      page,
+      '[data-testid="compare-bar"]',
+      "padding-bottom"
+    );
     expect(paddingBottom).toBe(HOME_BAR);
   });
 });
@@ -113,13 +136,17 @@ test.describe("Layout body bottom inset", () => {
     await simulateNotch(page);
   });
 
-  test("page body wrapper paddingBottom equals --safe-inset-bottom", async ({ page }) => {
+  test("page body wrapper paddingBottom equals --safe-inset-bottom", async ({
+    page,
+  }) => {
     // The main layout div uses pb-[var(--safe-inset-bottom)] to push content
     // above the iOS home indicator bar.
     const paddingBottom = await page.evaluate(() => {
       // The layout wrapper sits directly under <body> — find by nav-height pt class
       const el = document.querySelector(".pt-\\[var\\(--nav-height\\)\\]");
-      if (!el) throw new Error("Layout wrapper not found");
+      if (!el) {
+        throw new Error("Layout wrapper not found");
+      }
       return parseFloat(getComputedStyle(el).paddingBottom);
     });
     expect(paddingBottom).toBe(HOME_BAR);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "validate:lenses": "node --experimental-strip-types scripts/validate-lenses.mts",
     "build": "npm run gen:icons && npm run verify:icons && npm run validate:lenses && next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint --fix && git diff --name-only --diff-filter=ACMR | xargs prettier --write --ignore-unknown && eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,12 @@
 // X-Glass Service Worker
 // Bump CACHE_VERSION whenever the caching logic changes to force all clients to
 // pick up the new worker and discard stale caches.
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = "v2";
 
 const CACHE = {
-  shell:  `x-glass-shell-${CACHE_VERSION}`,   // offline page + navigation
-  static: `x-glass-static-${CACHE_VERSION}`,  // _next/static/** (hashed, permanent)
-  images: `x-glass-images-${CACHE_VERSION}`,  // /lenses/** lens photos
+  shell: `x-glass-shell-${CACHE_VERSION}`, // offline page + navigation
+  static: `x-glass-static-${CACHE_VERSION}`, // _next/static/** (hashed, permanent)
+  images: `x-glass-images-${CACHE_VERSION}`, // /lenses/** lens photos
 };
 
 const ALL_CACHES = Object.values(CACHE);
@@ -14,14 +14,14 @@ const ALL_CACHES = Object.values(CACHE);
 // Pages to pre-cache on install so they're available offline immediately.
 // Including the locale home pages means the app works even on the very first
 // offline launch, before the user has browsed any pages while online.
-const PRECACHE_URLS = ['/offline', '/en/', '/zh/'];
+const PRECACHE_URLS = ["/offline", "/en/", "/zh/"];
 
 // How long (seconds) lens images stay in the cache before a background refresh.
 const IMAGE_TTL_S = 30 * 24 * 60 * 60; // 30 days
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────────
 
-self.addEventListener('install', (event) => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(CACHE.shell)
@@ -33,7 +33,7 @@ self.addEventListener('install', (event) => {
   );
 });
 
-self.addEventListener('activate', (event) => {
+self.addEventListener("activate", (event) => {
   // Delete caches from previous versions.
   event.waitUntil(
     caches
@@ -52,35 +52,39 @@ self.addEventListener('activate', (event) => {
 
 // ── Fetch routing ─────────────────────────────────────────────────────────────
 
-self.addEventListener('fetch', (event) => {
+self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
   // Only handle same-origin GET requests.
-  if (request.method !== 'GET' || url.origin !== self.location.origin) return;
+  if (request.method !== "GET" || url.origin !== self.location.origin) {
+    return;
+  }
 
   // Skip API routes entirely — always go to the network.
-  if (url.pathname.startsWith('/api/')) return;
+  if (url.pathname.startsWith("/api/")) {
+    return;
+  }
 
   // _next/static — content-hashed files, safe to cache forever.
-  if (url.pathname.startsWith('/_next/static/')) {
+  if (url.pathname.startsWith("/_next/static/")) {
     event.respondWith(cacheFirst(request, CACHE.static));
     return;
   }
 
   // Lens photos, PWA icons, and splash screens — cache first, refresh after TTL.
   if (
-    url.pathname.startsWith('/lenses/') ||
-    url.pathname.startsWith('/icons/') ||
-    url.pathname.startsWith('/screenshots/') ||
-    url.pathname.startsWith('/splash/')
+    url.pathname.startsWith("/lenses/") ||
+    url.pathname.startsWith("/icons/") ||
+    url.pathname.startsWith("/screenshots/") ||
+    url.pathname.startsWith("/splash/")
   ) {
     event.respondWith(cacheFirst(request, CACHE.images, IMAGE_TTL_S));
     return;
   }
 
   // HTML navigation — network first, fall back to cached page or /offline.
-  if (request.mode === 'navigate') {
+  if (request.mode === "navigate") {
     event.respondWith(networkFirstWithOfflineFallback(request));
     return;
   }
@@ -101,7 +105,7 @@ async function cacheFirst(request, cacheName, maxAgeSeconds) {
 
   if (cached) {
     if (maxAgeSeconds) {
-      const date = cached.headers.get('date');
+      const date = cached.headers.get("date");
       const ageSeconds = date
         ? (Date.now() - new Date(date).getTime()) / 1000
         : 0;
@@ -124,7 +128,7 @@ async function networkFirst(request) {
     return await fetch(request);
   } catch {
     const cached = await caches.match(request);
-    return cached ?? new Response('Network error', { status: 503 });
+    return cached ?? new Response("Network error", { status: 503 });
   }
 }
 
@@ -136,20 +140,29 @@ async function networkFirstWithOfflineFallback(request) {
   const cache = await caches.open(CACHE.shell);
   try {
     const response = await fetch(request);
-    if (response.ok) cache.put(request, response.clone());
+    if (response.ok) {
+      cache.put(request, response.clone());
+    }
     return response;
   } catch {
     const cached = await cache.match(request);
-    if (cached) return cached;
+    if (cached) {
+      return cached;
+    }
     // When the PWA is launched via the home screen icon (start_url = '/'), the
     // locale middleware can't run offline so there's no cached entry for '/'.
     // Fall back to the precached English home page so the app is usable.
     const url = new URL(request.url);
-    if (url.pathname === '/') {
-      const home = await cache.match('/en/');
-      if (home) return home;
+    if (url.pathname === "/") {
+      const home = await cache.match("/en/");
+      if (home) {
+        return home;
+      }
     }
-    return (await cache.match('/offline')) ?? new Response('Offline', { status: 503 });
+    return (
+      (await cache.match("/offline")) ??
+      new Response("Offline", { status: 503 })
+    );
   }
 }
 
@@ -159,6 +172,8 @@ async function networkFirstWithOfflineFallback(request) {
  */
 async function fetchAndStore(request, cache) {
   const response = await fetch(request);
-  if (response.ok) cache.put(request, response.clone());
+  if (response.ok) {
+    cache.put(request, response.clone());
+  }
   return response;
 }

--- a/scripts/gen-icons.tsx
+++ b/scripts/gen-icons.tsx
@@ -11,8 +11,17 @@ import { resolve, join, dirname } from "node:path";
 import { Resvg, type ResvgRenderOptions } from "@resvg/resvg-js";
 
 import Iris from "../src/components/Iris.tsx";
-import { IRIS_NAV, R_HOUSING, type IrisConfig } from "../src/config/iris-config.ts";
-import { SPLASH_DEVICES, SPLASH_BG, splashUrl, type SplashScheme } from "../src/config/splash.ts";
+import {
+  IRIS_NAV,
+  R_HOUSING,
+  type IrisConfig,
+} from "../src/config/iris-config.ts";
+import {
+  SPLASH_DEVICES,
+  SPLASH_BG,
+  splashUrl,
+  type SplashScheme,
+} from "../src/config/splash.ts";
 import { buildDerivedConfig } from "../src/lib/iris-kinematics.ts";
 
 // ── Font resolution ───────────────────────────────────────────────────────────
@@ -24,15 +33,25 @@ function resolvePackageFile(pkg: string, relPath: string): string {
   let dir = process.cwd();
   while (true) {
     const candidate = join(dir, "node_modules", pkg, relPath);
-    if (existsSync(candidate)) return candidate;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
     const parent = dirname(dir);
-    if (parent === dir) throw new Error(`Cannot find ${pkg}/${relPath} in any node_modules`);
+    if (parent === dir) {
+      throw new Error(`Cannot find ${pkg}/${relPath} in any node_modules`);
+    }
     dir = parent;
   }
 }
 
-const geistBoldPath    = resolvePackageFile("geist", "dist/fonts/geist-sans/Geist-Bold.ttf");
-const geistRegularPath = resolvePackageFile("geist", "dist/fonts/geist-sans/Geist-Regular.ttf");
+const geistBoldPath = resolvePackageFile(
+  "geist",
+  "dist/fonts/geist-sans/Geist-Bold.ttf"
+);
+const geistRegularPath = resolvePackageFile(
+  "geist",
+  "dist/fonts/geist-sans/Geist-Regular.ttf"
+);
 
 // ── ViewBox computation ───────────────────────────────────────────────────────
 //
@@ -62,11 +81,11 @@ const tightViewBox = `viewBox="${-vbHalf} ${-vbHalf} ${vbHalf * 2} ${vbHalf * 2}
 const PADDING = {
   // favicon: maximise fill for small sizes (32px tab icon) where breathing
   // room is imperceptible and the icon must compete with other tab favicons.
-  favicon:  0.05,   // → ~90% fill
+  favicon: 0.05, // → ~90% fill
   // standard: comfortable breathing room for large transparent-bg PWA icons.
-  standard: 0.175,  // → ~65% fill
+  standard: 0.175, // → ~65% fill
   // maskable: keeps the mark inside Android's safe zone (inner 80% circle).
-  maskable: 0.225,  // → ~55% fill
+  maskable: 0.225, // → ~55% fill
 } as const;
 
 function padR(padding: number): number {
@@ -86,7 +105,9 @@ function irisToSvg(size: number, padding: number, background?: string): string {
     createElement(Iris, { config: IRIS_NAV, uid: "gen", size })
   );
   const match = html.match(/<svg[\s\S]*<\/svg>/);
-  if (!match) throw new Error("gen-icons: no <svg> found in rendered Iris output");
+  if (!match) {
+    throw new Error("gen-icons: no <svg> found in rendered Iris output");
+  }
   let result = match[0]
     .replace("<svg ", `<svg xmlns="http://www.w3.org/2000/svg" `)
     .replace(tightViewBox, paddedViewBox(padding));
@@ -103,8 +124,15 @@ function irisToSvg(size: number, padding: number, background?: string): string {
   return result;
 }
 
-function svgToPng(svg: string, size: number, opts?: ResvgRenderOptions): Buffer {
-  const resvg = new Resvg(svg, { fitTo: { mode: "width", value: size }, ...opts });
+function svgToPng(
+  svg: string,
+  size: number,
+  opts?: ResvgRenderOptions
+): Buffer {
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: "width", value: size },
+    ...opts,
+  });
   return Buffer.from(resvg.render().asPng());
 }
 
@@ -119,51 +147,55 @@ function irisEmbedSvg(
   size: number,
   padding: number,
   config: IrisConfig = IRIS_NAV,
-  uid = "og",
+  uid = "og"
 ): string {
-  const html = renderToStaticMarkup(
-    createElement(Iris, { config, uid, size })
-  );
+  const html = renderToStaticMarkup(createElement(Iris, { config, uid, size }));
   const match = html.match(/<svg[\s\S]*<\/svg>/);
-  if (!match) throw new Error("gen-icons: no <svg> found in Iris render");
+  if (!match) {
+    throw new Error("gen-icons: no <svg> found in Iris render");
+  }
   return match[0]
-    .replace("<svg ", `<svg xmlns="http://www.w3.org/2000/svg" x="${x}" y="${y}" `)
+    .replace(
+      "<svg ",
+      `<svg xmlns="http://www.w3.org/2000/svg" x="${x}" y="${y}" `
+    )
     .replace(tightViewBox, paddedViewBox(padding));
 }
 
 // Iris config with inverted colours for dark-background splash screens.
 const IRIS_NAV_DARK: IrisConfig = {
   ...IRIS_NAV,
-  bladeColor:  "#e8e8e8",
+  bladeColor: "#e8e8e8",
   strokeColor: "#0a0a0a",
 };
 
 function generateOgSvg(): string {
-  const canvasW = 1200, canvasH = 630;
+  const canvasW = 1200,
+    canvasH = 630;
   const irisSize = 380;
   const irisX = 80;
-  const irisY = Math.round((canvasH - irisSize) / 2);   // 125
+  const irisY = Math.round((canvasH - irisSize) / 2); // 125
 
-  const dividerX  = irisX + irisSize + 48;              // 508
-  const dividerH  = 200;
+  const dividerX = irisX + irisSize + 48; // 508
+  const dividerH = 200;
   const dividerY1 = Math.round((canvasH - dividerH) / 2); // 215
-  const dividerY2 = dividerY1 + dividerH;                  // 415
+  const dividerY2 = dividerY1 + dividerH; // 415
 
-  const textX = dividerX + 1 + 52;                      // 561
+  const textX = dividerX + 1 + 52; // 561
 
   // SVG text y = baseline. Block layout mirrors the original flex column:
   //   title (96px, lineHeight 1) + 24px gap + subtitle (26px, lineHeight 1)
   // Ascent ≈ 80 % of font-size for Geist.
-  const titleSize    = 96;
+  const titleSize = 96;
   const subtitleSize = 26;
-  const blockH    = titleSize + 24 + subtitleSize;
-  const blockTop  = Math.round((canvasH - blockH) / 2); // 242
-  const titleY    = blockTop + Math.round(titleSize    * 0.80); // ~319
-  const subtitleY = blockTop + titleSize + 24 + Math.round(subtitleSize * 0.80); // ~383
+  const blockH = titleSize + 24 + subtitleSize;
+  const blockTop = Math.round((canvasH - blockH) / 2); // 242
+  const titleY = blockTop + Math.round(titleSize * 0.8); // ~319
+  const subtitleY = blockTop + titleSize + 24 + Math.round(subtitleSize * 0.8); // ~383
 
   // letter-spacing in SVG is in absolute units (px-equivalent), not em.
-  const titleLS    = (-0.02 * titleSize).toFixed(2);    // -1.92
-  const subtitleLS = ( 0.12 * subtitleSize).toFixed(2); //  3.12
+  const titleLS = (-0.02 * titleSize).toFixed(2); // -1.92
+  const subtitleLS = (0.12 * subtitleSize).toFixed(2); //  3.12
 
   const irisSvg = irisEmbedSvg(irisX, irisY, irisSize, PADDING.standard);
 
@@ -196,12 +228,12 @@ function buildIco(images: Array<{ size: number; png: Buffer }>): Buffer {
     const entry = Buffer.alloc(dirEntrySize);
     entry.writeUInt8(size >= 256 ? 0 : size, 0); // width  (0 = 256)
     entry.writeUInt8(size >= 256 ? 0 : size, 1); // height (0 = 256)
-    entry.writeUInt8(0, 2);                       // colour palette
-    entry.writeUInt8(0, 3);                       // reserved
-    entry.writeUInt16LE(1, 4);                    // colour planes
-    entry.writeUInt16LE(32, 6);                   // bits per pixel
-    entry.writeUInt32LE(png.length, 8);           // data size
-    entry.writeUInt32LE(dataOffset, 12);          // data offset
+    entry.writeUInt8(0, 2); // colour palette
+    entry.writeUInt8(0, 3); // reserved
+    entry.writeUInt16LE(1, 4); // colour planes
+    entry.writeUInt16LE(32, 6); // bits per pixel
+    entry.writeUInt32LE(png.length, 8); // data size
+    entry.writeUInt32LE(dataOffset, 12); // data offset
     dirEntries.push(entry);
     dataOffset += png.length;
   }
@@ -211,7 +243,7 @@ function buildIco(images: Array<{ size: number; png: Buffer }>): Buffer {
 
 // ── Output definitions ────────────────────────────────────────────────────────
 
-const appDir  = resolve("src/app");
+const appDir = resolve("src/app");
 const iconsDir = resolve("public/icons");
 mkdirSync(iconsDir, { recursive: true });
 
@@ -222,23 +254,46 @@ const outputs: Array<{
   background?: string;
 }> = [
   // Next.js file-convention icon (browser tab favicon)
-  { path: `${appDir}/icon.png`,        size: 32,  padding: PADDING.favicon   },
+  { path: `${appDir}/icon.png`, size: 32, padding: PADDING.favicon },
   // PWA manifest icons — maskable (Android safe zone)
-  { path: `${iconsDir}/icon-maskable-192.png`,  size: 192,  padding: PADDING.maskable },
-  { path: `${iconsDir}/icon-maskable-512.png`,  size: 512,  padding: PADDING.maskable },
+  {
+    path: `${iconsDir}/icon-maskable-192.png`,
+    size: 192,
+    padding: PADDING.maskable,
+  },
+  {
+    path: `${iconsDir}/icon-maskable-512.png`,
+    size: 512,
+    padding: PADDING.maskable,
+  },
   // PWA manifest icons — transparent background (purpose: "any").
   // Chrome renders these as-is in the omnibox install chip, the Mac dock, and
   // the Windows taskbar. A transparent canvas lets the host UI chrome (e.g.
   // Chrome's gray pill) show through, matching how native-feeling PWAs look.
-  { path: `${iconsDir}/icon-192.png`,   size: 192,  padding: PADDING.standard },
-  { path: `${iconsDir}/icon-512.png`,   size: 512,  padding: PADDING.standard },
-  { path: `${iconsDir}/icon-1024.png`,  size: 1024, padding: PADDING.standard },
+  { path: `${iconsDir}/icon-192.png`, size: 192, padding: PADDING.standard },
+  { path: `${iconsDir}/icon-512.png`, size: 512, padding: PADDING.standard },
+  { path: `${iconsDir}/icon-1024.png`, size: 1024, padding: PADDING.standard },
   // Opaque white-background variants — iOS apple-touch-icon only. iOS fills
   // transparent pixels with an uncontrolled color (often black), so the
   // apple-touch-icon must ship a solid background baked into the PNG.
-  { path: `${iconsDir}/icon-192-white.png`,   size: 192,  padding: PADDING.standard, background: "white" },
-  { path: `${iconsDir}/icon-512-white.png`,   size: 512,  padding: PADDING.standard, background: "white" },
-  { path: `${iconsDir}/icon-1024-white.png`,  size: 1024, padding: PADDING.standard, background: "white" },
+  {
+    path: `${iconsDir}/icon-192-white.png`,
+    size: 192,
+    padding: PADDING.standard,
+    background: "white",
+  },
+  {
+    path: `${iconsDir}/icon-512-white.png`,
+    size: 512,
+    padding: PADDING.standard,
+    background: "white",
+  },
+  {
+    path: `${iconsDir}/icon-1024-white.png`,
+    size: 1024,
+    padding: PADDING.standard,
+    background: "white",
+  },
 ];
 
 for (const { path, size, padding, background } of outputs) {
@@ -269,7 +324,10 @@ const ogFontOpts: ResvgRenderOptions = {
     loadSystemFonts: false,
   },
 };
-writeFileSync(resolve("public/opengraph-image.png"), svgToPng(generateOgSvg(), 1200, ogFontOpts));
+writeFileSync(
+  resolve("public/opengraph-image.png"),
+  svgToPng(generateOgSvg(), 1200, ogFontOpts)
+);
 console.log(`✓ public/opengraph-image.png (1200×630)`);
 
 // ── iOS PWA splash screens ────────────────────────────────────────────────────
@@ -280,12 +338,16 @@ console.log(`✓ public/opengraph-image.png (1200×630)`);
 // from the top (slightly above centre — matches the iOS native aesthetic).
 // Icon size: 28 % of the shorter dimension so it reads well on all screen sizes.
 
-function generateSplashSvg(canvasW: number, canvasH: number, scheme: SplashScheme): string {
-  const bg     = SPLASH_BG[scheme];
+function generateSplashSvg(
+  canvasW: number,
+  canvasH: number,
+  scheme: SplashScheme
+): string {
+  const bg = SPLASH_BG[scheme];
   const config = scheme === "dark" ? IRIS_NAV_DARK : IRIS_NAV;
   const iconSize = Math.round(Math.min(canvasW, canvasH) * 0.28);
   const x = Math.round((canvasW - iconSize) / 2);
-  const y = Math.round(canvasH * 0.40 - iconSize / 2);
+  const y = Math.round(canvasH * 0.4 - iconSize / 2);
   const iris = irisEmbedSvg(x, y, iconSize, PADDING.standard, config, "splash");
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${canvasW}" height="${canvasH}" viewBox="0 0 ${canvasW} ${canvasH}">`,
@@ -301,9 +363,14 @@ mkdirSync(splashDir, { recursive: true });
 for (const device of SPLASH_DEVICES) {
   for (const scheme of ["light", "dark"] as const) {
     const outPath = resolve(splashDir, `splash-${device.label}-${scheme}.png`);
-    writeFileSync(outPath, svgToPng(generateSplashSvg(device.w, device.h, scheme), device.w));
+    writeFileSync(
+      outPath,
+      svgToPng(generateSplashSvg(device.w, device.h, scheme), device.w)
+    );
     // Use splashUrl to ensure filename convention stays in sync with the config.
-    console.log(`✓ public${splashUrl(device.label, scheme)} (${device.w}×${device.h}) — ${device.devices}`);
+    console.log(
+      `✓ public${splashUrl(device.label, scheme)} (${device.w}×${device.h}) — ${device.devices}`
+    );
   }
 }
 

--- a/scripts/verify-icons.ts
+++ b/scripts/verify-icons.ts
@@ -13,7 +13,12 @@ import { readFileSync, existsSync, statSync } from "node:fs";
 import { inflateSync } from "node:zlib";
 import { resolve } from "node:path";
 
-import { SPLASH_DEVICES, SPLASH_BG, splashUrl, type SplashScheme } from "../src/config/splash.ts";
+import {
+  SPLASH_DEVICES,
+  SPLASH_BG,
+  splashUrl,
+  type SplashScheme,
+} from "../src/config/splash.ts";
 
 // ── Minimal PNG decoder (8-bit RGBA only — matches resvg output) ────────────
 
@@ -45,11 +50,15 @@ function decodePng(path: string): Png {
       colorType = body.readUInt8(9);
     } else if (type === "IDAT") {
       idat.push(body);
-    } else if (type === "IEND") break;
+    } else if (type === "IEND") {
+      break;
+    }
     i += 8 + len + 4;
   }
   if (colorType !== 6 || bitDepth !== 8) {
-    throw new Error(`unsupported PNG format (colorType=${colorType} bitDepth=${bitDepth})`);
+    throw new Error(
+      `unsupported PNG format (colorType=${colorType} bitDepth=${bitDepth})`
+    );
   }
   const raw = inflateSync(Buffer.concat(idat));
   const bpp = 4;
@@ -65,10 +74,18 @@ function decodePng(path: string): Png {
       const upLeft = x >= bpp ? prev[x - bpp] : 0;
       let recon: number;
       switch (filter) {
-        case 0: recon = 0; break;
-        case 1: recon = left; break;
-        case 2: recon = up; break;
-        case 3: recon = (left + up) >> 1; break;
+        case 0:
+          recon = 0;
+          break;
+        case 1:
+          recon = left;
+          break;
+        case 2:
+          recon = up;
+          break;
+        case 3:
+          recon = (left + up) >> 1;
+          break;
         case 4: {
           const p = left + up - upLeft;
           const pa = Math.abs(p - left);
@@ -77,7 +94,8 @@ function decodePng(path: string): Png {
           recon = pa <= pb && pa <= pc ? left : pb <= pc ? up : upLeft;
           break;
         }
-        default: throw new Error(`unknown PNG filter ${filter}`);
+        default:
+          throw new Error(`unknown PNG filter ${filter}`);
       }
       row[x] = (row[x] + recon) & 0xff;
     }
@@ -96,7 +114,12 @@ function pixel(img: Png, x: number, y: number): Rgba {
 
 function hexToRgba(hex: string): Rgba {
   const h = hex.replace("#", "");
-  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16), 255];
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+    255,
+  ];
 }
 
 function rgbaEq(a: Rgba, b: Rgba): boolean {
@@ -120,8 +143,12 @@ interface Expectation {
 }
 
 function expectedCorner(bg: BgContract): Rgba {
-  if (bg === "transparent") return [0, 0, 0, 0];
-  if (bg === "opaque-white") return [255, 255, 255, 255];
+  if (bg === "transparent") {
+    return [0, 0, 0, 0];
+  }
+  if (bg === "opaque-white") {
+    return [255, 255, 255, 255];
+  }
   return bg;
 }
 
@@ -129,25 +156,79 @@ const ICON_EXPECTATIONS: Expectation[] = [
   // PWA manifest purpose="any" — transparent, so Chrome's omnibox install
   // chip, the macOS Dock, and Windows taskbar render the bare mark without
   // a white square around it.
-  { path: "public/icons/icon-192.png",  width: 192,  height: 192,  bg: "transparent", mark: true },
-  { path: "public/icons/icon-512.png",  width: 512,  height: 512,  bg: "transparent", mark: true },
-  { path: "public/icons/icon-1024.png", width: 1024, height: 1024, bg: "transparent", mark: true },
+  {
+    path: "public/icons/icon-192.png",
+    width: 192,
+    height: 192,
+    bg: "transparent",
+    mark: true,
+  },
+  {
+    path: "public/icons/icon-512.png",
+    width: 512,
+    height: 512,
+    bg: "transparent",
+    mark: true,
+  },
+  {
+    path: "public/icons/icon-1024.png",
+    width: 1024,
+    height: 1024,
+    bg: "transparent",
+    mark: true,
+  },
 
   // iOS apple-touch-icon — must be opaque. iOS fills transparent pixels with
   // an uncontrolled color on the home screen, so we ship a baked white
   // background specifically for this surface.
-  { path: "public/icons/icon-192-white.png",  width: 192,  height: 192,  bg: "opaque-white", mark: true },
-  { path: "public/icons/icon-512-white.png",  width: 512,  height: 512,  bg: "opaque-white", mark: true },
-  { path: "public/icons/icon-1024-white.png", width: 1024, height: 1024, bg: "opaque-white", mark: true },
+  {
+    path: "public/icons/icon-192-white.png",
+    width: 192,
+    height: 192,
+    bg: "opaque-white",
+    mark: true,
+  },
+  {
+    path: "public/icons/icon-512-white.png",
+    width: 512,
+    height: 512,
+    bg: "opaque-white",
+    mark: true,
+  },
+  {
+    path: "public/icons/icon-1024-white.png",
+    width: 1024,
+    height: 1024,
+    bg: "opaque-white",
+    mark: true,
+  },
 
   // Android maskable — transparent canvas, Android supplies its own adaptive
   // background. Mark lives inside the 80% safe zone (enforced by the padding
   // constant in gen-icons.tsx, validated here by the mark presence).
-  { path: "public/icons/icon-maskable-192.png", width: 192, height: 192, bg: "transparent", mark: true },
-  { path: "public/icons/icon-maskable-512.png", width: 512, height: 512, bg: "transparent", mark: true },
+  {
+    path: "public/icons/icon-maskable-192.png",
+    width: 192,
+    height: 192,
+    bg: "transparent",
+    mark: true,
+  },
+  {
+    path: "public/icons/icon-maskable-512.png",
+    width: 512,
+    height: 512,
+    bg: "transparent",
+    mark: true,
+  },
 
   // Next.js file-convention browser favicon (src/app/icon.png).
-  { path: "src/app/icon.png", width: 32, height: 32, bg: "transparent", mark: true },
+  {
+    path: "src/app/icon.png",
+    width: 32,
+    height: 32,
+    bg: "transparent",
+    mark: true,
+  },
 ];
 
 const SPLASH_EXPECTATIONS: Expectation[] = SPLASH_DEVICES.flatMap((device) =>
@@ -180,7 +261,9 @@ function hasMark(img: Png): boolean {
   let opaque = 0;
   const total = img.width * img.height;
   for (let i = 3; i < img.data.length; i += 4) {
-    if (img.data[i] > 0) opaque++;
+    if (img.data[i] > 0) {
+      opaque++;
+    }
   }
   return opaque / total > 0.01;
 }
@@ -195,7 +278,10 @@ function checkCorner(img: Png, expected: Rgba, path: string): void {
   for (const [x, y] of corners) {
     const got = pixel(img, x, y);
     if (!rgbaEq(got, expected)) {
-      fail(path, `corner (${x},${y}) expected ${JSON.stringify(expected)}, got ${JSON.stringify(got)}`);
+      fail(
+        path,
+        `corner (${x},${y}) expected ${JSON.stringify(expected)}, got ${JSON.stringify(got)}`
+      );
       return; // one corner failure is enough — don't spam
     }
   }
@@ -215,7 +301,10 @@ function checkExpectation(exp: Expectation): void {
     return;
   }
   if (img.width !== exp.width || img.height !== exp.height) {
-    fail(exp.path, `expected ${exp.width}×${exp.height}, got ${img.width}×${img.height}`);
+    fail(
+      exp.path,
+      `expected ${exp.width}×${exp.height}, got ${img.width}×${img.height}`
+    );
   }
   checkCorner(img, expectedCorner(exp.bg), exp.path);
   if (exp.mark && !hasMark(img)) {
@@ -239,11 +328,16 @@ for (const { path, minBytes } of EXISTENCE_ONLY) {
   }
 }
 
-const totalChecked = ICON_EXPECTATIONS.length + SPLASH_EXPECTATIONS.length + EXISTENCE_ONLY.length;
+const totalChecked =
+  ICON_EXPECTATIONS.length + SPLASH_EXPECTATIONS.length + EXISTENCE_ONLY.length;
 
 if (errors.length > 0) {
-  console.error(`\n✗ Icon verification failed (${errors.length} issue${errors.length === 1 ? "" : "s"}):\n`);
-  for (const line of errors) console.error(line);
+  console.error(
+    `\n✗ Icon verification failed (${errors.length} issue${errors.length === 1 ? "" : "s"}):\n`
+  );
+  for (const line of errors) {
+    console.error(line);
+  }
   console.error("");
   process.exit(1);
 }

--- a/src/app/[locale]/design-lab/iris-pheno/actions.ts
+++ b/src/app/[locale]/design-lab/iris-pheno/actions.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 const PRESET_PATH = path.join(
   process.cwd(),
-  "src/app/[locale]/design-lab/iris-pheno/preset.json",
+  "src/app/[locale]/design-lab/iris-pheno/preset.json"
 );
 
 const BRAND_PATH = path.join(process.cwd(), "src/config/brand.ts");
@@ -42,20 +42,27 @@ export interface BrandExportValues {
  * in brand.ts. Returns null if the preset cannot be found or parsed.
  */
 export async function readFromBrand(
-  presetName: "IRIS_LG" | "IRIS_SM",
+  presetName: "IRIS_LG" | "IRIS_SM"
 ): Promise<BrandExportValues | null> {
   try {
     const content = await readFile(BRAND_PATH, "utf-8");
 
     const startPattern = new RegExp(`export const ${presetName}[^=]*=\\s*\\{`);
     const startMatch = startPattern.exec(content);
-    if (!startMatch) return null;
+    if (!startMatch) {
+      return null;
+    }
 
     const bodyStart = startMatch.index + startMatch[0].length;
-    let depth = 1, bodyEnd = bodyStart;
+    let depth = 1,
+      bodyEnd = bodyStart;
     while (bodyEnd < content.length && depth > 0) {
-      if (content[bodyEnd] === "{") depth++;
-      if (content[bodyEnd] === "}") depth--;
+      if (content[bodyEnd] === "{") {
+        depth++;
+      }
+      if (content[bodyEnd] === "}") {
+        depth--;
+      }
       bodyEnd++;
     }
     const body = content.slice(bodyStart, bodyEnd - 1);
@@ -66,13 +73,13 @@ export async function readFromBrand(
     }
 
     return {
-      N:                  extract("N"),
-      t:                  extract("t"),
-      halfSpread:         extract("halfSpread"),
-      overlap:            extract("overlap"),
-      curve:              extract("curve"),
-      twist:              extract("twist"),
-      bladeStrokeWidth:   extract("bladeStrokeWidth"),
+      N: extract("N"),
+      t: extract("t"),
+      halfSpread: extract("halfSpread"),
+      overlap: extract("overlap"),
+      curve: extract("curve"),
+      twist: extract("twist"),
+      bladeStrokeWidth: extract("bladeStrokeWidth"),
       shadowStdDeviation: extract("shadowStdDeviation"),
     };
   } catch {
@@ -87,7 +94,7 @@ export async function readFromBrand(
  */
 export async function exportToBrand(
   presetName: "IRIS_LG" | "IRIS_SM",
-  values: BrandExportValues,
+  values: BrandExportValues
 ): Promise<{ ok: boolean; error?: string }> {
   try {
     let content = await readFile(BRAND_PATH, "utf-8");
@@ -95,7 +102,9 @@ export async function exportToBrand(
     // Locate the object body for the target preset
     const startPattern = new RegExp(`export const ${presetName}[^=]*=\\s*\\{`);
     const startMatch = startPattern.exec(content);
-    if (!startMatch) return { ok: false, error: `${presetName} not found in brand.ts` };
+    if (!startMatch) {
+      return { ok: false, error: `${presetName} not found in brand.ts` };
+    }
 
     const bodyStart = startMatch.index + startMatch[0].length;
 
@@ -103,28 +112,29 @@ export async function exportToBrand(
     let depth = 1;
     let bodyEnd = bodyStart;
     while (bodyEnd < content.length && depth > 0) {
-      if (content[bodyEnd] === "{") depth++;
-      if (content[bodyEnd] === "}") depth--;
+      if (content[bodyEnd] === "{") {
+        depth++;
+      }
+      if (content[bodyEnd] === "}") {
+        depth--;
+      }
       bodyEnd++;
     }
 
     // Patch each value with a regex that matches `key: <number>` (ignores JSDoc lines)
     let body = content.slice(bodyStart, bodyEnd - 1);
     const patch: Record<string, number> = {
-      N:                  values.N,
-      t:                  values.t,
-      halfSpread:         values.halfSpread,
-      overlap:            values.overlap,
-      curve:              values.curve,
-      twist:              values.twist,
-      bladeStrokeWidth:   values.bladeStrokeWidth,
+      N: values.N,
+      t: values.t,
+      halfSpread: values.halfSpread,
+      overlap: values.overlap,
+      curve: values.curve,
+      twist: values.twist,
+      bladeStrokeWidth: values.bladeStrokeWidth,
       shadowStdDeviation: values.shadowStdDeviation,
     };
     for (const [key, val] of Object.entries(patch)) {
-      body = body.replace(
-        new RegExp(`(\\b${key}:\\s*)[\\d.]+`),
-        `$1${val}`,
-      );
+      body = body.replace(new RegExp(`(\\b${key}:\\s*)[\\d.]+`), `$1${val}`);
     }
 
     content = content.slice(0, bodyStart) + body + content.slice(bodyEnd - 1);

--- a/src/app/[locale]/design-lab/iris-pheno/page.tsx
+++ b/src/app/[locale]/design-lab/iris-pheno/page.tsx
@@ -8,37 +8,81 @@ const LOGO_SM_THRESHOLD = 40; // px — mirrors brand.ts threshold for reference
 // ── ApertureMark ─────────────────────────────────────────────────────────────
 
 function ApertureMark({
-  N, t, halfSpread, overlap, curve, twist, shadowIntensity, bladeStroke,
-  fill, gap, size, uid,
+  N,
+  t,
+  halfSpread,
+  overlap,
+  curve,
+  twist,
+  shadowIntensity,
+  bladeStroke,
+  fill,
+  gap,
+  size,
+  uid,
 }: {
-  N: number; t: number; halfSpread: number; overlap: number; curve: number;
-  twist: number; shadowIntensity: number; bladeStroke: number;
-  fill: string; gap: string; size: number; uid: string;
+  N: number;
+  t: number;
+  halfSpread: number;
+  overlap: number;
+  curve: number;
+  twist: number;
+  shadowIntensity: number;
+  bladeStroke: number;
+  fill: string;
+  gap: string;
+  size: number;
+  uid: string;
 }) {
-  const params: IrisPhenoParams = { N, halfSpread, overlap, curve, twist };
+  const params: IrisPhenoParams = useMemo(
+    () => ({ N, halfSpread, overlap, curve, twist }),
+    [N, halfSpread, overlap, curve, twist]
+  );
   const stepDeg = 360 / N;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const bp   = useMemo(() => bladePath(t, params),    [N, t, halfSpread, overlap, curve, twist]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const poly = useMemo(() => coverPoints(t, params),  [N, t, halfSpread, overlap, curve, twist]);
+  const bp = useMemo(() => bladePath(t, params), [t, params]);
+  const poly = useMemo(() => coverPoints(t, params), [t, params]);
 
   return (
-    <svg viewBox="-120 -120 240 240" width={size} height={size} style={{ display: "block", flexShrink: 0 }}>
+    <svg
+      viewBox="-120 -120 240 240"
+      width={size}
+      height={size}
+      style={{ display: "block", flexShrink: 0 }}
+    >
       <defs>
-        <clipPath id={`iclip-${uid}`}><circle r={R} /></clipPath>
+        <clipPath id={`iclip-${uid}`}>
+          <circle r={R} />
+        </clipPath>
         {shadowIntensity > 0 && (
-          <filter id={`bshadow-${uid}`} x="-25%" y="-25%" width="150%" height="150%">
-            <feDropShadow dx={0} dy={0} stdDeviation={shadowIntensity * 5}
-              floodColor="black" floodOpacity={0.55} />
+          <filter
+            id={`bshadow-${uid}`}
+            x="-25%"
+            y="-25%"
+            width="150%"
+            height="150%"
+          >
+            <feDropShadow
+              dx={0}
+              dy={0}
+              stdDeviation={shadowIntensity * 5}
+              floodColor="black"
+              floodOpacity={0.55}
+            />
           </filter>
         )}
         {Array.from({ length: N }, (_, i) => (
           <mask id={`bmask-${i}-${uid}`} key={i}>
             <rect x="-120" y="-120" width="240" height="240" fill="white" />
             <g transform={`rotate(${stepDeg * ((i + 1) % N)})`}>
-              <path d={bp} fill="black" stroke="black"
-                strokeWidth={bladeStroke} strokeLinejoin="miter" strokeMiterlimit={10} />
+              <path
+                d={bp}
+                fill="black"
+                stroke="black"
+                strokeWidth={bladeStroke}
+                strokeLinejoin="miter"
+                strokeMiterlimit={10}
+              />
             </g>
           </mask>
         ))}
@@ -47,9 +91,17 @@ function ApertureMark({
         {Array.from({ length: N }, (_, i) => (
           <g key={i} mask={`url(#bmask-${i}-${uid})`}>
             <g transform={`rotate(${stepDeg * i})`}>
-              <path d={bp} fill={fill} stroke={gap} strokeWidth={bladeStroke}
-                strokeLinejoin="miter" strokeMiterlimit={10}
-                filter={shadowIntensity > 0 ? `url(#bshadow-${uid})` : undefined} />
+              <path
+                d={bp}
+                fill={fill}
+                stroke={gap}
+                strokeWidth={bladeStroke}
+                strokeLinejoin="miter"
+                strokeMiterlimit={10}
+                filter={
+                  shadowIntensity > 0 ? `url(#bshadow-${uid})` : undefined
+                }
+              />
             </g>
           </g>
         ))}
@@ -61,19 +113,40 @@ function ApertureMark({
 
 // ── Slider ────────────────────────────────────────────────────────────────────
 
-function Slider({ label, value, min, max, step, onChange, display }: {
-  label: string; value: number; min: number; max: number; step: number;
-  onChange: (v: number) => void; display?: string;
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  display,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  display?: string;
 }) {
   return (
     <div className="space-y-1">
       <div className="flex justify-between text-xs text-gray-500">
         <span>{label}</span>
-        <span className="font-mono tabular-nums">{display ?? value.toFixed(2)}</span>
+        <span className="font-mono tabular-nums">
+          {display ?? value.toFixed(2)}
+        </span>
       </div>
-      <input type="range" min={min} max={max} step={step} value={value}
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full accent-zinc-800" />
+        className="w-full accent-zinc-800"
+      />
     </div>
   );
 }
@@ -82,24 +155,40 @@ function Slider({ label, value, min, max, step, onChange, display }: {
 
 const RING_SPACING = 64;
 const RING_VALUES = [
-  { label: "A",   t: 1.00 }, { label: "16",  t: 0.30 }, { label: "11",  t: 0.40 },
-  { label: "8",   t: 0.50 }, { label: "5.6", t: 0.60 }, { label: "4",   t: 0.70 },
-  { label: "2.8", t: 0.80 }, { label: "2",   t: 0.90 }, { label: "1.4", t: 1.00 },
+  { label: "A", t: 1.0 },
+  { label: "16", t: 0.3 },
+  { label: "11", t: 0.4 },
+  { label: "8", t: 0.5 },
+  { label: "5.6", t: 0.6 },
+  { label: "4", t: 0.7 },
+  { label: "2.8", t: 0.8 },
+  { label: "2", t: 0.9 },
+  { label: "1.4", t: 1.0 },
 ] as const;
 
-function ApertureRingControl({ value, onChange }: {
+function ApertureRingControl({
+  value,
+  onChange,
+}: {
   value: number;
   onChange: (t: number) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [offset, setOffset]   = useState(0);
+  const [offset, setOffset] = useState(0);
   const [snapping, setSnapping] = useState(false);
-  const isDragging  = useRef(false);
-  const dragStart   = useRef<{ x: number; offset: number } | null>(null);
+  const isDragging = useRef(false);
+  const dragStart = useRef<{ x: number; offset: number } | null>(null);
 
   function indexForValue(v: number) {
-    let best = 0, bestDist = Infinity;
-    RING_VALUES.forEach((rv, i) => { const d = Math.abs(rv.t - v); if (d < bestDist) { bestDist = d; best = i; } });
+    let best = 0,
+      bestDist = Infinity;
+    RING_VALUES.forEach((rv, i) => {
+      const d = Math.abs(rv.t - v);
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    });
     return best;
   }
   function offsetForIndex(i: number) {
@@ -108,78 +197,142 @@ function ApertureRingControl({ value, onChange }: {
   }
   function nearestIndex(raw: number) {
     const w = containerRef.current?.offsetWidth ?? 400;
-    return Math.max(0, Math.min(RING_VALUES.length - 1, Math.round((w / 2 - raw) / RING_SPACING - 0.5)));
+    return Math.max(
+      0,
+      Math.min(
+        RING_VALUES.length - 1,
+        Math.round((w / 2 - raw) / RING_SPACING - 0.5)
+      )
+    );
   }
   function tFromOffset(raw: number) {
     const w = containerRef.current?.offsetWidth ?? 400;
     const pos = (w / 2 - raw) / RING_SPACING - 0.5;
-    if (pos <= 0) return RING_VALUES[0].t;
-    if (pos >= RING_VALUES.length - 1) return RING_VALUES[RING_VALUES.length - 1].t;
+    if (pos <= 0) {
+      return RING_VALUES[0].t;
+    }
+    if (pos >= RING_VALUES.length - 1) {
+      return RING_VALUES[RING_VALUES.length - 1].t;
+    }
     const lo = Math.floor(pos);
-    return RING_VALUES[lo].t + (RING_VALUES[lo + 1].t - RING_VALUES[lo].t) * (pos - lo);
+    return (
+      RING_VALUES[lo].t +
+      (RING_VALUES[lo + 1].t - RING_VALUES[lo].t) * (pos - lo)
+    );
   }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { setOffset(offsetForIndex(indexForValue(value))); }, []);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { if (!isDragging.current) setOffset(offsetForIndex(indexForValue(value))); }, [value]);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOffset(offsetForIndex(indexForValue(value)));
+  }, [value]);
+
+  useEffect(() => {
+    if (!isDragging.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setOffset(offsetForIndex(indexForValue(value)));
+    }
+  }, [value]);
 
   function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
     e.currentTarget.setPointerCapture(e.pointerId);
-    isDragging.current = true; dragStart.current = { x: e.clientX, offset }; setSnapping(false);
+    isDragging.current = true;
+    dragStart.current = { x: e.clientX, offset };
+    setSnapping(false);
   }
   function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
-    if (!isDragging.current || !dragStart.current) return;
+    if (!isDragging.current || !dragStart.current) {
+      return;
+    }
     const neo = dragStart.current.offset + (e.clientX - dragStart.current.x);
-    setOffset(neo); onChange(tFromOffset(neo));
+    setOffset(neo);
+    onChange(tFromOffset(neo));
   }
   function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
-    if (!isDragging.current || !dragStart.current) return;
+    if (!isDragging.current || !dragStart.current) {
+      return;
+    }
     const neo = dragStart.current.offset + (e.clientX - dragStart.current.x);
-    isDragging.current = false; dragStart.current = null;
+    isDragging.current = false;
+    dragStart.current = null;
     const idx = nearestIndex(neo);
-    setSnapping(true); setOffset(offsetForIndex(idx)); onChange(RING_VALUES[idx].t);
+    setSnapping(true);
+    setOffset(offsetForIndex(idx));
+    onChange(RING_VALUES[idx].t);
     setTimeout(() => setSnapping(false), 220);
   }
 
   return (
     <div className="relative">
-      <div ref={containerRef}
+      <div
+        ref={containerRef}
         className="relative rounded-xl overflow-hidden select-none cursor-grab active:cursor-grabbing"
         style={{ height: 52, backgroundColor: "#1a1a1a" }}
-        onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}>
-        <div className="absolute inset-x-0 top-0 h-px" style={{ background: "rgba(255,255,255,0.08)" }} />
-        <div className="absolute inset-0" style={{
-          maskImage: "linear-gradient(to right, transparent 0%, black 18%, black 82%, transparent 100%)",
-          WebkitMaskImage: "linear-gradient(to right, transparent 0%, black 18%, black 82%, transparent 100%)",
-        }}>
-          <div className="absolute top-0 h-full flex items-center"
-            style={{ left: offset, transition: snapping ? "left 0.2s ease-out" : "none", willChange: "left" }}>
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+      >
+        <div
+          className="absolute inset-x-0 top-0 h-px"
+          style={{ background: "rgba(255,255,255,0.08)" }}
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            maskImage:
+              "linear-gradient(to right, transparent 0%, black 18%, black 82%, transparent 100%)",
+            WebkitMaskImage:
+              "linear-gradient(to right, transparent 0%, black 18%, black 82%, transparent 100%)",
+          }}
+        >
+          <div
+            className="absolute top-0 h-full flex items-center"
+            style={{
+              left: offset,
+              transition: snapping ? "left 0.2s ease-out" : "none",
+              willChange: "left",
+            }}
+          >
             {RING_VALUES.map((v) => (
-              <div key={v.label}
+              <div
+                key={v.label}
                 className="flex items-center justify-center font-bold text-sm tabular-nums"
-                style={{ width: RING_SPACING, color: v.label === "A" ? "#C0452D" : "white", letterSpacing: "0.02em" }}>
+                style={{
+                  width: RING_SPACING,
+                  color: v.label === "A" ? "#C0452D" : "white",
+                  letterSpacing: "0.02em",
+                }}
+              >
                 {v.label}
               </div>
             ))}
           </div>
         </div>
       </div>
-      <div className="absolute pointer-events-none"
-        style={{ left: "50%", top: -10, transform: "translateX(-50%)", width: 2, height: 18, backgroundColor: "white", zIndex: 1 }} />
+      <div
+        className="absolute pointer-events-none"
+        style={{
+          left: "50%",
+          top: -10,
+          transform: "translateX(-50%)",
+          width: 2,
+          height: 18,
+          backgroundColor: "white",
+          zIndex: 1,
+        }}
+      />
     </div>
   );
 }
 
 // ── constants ─────────────────────────────────────────────────────────────────
 
-const BLADE_OPTIONS  = [5, 6, 7, 9] as const;
-const PREVIEW_SIZES  = [16, 24, 32, 48, 64, 128] as const;
+const BLADE_OPTIONS = [5, 6, 7, 9] as const;
+const PREVIEW_SIZES = [16, 24, 32, 48, 64, 128] as const;
 const LIGHT_BG = "#f3f4f6";
-const DARK_BG  = "#111827";
+const DARK_BG = "#111827";
 const THEMES = [
-  { fill: "rgb(35,39,43)",   gap: LIGHT_BG, bg: LIGHT_BG, label: "light" },
-  { fill: "rgb(225,227,229)", gap: DARK_BG,  bg: DARK_BG,  label: "dark"  },
+  { fill: "rgb(35,39,43)", gap: LIGHT_BG, bg: LIGHT_BG, label: "light" },
+  { fill: "rgb(225,227,229)", gap: DARK_BG, bg: DARK_BG, label: "dark" },
 ] as const;
 
 function fStop(t: number) {
@@ -189,33 +342,60 @@ function fStop(t: number) {
 // ── ParamControls ─────────────────────────────────────────────────────────────
 
 function ParamControls({
-  N, setN, aperture, setAperture,
-  halfSpread, setHalfSpread, overlap, setOverlap,
-  curve, setCurve, twist, setTwist,
-  bladeStroke, setBladeStroke, shadow, setShadow,
+  N,
+  setN,
+  aperture,
+  setAperture,
+  halfSpread,
+  setHalfSpread,
+  overlap,
+  setOverlap,
+  curve,
+  setCurve,
+  twist,
+  setTwist,
+  bladeStroke,
+  setBladeStroke,
+  shadow,
+  setShadow,
   onReset,
 }: {
-  N: number;           setN: (v: number) => void;
-  aperture: number;    setAperture: (v: number) => void;
-  halfSpread: number;  setHalfSpread: (v: number) => void;
-  overlap: number;     setOverlap: (v: number) => void;
-  curve: number;       setCurve: (v: number) => void;
-  twist: number;       setTwist: (v: number) => void;
-  bladeStroke: number; setBladeStroke: (v: number) => void;
-  shadow: number;      setShadow: (v: number) => void;
+  N: number;
+  setN: (v: number) => void;
+  aperture: number;
+  setAperture: (v: number) => void;
+  halfSpread: number;
+  setHalfSpread: (v: number) => void;
+  overlap: number;
+  setOverlap: (v: number) => void;
+  curve: number;
+  setCurve: (v: number) => void;
+  twist: number;
+  setTwist: (v: number) => void;
+  bladeStroke: number;
+  setBladeStroke: (v: number) => void;
+  shadow: number;
+  setShadow: (v: number) => void;
   onReset: () => void;
 }) {
   return (
     <aside className="w-72 shrink-0 space-y-5 rounded-xl border border-gray-200 p-5">
       {/* Blade count */}
       <div>
-        <p className="mb-2 text-xs font-medium text-gray-400 uppercase tracking-wider">Blade count</p>
+        <p className="mb-2 text-xs font-medium text-gray-400 uppercase tracking-wider">
+          Blade count
+        </p>
         <div className="flex gap-2">
           {BLADE_OPTIONS.map((n) => (
-            <button key={n} onClick={() => setN(n)}
+            <button
+              key={n}
+              onClick={() => setN(n)}
               className={`flex-1 rounded-md py-1.5 text-sm font-medium transition-colors ${
-                N === n ? "bg-zinc-900 text-zinc-50" : "bg-gray-100 text-gray-500 hover:bg-gray-200"
-              }`}>
+                N === n
+                  ? "bg-zinc-900 text-zinc-50"
+                  : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+              }`}
+            >
               {n}
             </button>
           ))}
@@ -224,26 +404,76 @@ function ParamControls({
 
       {/* Sliders */}
       <div className="space-y-4">
-        <Slider label="Aperture openness" value={aperture} min={0.02} max={0.98} step={0.01}
-          onChange={setAperture} display={fStop(aperture)} />
-        <Slider label="Blade gap stroke" value={bladeStroke} min={0} max={8} step={0.1}
-          onChange={setBladeStroke} display={`${bladeStroke.toFixed(1)}px`} />
-        <Slider label="Half-spread (sweep)" value={halfSpread} min={0} max={0.95} step={0.01}
-          onChange={setHalfSpread} />
-        <Slider label="Blade overlap" value={overlap} min={0.02} max={0.9} step={0.01}
-          onChange={setOverlap} display={`${(overlap * 100).toFixed(0)}%`} />
-        <Slider label="Side edge curve" value={curve} min={0} max={1.0} step={0.01}
-          onChange={setCurve} display={curve === 0 ? "off" : curve.toFixed(2)} />
-        <Slider label="Closing twist" value={twist} min={0} max={2} step={0.05}
-          onChange={setTwist} display={twist === 0 ? "off" : `${twist.toFixed(2)}×`} />
-        <Slider label="Shadow intensity" value={shadow} min={0} max={1} step={0.01}
-          onChange={setShadow} display={shadow === 0 ? "off" : shadow.toFixed(2)} />
+        <Slider
+          label="Aperture openness"
+          value={aperture}
+          min={0.02}
+          max={0.98}
+          step={0.01}
+          onChange={setAperture}
+          display={fStop(aperture)}
+        />
+        <Slider
+          label="Blade gap stroke"
+          value={bladeStroke}
+          min={0}
+          max={8}
+          step={0.1}
+          onChange={setBladeStroke}
+          display={`${bladeStroke.toFixed(1)}px`}
+        />
+        <Slider
+          label="Half-spread (sweep)"
+          value={halfSpread}
+          min={0}
+          max={0.95}
+          step={0.01}
+          onChange={setHalfSpread}
+        />
+        <Slider
+          label="Blade overlap"
+          value={overlap}
+          min={0.02}
+          max={0.9}
+          step={0.01}
+          onChange={setOverlap}
+          display={`${(overlap * 100).toFixed(0)}%`}
+        />
+        <Slider
+          label="Side edge curve"
+          value={curve}
+          min={0}
+          max={1.0}
+          step={0.01}
+          onChange={setCurve}
+          display={curve === 0 ? "off" : curve.toFixed(2)}
+        />
+        <Slider
+          label="Closing twist"
+          value={twist}
+          min={0}
+          max={2}
+          step={0.05}
+          onChange={setTwist}
+          display={twist === 0 ? "off" : `${twist.toFixed(2)}×`}
+        />
+        <Slider
+          label="Shadow intensity"
+          value={shadow}
+          min={0}
+          max={1}
+          step={0.01}
+          onChange={setShadow}
+          display={shadow === 0 ? "off" : shadow.toFixed(2)}
+        />
       </div>
 
       {/* Reset only — export is handled by Aperture V2 Studio */}
       <div className="pt-1">
-        <button onClick={onReset}
-          className="w-full rounded-md py-1.5 text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors">
+        <button
+          onClick={onReset}
+          className="w-full rounded-md py-1.5 text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
+        >
           Reset
         </button>
         <p className="mt-2 text-xs text-gray-400 text-center">
@@ -258,24 +488,24 @@ function ParamControls({
 
 export default function IrisPhenoLab() {
   // ─ Large section (IRIS_LG) ─────────────────────────────────────────────
-  const [lgN,           setLgN]           = useState(7);
-  const [lgT,           setLgT]           = useState(0.3);
-  const [lgHalfSpread,  setLgHalfSpread]  = useState(0.6);
-  const [lgOverlap,     setLgOverlap]     = useState(0.65);
-  const [lgCurve,       setLgCurve]       = useState(1.0);
-  const [lgTwist,       setLgTwist]       = useState(0.35);
+  const [lgN, setLgN] = useState(7);
+  const [lgT, setLgT] = useState(0.3);
+  const [lgHalfSpread, setLgHalfSpread] = useState(0.6);
+  const [lgOverlap, setLgOverlap] = useState(0.65);
+  const [lgCurve, setLgCurve] = useState(1.0);
+  const [lgTwist, setLgTwist] = useState(0.35);
   const [lgBladeStroke, setLgBladeStroke] = useState(0.5);
-  const [lgShadow,      setLgShadow]      = useState(0.8);
+  const [lgShadow, setLgShadow] = useState(0.8);
 
   // Mouse-driven display aperture (fades to lgT on leave)
   const [lgDisplayT, _setLgDisplayT] = useState(0.3);
-  const lgDisplayTRef  = useRef(0.3);
-  const lgTRef         = useRef(0.3);
-  const lgHoveringRef  = useRef(false);
-  const lgPreviewRef   = useRef<HTMLDivElement>(null);
-  const lgEntryOffset  = useRef(0);
-  const lgEntryTime    = useRef(0);
-  const lgEaseRaf      = useRef<number | null>(null);
+  const lgDisplayTRef = useRef(0.3);
+  const lgTRef = useRef(0.3);
+  const lgHoveringRef = useRef(false);
+  const lgPreviewRef = useRef<HTMLDivElement>(null);
+  const lgEntryOffset = useRef(0);
+  const lgEntryTime = useRef(0);
+  const lgEaseRaf = useRef<number | null>(null);
 
   function setLgDisplayT(v: number) {
     lgDisplayTRef.current = v;
@@ -285,82 +515,143 @@ export default function IrisPhenoLab() {
   // Keep lgTRef in sync; mirror to display when not hovering
   useEffect(() => {
     lgTRef.current = lgT;
-    if (!lgHoveringRef.current) setLgDisplayT(lgT);
-  }, [lgT]); // eslint-disable-line react-hooks/exhaustive-deps
+    // The display state mirrors the latest control value unless the preview is actively being scrubbed.
+    if (!lgHoveringRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLgDisplayT(lgT);
+    }
+  }, [lgT]);
 
-  useEffect(() => () => { if (lgEaseRaf.current) cancelAnimationFrame(lgEaseRaf.current); }, []);
+  useEffect(
+    () => () => {
+      if (lgEaseRaf.current) {
+        cancelAnimationFrame(lgEaseRaf.current);
+      }
+    },
+    []
+  );
 
   function lgMouseEnter(e: React.MouseEvent<HTMLDivElement>) {
-    if (lgEaseRaf.current) { cancelAnimationFrame(lgEaseRaf.current); lgEaseRaf.current = null; }
+    if (lgEaseRaf.current) {
+      cancelAnimationFrame(lgEaseRaf.current);
+      lgEaseRaf.current = null;
+    }
     lgHoveringRef.current = true;
     const rect = lgPreviewRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const absT = Math.max(0.02, Math.min(0.98, (e.clientX - rect.left) / rect.width));
+    if (!rect) {
+      return;
+    }
+    const absT = Math.max(
+      0.02,
+      Math.min(0.98, (e.clientX - rect.left) / rect.width)
+    );
     lgEntryOffset.current = lgDisplayTRef.current - absT;
-    lgEntryTime.current   = performance.now();
+    lgEntryTime.current = performance.now();
   }
 
   function lgMouseMove(e: React.MouseEvent<HTMLDivElement>) {
-    if (!lgHoveringRef.current) return;
+    if (!lgHoveringRef.current) {
+      return;
+    }
     const rect = lgPreviewRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const absT = Math.max(0.02, Math.min(0.98, (e.clientX - rect.left) / rect.width));
-    const p    = Math.min(1, (performance.now() - lgEntryTime.current) / 180);
-    const off  = lgEntryOffset.current * (1 - p) ** 2;
+    if (!rect) {
+      return;
+    }
+    const absT = Math.max(
+      0.02,
+      Math.min(0.98, (e.clientX - rect.left) / rect.width)
+    );
+    const p = Math.min(1, (performance.now() - lgEntryTime.current) / 180);
+    const off = lgEntryOffset.current * (1 - p) ** 2;
     setLgDisplayT(Math.max(0.02, Math.min(0.98, absT + off)));
   }
 
   function lgMouseLeave() {
     lgHoveringRef.current = false;
-    const fromT    = lgDisplayTRef.current;
-    const toT      = lgTRef.current;
-    const startMs  = performance.now();
+    const fromT = lgDisplayTRef.current;
+    const toT = lgTRef.current;
+    const startMs = performance.now();
     function tick(now: number) {
-      const p     = Math.min(1, (now - startMs) / 700);
+      const p = Math.min(1, (now - startMs) / 700);
       const eased = 1 - (1 - p) ** 3;
       setLgDisplayT(fromT + (toT - fromT) * eased);
-      if (p < 1) lgEaseRaf.current = requestAnimationFrame(tick);
-      else lgEaseRaf.current = null;
+      if (p < 1) {
+        lgEaseRaf.current = requestAnimationFrame(tick);
+      } else {
+        lgEaseRaf.current = null;
+      }
     }
     lgEaseRaf.current = requestAnimationFrame(tick);
   }
 
   // ─ Small section (IRIS_SM) ─────────────────────────────────────────
-  const [smN,           setSmN]           = useState(5);
-  const [smT,           setSmT]           = useState(0.35);
-  const [smHalfSpread,  setSmHalfSpread]  = useState(0.6);
-  const [smOverlap,     setSmOverlap]     = useState(0.65);
-  const [smCurve,       setSmCurve]       = useState(1.0);
-  const [smTwist,       setSmTwist]       = useState(0.35);
+  const [smN, setSmN] = useState(5);
+  const [smT, setSmT] = useState(0.35);
+  const [smHalfSpread, setSmHalfSpread] = useState(0.6);
+  const [smOverlap, setSmOverlap] = useState(0.65);
+  const [smCurve, setSmCurve] = useState(1.0);
+  const [smTwist, setSmTwist] = useState(0.35);
   const [smBladeStroke, setSmBladeStroke] = useState(4.0);
-  const [smShadow,      setSmShadow]      = useState(0.4);
+  const [smShadow, setSmShadow] = useState(0.4);
 
   // ─ Reset handlers (local only — no brand.ts I/O) ─────────────────────────
   function handleLgReset() {
-    setLgN(7); setLgT(0.3); lgTRef.current = 0.3; setLgDisplayT(0.3);
-    setLgHalfSpread(0.6); setLgOverlap(0.65); setLgCurve(1.0);
-    setLgTwist(0.35); setLgBladeStroke(0.5); setLgShadow(0.8);
+    setLgN(7);
+    setLgT(0.3);
+    lgTRef.current = 0.3;
+    setLgDisplayT(0.3);
+    setLgHalfSpread(0.6);
+    setLgOverlap(0.65);
+    setLgCurve(1.0);
+    setLgTwist(0.35);
+    setLgBladeStroke(0.5);
+    setLgShadow(0.8);
   }
 
   function handleSmReset() {
-    setSmN(5); setSmT(0.35);
-    setSmHalfSpread(0.6); setSmOverlap(0.65); setSmCurve(1.0);
-    setSmTwist(0.35); setSmBladeStroke(4.0); setSmShadow(0.4);
+    setSmN(5);
+    setSmT(0.35);
+    setSmHalfSpread(0.6);
+    setSmOverlap(0.65);
+    setSmCurve(1.0);
+    setSmTwist(0.35);
+    setSmBladeStroke(4.0);
+    setSmShadow(0.4);
   }
 
   // ─ Render ─────────────────────────────────────────────────────────────────
-  const lgShared = { N: lgN, halfSpread: lgHalfSpread, overlap: lgOverlap, curve: lgCurve, twist: lgTwist, bladeStroke: lgBladeStroke, shadowIntensity: lgShadow };
-  const smShared = { N: smN, halfSpread: smHalfSpread, overlap: smOverlap, curve: smCurve, twist: smTwist, bladeStroke: smBladeStroke, shadowIntensity: smShadow };
+  const lgShared = {
+    N: lgN,
+    halfSpread: lgHalfSpread,
+    overlap: lgOverlap,
+    curve: lgCurve,
+    twist: lgTwist,
+    bladeStroke: lgBladeStroke,
+    shadowIntensity: lgShadow,
+  };
+  const smShared = {
+    N: smN,
+    halfSpread: smHalfSpread,
+    overlap: smOverlap,
+    curve: smCurve,
+    twist: smTwist,
+    bladeStroke: smBladeStroke,
+    shadowIntensity: smShadow,
+  };
 
   return (
     <main className="mx-auto max-w-7xl px-6 py-10 space-y-14">
       {/* Header */}
       <div>
-        <div className="mb-1 text-xs text-gray-400 tracking-wide uppercase">Design Lab</div>
-        <h1 className="text-2xl font-semibold tracking-tight">Iris Pheno — Phenomenokinematic Model (demo)</h1>
+        <div className="mb-1 text-xs text-gray-400 tracking-wide uppercase">
+          Design Lab
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Iris Pheno — Phenomenokinematic Model (demo)
+        </h1>
         <p className="mt-1 text-sm text-gray-500">
-          Two optical presets, analogous to font optical sizing.
-          Large for hero renders (≥{LOGO_SM_THRESHOLD}px), SM for nav and favicon.
+          Two optical presets, analogous to font optical sizing. Large for hero
+          renders (≥{LOGO_SM_THRESHOLD}px), SM for nav and favicon.
         </p>
       </div>
 
@@ -368,7 +659,9 @@ export default function IrisPhenoLab() {
       <section>
         <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-5">
           Large size — <span className="font-mono">IRIS_LG</span>
-          <span className="ml-2 font-normal normal-case text-gray-400">(≥{LOGO_SM_THRESHOLD}px)</span>
+          <span className="ml-2 font-normal normal-case text-gray-400">
+            (≥{LOGO_SM_THRESHOLD}px)
+          </span>
         </h2>
         <div className="flex gap-6 items-start">
           {/* Preview + ring */}
@@ -381,9 +674,19 @@ export default function IrisPhenoLab() {
               onMouseLeave={lgMouseLeave}
             >
               {THEMES.map((theme, idx) => (
-                <div key={idx} className="flex-1 flex items-center justify-center rounded-xl py-14"
-                  style={{ backgroundColor: theme.bg }}>
-                  <ApertureMark {...lgShared} t={lgDisplayT} fill={theme.fill} gap={theme.gap} size={200} uid={`lg-${idx}`} />
+                <div
+                  key={idx}
+                  className="flex-1 flex items-center justify-center rounded-xl py-14"
+                  style={{ backgroundColor: theme.bg }}
+                >
+                  <ApertureMark
+                    {...lgShared}
+                    t={lgDisplayT}
+                    fill={theme.fill}
+                    gap={theme.gap}
+                    size={200}
+                    uid={`lg-${idx}`}
+                  />
                 </div>
               ))}
             </div>
@@ -392,14 +695,22 @@ export default function IrisPhenoLab() {
 
           {/* Controls */}
           <ParamControls
-            N={lgN} setN={setLgN}
-            aperture={lgT} setAperture={setLgT}
-            halfSpread={lgHalfSpread} setHalfSpread={setLgHalfSpread}
-            overlap={lgOverlap} setOverlap={setLgOverlap}
-            curve={lgCurve} setCurve={setLgCurve}
-            twist={lgTwist} setTwist={setLgTwist}
-            bladeStroke={lgBladeStroke} setBladeStroke={setLgBladeStroke}
-            shadow={lgShadow} setShadow={setLgShadow}
+            N={lgN}
+            setN={setLgN}
+            aperture={lgT}
+            setAperture={setLgT}
+            halfSpread={lgHalfSpread}
+            setHalfSpread={setLgHalfSpread}
+            overlap={lgOverlap}
+            setOverlap={setLgOverlap}
+            curve={lgCurve}
+            setCurve={setLgCurve}
+            twist={lgTwist}
+            setTwist={setLgTwist}
+            bladeStroke={lgBladeStroke}
+            setBladeStroke={setLgBladeStroke}
+            shadow={lgShadow}
+            setShadow={setLgShadow}
             onReset={handleLgReset}
           />
         </div>
@@ -408,8 +719,11 @@ export default function IrisPhenoLab() {
       {/* ── Section 2: Favicon / IRIS_SM ─────────────────────────────── */}
       <section>
         <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-5">
-          Favicon / icon size preview — <span className="font-mono">IRIS_SM</span>
-          <span className="ml-2 font-normal normal-case text-gray-400">(&lt;{LOGO_SM_THRESHOLD}px)</span>
+          Favicon / icon size preview —{" "}
+          <span className="font-mono">IRIS_SM</span>
+          <span className="ml-2 font-normal normal-case text-gray-400">
+            (&lt;{LOGO_SM_THRESHOLD}px)
+          </span>
         </h2>
         <div className="flex gap-6 items-start">
           {/* Preview grid */}
@@ -418,15 +732,34 @@ export default function IrisPhenoLab() {
               {THEMES.map((theme, tidx) => (
                 <div key={tidx} className="flex items-end gap-5 flex-wrap">
                   {PREVIEW_SIZES.map((sz) => (
-                    <div key={sz} className="flex flex-col items-center gap-1.5">
-                      <div className="flex items-center justify-center rounded"
-                        style={{ background: theme.bg, padding: sz < 32 ? 4 : 6 }}>
-                        <ApertureMark {...smShared} t={smT} fill={theme.fill} gap={theme.gap} size={sz} uid={`sm-${tidx}-${sz}`} />
+                    <div
+                      key={sz}
+                      className="flex flex-col items-center gap-1.5"
+                    >
+                      <div
+                        className="flex items-center justify-center rounded"
+                        style={{
+                          background: theme.bg,
+                          padding: sz < 32 ? 4 : 6,
+                        }}
+                      >
+                        <ApertureMark
+                          {...smShared}
+                          t={smT}
+                          fill={theme.fill}
+                          gap={theme.gap}
+                          size={sz}
+                          uid={`sm-${tidx}-${sz}`}
+                        />
                       </div>
-                      <span className="text-xs text-gray-400 tabular-nums">{sz}</span>
+                      <span className="text-xs text-gray-400 tabular-nums">
+                        {sz}
+                      </span>
                     </div>
                   ))}
-                  <span className="text-xs text-gray-300 self-end pb-4">{theme.label}</span>
+                  <span className="text-xs text-gray-300 self-end pb-4">
+                    {theme.label}
+                  </span>
                 </div>
               ))}
             </div>
@@ -434,14 +767,22 @@ export default function IrisPhenoLab() {
 
           {/* Controls */}
           <ParamControls
-            N={smN} setN={setSmN}
-            aperture={smT} setAperture={setSmT}
-            halfSpread={smHalfSpread} setHalfSpread={setSmHalfSpread}
-            overlap={smOverlap} setOverlap={setSmOverlap}
-            curve={smCurve} setCurve={setSmCurve}
-            twist={smTwist} setTwist={setSmTwist}
-            bladeStroke={smBladeStroke} setBladeStroke={setSmBladeStroke}
-            shadow={smShadow} setShadow={setSmShadow}
+            N={smN}
+            setN={setSmN}
+            aperture={smT}
+            setAperture={setSmT}
+            halfSpread={smHalfSpread}
+            setHalfSpread={setSmHalfSpread}
+            overlap={smOverlap}
+            setOverlap={setSmOverlap}
+            curve={smCurve}
+            setCurve={setSmCurve}
+            twist={smTwist}
+            setTwist={setSmTwist}
+            bladeStroke={smBladeStroke}
+            setBladeStroke={setSmBladeStroke}
+            shadow={smShadow}
+            setShadow={setSmShadow}
             onReset={handleSmReset}
           />
         </div>

--- a/src/app/[locale]/design-lab/iris/actions.ts
+++ b/src/app/[locale]/design-lab/iris/actions.ts
@@ -9,23 +9,37 @@ import { writeFile, readFile } from "fs/promises";
 import { exec } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { type IrisConfig, type IrisAnimation, type IrisInteractiveMode } from "@/config/iris-config";
+import {
+  type IrisConfig,
+  type IrisAnimation,
+  type IrisInteractiveMode,
+} from "@/config/iris-config";
 
 const execAsync = promisify(exec);
 
 const CONFIG_PATH = path.join(process.cwd(), "src/config/iris-config.ts");
 
 /** Find the body of the named preset object literal `export const NAME: IrisConfig = { … }`. */
-function findPresetBody(content: string, presetName: string): { bodyStart: number; bodyEnd: number } | null {
+function findPresetBody(
+  content: string,
+  presetName: string
+): { bodyStart: number; bodyEnd: number } | null {
   const startPattern = new RegExp(`export const ${presetName}[^{]*\\{`);
   const startMatch = startPattern.exec(content);
-  if (!startMatch) return null;
+  if (!startMatch) {
+    return null;
+  }
 
   const bodyStart = startMatch.index + startMatch[0].length;
-  let depth = 1, bodyEnd = bodyStart;
+  let depth = 1,
+    bodyEnd = bodyStart;
   while (bodyEnd < content.length && depth > 0) {
-    if (content[bodyEnd] === "{") depth++;
-    if (content[bodyEnd] === "}") depth--;
+    if (content[bodyEnd] === "{") {
+      depth++;
+    }
+    if (content[bodyEnd] === "}") {
+      depth--;
+    }
     bodyEnd++;
   }
   return { bodyStart, bodyEnd: bodyEnd - 1 };
@@ -38,13 +52,20 @@ function findPresetBody(content: string, presetName: string): { bodyStart: numbe
 function extractObjectBlock(body: string, key: string): string | null {
   const startPattern = new RegExp(`\\b${key}:\\s*\\{`);
   const startMatch = startPattern.exec(body);
-  if (!startMatch) return null;
+  if (!startMatch) {
+    return null;
+  }
 
   const blockStart = startMatch.index + startMatch[0].length;
-  let depth = 1, pos = blockStart;
+  let depth = 1,
+    pos = blockStart;
   while (pos < body.length && depth > 0) {
-    if (body[pos] === "{") depth++;
-    if (body[pos] === "}") depth--;
+    if (body[pos] === "{") {
+      depth++;
+    }
+    if (body[pos] === "}") {
+      depth--;
+    }
     pos++;
   }
   return body.slice(blockStart, pos - 1);
@@ -56,53 +77,76 @@ function serializeBody(v: IrisConfig): string {
   const add = (key: string, val: string) => lines.push(`  ${key}: ${val},`);
 
   // Kinematic fields
-  add("N",            String(v.N));
-  add("pinDistance",  String(v.pinDistance));
-  add("slotOffset",   v.slotOffset.toFixed(6));
-  add("bladeLength",  String(v.bladeLength));
-  add("bladeWidth",   String(v.bladeWidth));
-  add("openFStop",    v.openFStop.toFixed(1));
+  add("N", String(v.N));
+  add("pinDistance", String(v.pinDistance));
+  add("slotOffset", v.slotOffset.toFixed(6));
+  add("bladeLength", String(v.bladeLength));
+  add("bladeWidth", String(v.bladeWidth));
+  add("openFStop", v.openFStop.toFixed(1));
   add("defaultFStop", v.defaultFStop.toFixed(1));
-  add("size",         String(v.size));
+  add("size", String(v.size));
 
   // Appearance
-  if (v.strokeWidth !== undefined) add("strokeWidth", v.strokeWidth.toFixed(2));
-  if (v.bladeColor  !== undefined) add("bladeColor",  `"${v.bladeColor}"`);
-  if (v.strokeColor !== undefined) add("strokeColor", `"${v.strokeColor}"`);
+  if (v.strokeWidth !== undefined) {
+    add("strokeWidth", v.strokeWidth.toFixed(2));
+  }
+  if (v.bladeColor !== undefined) {
+    add("bladeColor", `"${v.bladeColor}"`);
+  }
+  if (v.strokeColor !== undefined) {
+    add("strokeColor", `"${v.strokeColor}"`);
+  }
 
   // Aperture limit
-  if (v.closedFStop !== undefined) add("closedFStop", String(v.closedFStop));
+  if (v.closedFStop !== undefined) {
+    add("closedFStop", String(v.closedFStop));
+  }
 
   // Interactive mode — serialized as a nested object
   if (v.interactive !== undefined) {
     if (v.interactive.type === "hover") {
       const h = v.interactive;
       const inner: string[] = [`    type: "hover",`];
-      if (h.hotzoneScaleH !== undefined) inner.push(`    hotzoneScaleH: ${h.hotzoneScaleH.toFixed(2)},`);
-      if (h.hotzoneScaleV !== undefined) inner.push(`    hotzoneScaleV: ${h.hotzoneScaleV.toFixed(2)},`);
-      if (h.easeOutMs     !== undefined) inner.push(`    easeOutMs: ${h.easeOutMs},`);
-      if (h.catchupMs     !== undefined) inner.push(`    catchupMs: ${h.catchupMs},`);
+      if (h.hotzoneScaleH !== undefined) {
+        inner.push(`    hotzoneScaleH: ${h.hotzoneScaleH.toFixed(2)},`);
+      }
+      if (h.hotzoneScaleV !== undefined) {
+        inner.push(`    hotzoneScaleV: ${h.hotzoneScaleV.toFixed(2)},`);
+      }
+      if (h.easeOutMs !== undefined) {
+        inner.push(`    easeOutMs: ${h.easeOutMs},`);
+      }
+      if (h.catchupMs !== undefined) {
+        inner.push(`    catchupMs: ${h.catchupMs},`);
+      }
       lines.push(`  interactive: {\n${inner.join("\n")}\n  },`);
     } else if (v.interactive.type === "tap") {
       const t = v.interactive;
       if (t.animation.type === "sweep") {
         lines.push(
           `  interactive: {\n` +
-          `    type: "tap",\n` +
-          `    animation: { type: "sweep", sweepMs: ${t.animation.sweepMs}, totalMs: ${t.animation.totalMs} },\n` +
-          `  },`
+            `    type: "tap",\n` +
+            `    animation: { type: "sweep", sweepMs: ${t.animation.sweepMs}, totalMs: ${t.animation.totalMs} },\n` +
+            `  },`
         );
       }
     }
   }
-  if (v.apertureStrip !== undefined) add("apertureStrip", String(v.apertureStrip));
+  if (v.apertureStrip !== undefined) {
+    add("apertureStrip", String(v.apertureStrip));
+  }
 
   // Mount animation
   if (v.onMount !== undefined && v.onMount.type === "sweep") {
-    add("onMount", `{ type: "sweep", sweepMs: ${v.onMount.sweepMs}, totalMs: ${v.onMount.totalMs} }`);
+    add(
+      "onMount",
+      `{ type: "sweep", sweepMs: ${v.onMount.sweepMs}, totalMs: ${v.onMount.totalMs} }`
+    );
   }
 
-  if (v.chaseTauMs !== undefined) add("chaseTauMs", String(v.chaseTauMs));
+  if (v.chaseTauMs !== undefined) {
+    add("chaseTauMs", String(v.chaseTauMs));
+  }
 
   return "\n" + lines.join("\n") + "\n";
 }
@@ -113,12 +157,14 @@ function serializeBody(v: IrisConfig): string {
  * Returns null if the preset cannot be found or parsed.
  */
 export async function readFromConfig(
-  presetName: "IRIS_HERO" | "IRIS_NAV" | "IRIS_LAB",
+  presetName: "IRIS_HERO" | "IRIS_NAV" | "IRIS_LAB"
 ): Promise<IrisConfig | null> {
   try {
     const content = await readFile(CONFIG_PATH, "utf-8");
     const range = findPresetBody(content, presetName);
-    if (!range) return null;
+    if (!range) {
+      return null;
+    }
 
     const body = content.slice(range.bodyStart, range.bodyEnd);
 
@@ -127,70 +173,94 @@ export async function readFromConfig(
       return m ? parseFloat(m[1]) : undefined;
     }
     function extractStr(key: string): string | undefined {
-      const m = new RegExp(`\\b${key}:\\s*"([^"]*)"`) .exec(body);
+      const m = new RegExp(`\\b${key}:\\s*"([^"]*)"`).exec(body);
       return m ? m[1] : undefined;
     }
-    function extractAnimation(key: string, src = body): IrisAnimation | undefined {
-      const m = new RegExp(`\\b${key}:\\s*\\{[^}]*type:\\s*"sweep"[^}]*sweepMs:\\s*(\\d+)[^}]*totalMs:\\s*(\\d+)`).exec(src);
-      if (m) return { type: "sweep", sweepMs: parseInt(m[1]), totalMs: parseInt(m[2]) };
+    function extractAnimation(
+      key: string,
+      src = body
+    ): IrisAnimation | undefined {
+      const m = new RegExp(
+        `\\b${key}:\\s*\\{[^}]*type:\\s*"sweep"[^}]*sweepMs:\\s*(\\d+)[^}]*totalMs:\\s*(\\d+)`
+      ).exec(src);
+      if (m) {
+        return {
+          type: "sweep",
+          sweepMs: parseInt(m[1]),
+          totalMs: parseInt(m[2]),
+        };
+      }
       return undefined;
     }
     function extractInteractive(): IrisInteractiveMode | undefined {
       const block = extractObjectBlock(body, "interactive");
-      if (!block) return undefined;
+      if (!block) {
+        return undefined;
+      }
 
       const typeMatch = /\btype:\s*"(hover|tap)"/.exec(block);
-      if (!typeMatch) return undefined;
+      if (!typeMatch) {
+        return undefined;
+      }
 
       if (typeMatch[1] === "hover") {
         return {
           type: "hover",
           hotzoneScaleH: extractNum("hotzoneScaleH", block),
           hotzoneScaleV: extractNum("hotzoneScaleV", block),
-          easeOutMs:     extractNum("easeOutMs",     block),
-          catchupMs:     extractNum("catchupMs",     block),
+          easeOutMs: extractNum("easeOutMs", block),
+          catchupMs: extractNum("catchupMs", block),
         };
       }
       if (typeMatch[1] === "tap") {
         const anim = extractAnimation("animation", block);
-        if (!anim) return undefined;
+        if (!anim) {
+          return undefined;
+        }
         return { type: "tap", animation: anim };
       }
       return undefined;
     }
 
     const N = extractNum("N");
-    const pinDistance  = extractNum("pinDistance");
-    const slotOffset   = extractNum("slotOffset");
-    const bladeLength  = extractNum("bladeLength");
-    const bladeWidth   = extractNum("bladeWidth");
-    const openFStop    = extractNum("openFStop");
+    const pinDistance = extractNum("pinDistance");
+    const slotOffset = extractNum("slotOffset");
+    const bladeLength = extractNum("bladeLength");
+    const bladeWidth = extractNum("bladeWidth");
+    const openFStop = extractNum("openFStop");
     const defaultFStop = extractNum("defaultFStop");
-    const size         = extractNum("size");
+    const size = extractNum("size");
 
     // Required fields — return null if any are missing.
-    if (N === undefined || pinDistance === undefined || slotOffset === undefined ||
-        bladeLength === undefined || bladeWidth === undefined || openFStop === undefined ||
-        defaultFStop === undefined || size === undefined) {
+    if (
+      N === undefined ||
+      pinDistance === undefined ||
+      slotOffset === undefined ||
+      bladeLength === undefined ||
+      bladeWidth === undefined ||
+      openFStop === undefined ||
+      defaultFStop === undefined ||
+      size === undefined
+    ) {
       return null;
     }
 
     return {
-      N:            Math.round(N),
+      N: Math.round(N),
       pinDistance,
       slotOffset,
       bladeLength,
       bladeWidth,
       openFStop,
       defaultFStop,
-      size:         Math.round(size),
-      strokeWidth:  extractNum("strokeWidth"),
-      bladeColor:   extractStr("bladeColor"),
-      strokeColor:  extractStr("strokeColor"),
-      closedFStop:  extractNum("closedFStop"),
-      interactive:  extractInteractive(),
-      onMount:      extractAnimation("onMount"),
-      chaseTauMs:   extractNum("chaseTauMs"),
+      size: Math.round(size),
+      strokeWidth: extractNum("strokeWidth"),
+      bladeColor: extractStr("bladeColor"),
+      strokeColor: extractStr("strokeColor"),
+      closedFStop: extractNum("closedFStop"),
+      interactive: extractInteractive(),
+      onMount: extractAnimation("onMount"),
+      chaseTauMs: extractNum("chaseTauMs"),
     };
   } catch {
     return null;
@@ -204,12 +274,14 @@ export async function readFromConfig(
  */
 export async function exportToConfig(
   presetName: "IRIS_HERO" | "IRIS_NAV" | "IRIS_LAB",
-  values: IrisConfig,
+  values: IrisConfig
 ): Promise<{ ok: boolean; error?: string }> {
   try {
     const originalContent = await readFile(CONFIG_PATH, "utf-8");
     const range = findPresetBody(originalContent, presetName);
-    if (!range) return { ok: false, error: `${presetName} not found in iris-config.ts` };
+    if (!range) {
+      return { ok: false, error: `${presetName} not found in iris-config.ts` };
+    }
 
     const newContent =
       originalContent.slice(0, range.bodyStart) +

--- a/src/app/[locale]/design-lab/iris/page.tsx
+++ b/src/app/[locale]/design-lab/iris/page.tsx
@@ -7,8 +7,6 @@ import {
   bladeShapePath,
   buildDerivedConfig,
   computeThetaOpen,
-  computeBladeCurvature,
-  tNormToTheta,
   DEFAULT_IRIS_CONFIG,
   apertureInradius,
   findThetaForInradius,
@@ -25,16 +23,23 @@ import Iris from "@/components/Iris";
 const VIEWBOX = "-150 -150 300 300";
 
 // ── F-stop ring constants ─────────────────────────────────────────────────────
-// Ring sits just inside the housing cover plate: inner radius = R_HOUSING − bladeWidth.
-// Ring radius is computed dynamically from bladeWidth in IrisStage.
-const FSTOP_RING_GAP = 4;                                    // inset from inner housing edge (SVG units)
-
 // Sequence: "A" (Auto) replaces f/1 and is drawn in red.
 // Arc spans 125° total across 9 equal steps (10 values → 9 gaps → 125/9 ≈ 13.9° per step).
-const FSTOP_SEQUENCE: (number | "A")[] = ["A", 1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22];
-const FSTOP_ARC_SPAN = 125;                                  // degrees
-const FSTOP_ANGLE_STEP = FSTOP_ARC_SPAN / (FSTOP_SEQUENCE.length - 1);  // ~13.9° per step
-const FSTOP_A_COLOR = "#f87171";                             // Auto marker red (Tailwind red-400)
+const FSTOP_SEQUENCE: (number | "A")[] = [
+  "A",
+  1.4,
+  2,
+  2.8,
+  4,
+  5.6,
+  8,
+  11,
+  16,
+  22,
+];
+const FSTOP_ARC_SPAN = 125; // degrees
+const FSTOP_ANGLE_STEP = FSTOP_ARC_SPAN / (FSTOP_SEQUENCE.length - 1); // ~13.9° per step
+const FSTOP_A_COLOR = "#f87171"; // Auto marker red (Tailwind red-400)
 
 // Continuous angle (degrees) in ring frame for a given f-stop value.
 // Uses the same log₂ scale as the sequence: f/1→0°, f/1.4→STEP, …, f/22→ARC_SPAN.
@@ -80,10 +85,17 @@ function IrisStage({
   const shape = useMemo(
     () => bladeShapePath(config),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [config.bladeLength, config.bladeWidth, config.bladeCurvature, config.pinDistance]
+    [
+      config.bladeLength,
+      config.bladeWidth,
+      config.bladeCurvature,
+      config.pinDistance,
+    ]
   );
 
-  if (blades.length === 0) return null;
+  if (blades.length === 0) {
+    return null;
+  }
 
   const b0 = blades[0];
   const b0AngleDeg = (b0.bladeAngle * 180) / Math.PI;
@@ -193,7 +205,12 @@ function IrisStage({
           <g key={i} mask={`url(#mask-stroke-${i}-${uid})`}>
             <g transform={`rotate(${(stepDeg * i).toFixed(3)})`}>
               <g transform={b0Transform}>
-                <path d={shape} fill="none" stroke={strokeColor} strokeWidth={strokeWidth} />
+                <path
+                  d={shape}
+                  fill="none"
+                  stroke={strokeColor}
+                  strokeWidth={strokeWidth}
+                />
               </g>
             </g>
           </g>
@@ -216,8 +233,7 @@ function IrisStage({
           />
           {/* Radial slots (one per blade) */}
           {Array.from({ length: N }, (_, i) => {
-            const slotAngle =
-              (i * 2 * Math.PI) / N + config.slotOffset + theta;
+            const slotAngle = (i * 2 * Math.PI) / N + config.slotOffset + theta;
             const r1 = 30;
             const r2 = R_HOUSING + 28;
             return (
@@ -263,87 +279,92 @@ function IrisStage({
       )}
 
       {/* ── Housing ring ── */}
-      <circle
-        r={R_HOUSING}
-        fill="none"
-        stroke="#d6d3d1"
-        strokeWidth="0.8"
-      />
-      <circle
-        r={R_HOUSING + 5}
-        fill="none"
-        stroke="#e7e5e4"
-        strokeWidth="2"
-      />
+      <circle r={R_HOUSING} fill="none" stroke="#d6d3d1" strokeWidth="0.8" />
+      <circle r={R_HOUSING + 5} fill="none" stroke="#e7e5e4" strokeWidth="2" />
 
       {/* ── F-stop ring overlay ── */}
-      {showFStopRing && (() => {
-        // The boundary between the visible dark iris body and the cream cover-plate zone
-        // is the inner edge of the housing cover plate: R_HOUSING − bladeWidth.
-        //
-        // Outer mode: ring circle at that boundary; labels go OUTWARD into the cream zone.
-        // Inner mode: ring circle at that boundary; labels go INWARD into the dark blade zone.
-        // The housing ring position is irrelevant to either mode.
-        const blackEdge = R_HOUSING - config.bladeWidth;
-        const ringR     = blackEdge;
-        // Outer mode: labels hug the iris black edge, tick above the text.
-        // Inner mode: labels sit inward of the ring circle.
-        const labelR    = fStopRingOuter ? blackEdge + 4 : blackEdge - 10;
+      {showFStopRing &&
+        (() => {
+          // The boundary between the visible dark iris body and the cream cover-plate zone
+          // is the inner edge of the housing cover plate: R_HOUSING − bladeWidth.
+          //
+          // Outer mode: ring circle at that boundary; labels go OUTWARD into the cream zone.
+          // Inner mode: ring circle at that boundary; labels go INWARD into the dark blade zone.
+          // The housing ring position is irrelevant to either mode.
+          const blackEdge = R_HOUSING - config.bladeWidth;
+          const ringR = blackEdge;
+          // Outer mode: labels hug the iris black edge, tick above the text.
+          // Inner mode: labels sit inward of the ring circle.
+          const labelR = fStopRingOuter ? blackEdge + 4 : blackEdge - 10;
 
-        const isValid = isFinite(fStop) && fStop >= 1;
-        // Rotate ring so that the current f-stop lands at 12 o'clock (-90° in SVG).
-        const ringRot = isValid ? -90 - fStopToRingAngle(fStop) : -90;
-        const ringRotStr = ringRot.toFixed(3);
+          const isValid = isFinite(fStop) && fStop >= 1;
+          // Rotate ring so that the current f-stop lands at 12 o'clock (-90° in SVG).
+          const ringRot = isValid ? -90 - fStopToRingAngle(fStop) : -90;
+          const ringRotStr = ringRot.toFixed(3);
 
-        // Fixed index marker position.
-        // Outer: above the text (further from centre) — starts 2 px beyond labelR.
-        // Inner: inward of the ring circle (unchanged).
-        const markerNear = fStopRingOuter ? labelR + 2    : ringR - 2;
-        const markerFar  = fStopRingOuter ? labelR + 7.6  : ringR - 7.6;
-        return (
-          <g>
-            {/* Fixed index mark at 12 o'clock — white, 5.6 px (70 % of original 8 px). */}
-            <line
-              x1="0" y1={-markerNear}
-              x2="0" y2={-markerFar}
-              stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round"
-            />
-            {/* Rotating group: ring arc + labels */}
-            <g transform={`rotate(${ringRotStr})`}>
-              <circle r={ringR} fill="none" stroke="#d4d4d8" strokeWidth="0.6" />
-              {FSTOP_SEQUENCE.map((f, i) => {
-                const deg = i * FSTOP_ANGLE_STEP;
-                const rad = (deg * Math.PI) / 180;
-                const cos = Math.cos(rad);
-                const sin = Math.sin(rad);
-                const lx = labelR * cos;
-                const ly = labelR * sin;
-                const isA = f === "A";
-                const label = isA ? "A"
-                  : (f === 1.4 || f === 2.8 || f === 5.6) ? (f as number).toFixed(1)
-                  : String(f);
-                // Radial orientation: text bottom faces the iris centre.
-                // deg=0 (12 o'clock within the rotating group) → rotate +90 = upright.
-                // Labels at the sides tilt to follow the arc curvature.
-                return (
-                  <g key={label}>
-                    <text
-                      x={lx.toFixed(3)} y={ly.toFixed(3)}
-                      textAnchor="middle" dominantBaseline="central"
-                      fontSize="7" fill={isA ? FSTOP_A_COLOR : "#71717a"}
-                      fontWeight={isA ? "600" : "normal"}
-                      fontFamily="ui-monospace, SFMono-Regular, monospace"
-                      transform={`rotate(${(deg + 90).toFixed(3)}, ${lx.toFixed(3)}, ${ly.toFixed(3)})`}
-                    >
-                      {label}
-                    </text>
-                  </g>
-                );
-              })}
+          // Fixed index marker position.
+          // Outer: above the text (further from centre) — starts 2 px beyond labelR.
+          // Inner: inward of the ring circle (unchanged).
+          const markerNear = fStopRingOuter ? labelR + 2 : ringR - 2;
+          const markerFar = fStopRingOuter ? labelR + 7.6 : ringR - 7.6;
+          return (
+            <g>
+              {/* Fixed index mark at 12 o'clock — white, 5.6 px (70 % of original 8 px). */}
+              <line
+                x1="0"
+                y1={-markerNear}
+                x2="0"
+                y2={-markerFar}
+                stroke="#ffffff"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              {/* Rotating group: ring arc + labels */}
+              <g transform={`rotate(${ringRotStr})`}>
+                <circle
+                  r={ringR}
+                  fill="none"
+                  stroke="#d4d4d8"
+                  strokeWidth="0.6"
+                />
+                {FSTOP_SEQUENCE.map((f, i) => {
+                  const deg = i * FSTOP_ANGLE_STEP;
+                  const rad = (deg * Math.PI) / 180;
+                  const cos = Math.cos(rad);
+                  const sin = Math.sin(rad);
+                  const lx = labelR * cos;
+                  const ly = labelR * sin;
+                  const isA = f === "A";
+                  const label = isA
+                    ? "A"
+                    : f === 1.4 || f === 2.8 || f === 5.6
+                      ? (f as number).toFixed(1)
+                      : String(f);
+                  // Radial orientation: text bottom faces the iris centre.
+                  // deg=0 (12 o'clock within the rotating group) → rotate +90 = upright.
+                  // Labels at the sides tilt to follow the arc curvature.
+                  return (
+                    <g key={label}>
+                      <text
+                        x={lx.toFixed(3)}
+                        y={ly.toFixed(3)}
+                        textAnchor="middle"
+                        dominantBaseline="central"
+                        fontSize="7"
+                        fill={isA ? FSTOP_A_COLOR : "#71717a"}
+                        fontWeight={isA ? "600" : "normal"}
+                        fontFamily="ui-monospace, SFMono-Regular, monospace"
+                        transform={`rotate(${(deg + 90).toFixed(3)}, ${lx.toFixed(3)}, ${ly.toFixed(3)})`}
+                      >
+                        {label}
+                      </text>
+                    </g>
+                  );
+                })}
+              </g>
             </g>
-          </g>
-        );
-      })()}
+          );
+        })()}
     </svg>
   );
 }
@@ -355,16 +376,17 @@ function IrisStage({
 const FSTOP_OPTIONS = FSTOP_SEQUENCE.filter((f): f is number => f !== "A");
 
 function formatFStop(f: number): string {
-  if (!isFinite(f) || f > 22) return "f/—";
+  if (!isFinite(f) || f > 22) {
+    return "f/—";
+  }
   return `f/${f.toFixed(1)}`;
 }
-
-
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function ApertureV2Lab() {
-  const [config, setConfig] = useState<IrisMechanismConfig>(DEFAULT_IRIS_CONFIG);
+  const [config, setConfig] =
+    useState<IrisMechanismConfig>(DEFAULT_IRIS_CONFIG);
 
   // Studio profiles: all three read/write iris-config.ts via server actions.
   // The workspace seeds from IRIS_LAB on mount.
@@ -378,7 +400,7 @@ export default function ApertureV2Lab() {
   const [exportStatus, setExportStatus] = useState<string | null>(null);
 
   const setField = (patch: Partial<IrisMechanismConfig>) => {
-    setConfig(prev => {
+    setConfig((prev) => {
       const next = { ...prev, ...patch };
       // Keep pinDistance inside [Rp, bladeLength − 1] after any change.
       // Rp is derived from bladeWidth, so it shifts when bladeWidth changes.
@@ -393,19 +415,31 @@ export default function ApertureV2Lab() {
 
   // Load the selected profile's params into the workspace.
   async function handleLoad() {
-    const key = selectedProfile === "production:hero" ? "IRIS_HERO"
-      : selectedProfile === "production:nav" ? "IRIS_NAV" : "IRIS_LAB";
+    const key =
+      selectedProfile === "production:hero"
+        ? "IRIS_HERO"
+        : selectedProfile === "production:nav"
+          ? "IRIS_NAV"
+          : "IRIS_LAB";
     const v = await readFromConfig(key);
-    if (!v) return;
+    if (!v) {
+      return;
+    }
     applyConfig(v);
   }
 
   // Apply a loaded IrisConfig to all workspace state variables.
   function applyConfig(v: IrisConfig) {
     setConfig(buildDerivedConfig(v, R_HOUSING));
-    if (v.bladeColor)  setBladeGray(parseInt(v.bladeColor.slice(1, 3), 16));
-    if (v.strokeColor) setStrokeGray(parseInt(v.strokeColor.slice(1, 3), 16));
-    if (v.strokeWidth !== undefined) setStrokeWidth(v.strokeWidth);
+    if (v.bladeColor) {
+      setBladeGray(parseInt(v.bladeColor.slice(1, 3), 16));
+    }
+    if (v.strokeColor) {
+      setStrokeGray(parseInt(v.strokeColor.slice(1, 3), 16));
+    }
+    if (v.strokeWidth !== undefined) {
+      setStrokeWidth(v.strokeWidth);
+    }
     setOpenFStop(v.openFStop);
     setDefaultFStop(v.defaultFStop);
     const hc = v.interactive?.type === "hover" ? v.interactive : null;
@@ -425,8 +459,12 @@ export default function ApertureV2Lab() {
   // Export current workspace params to the selected profile.
   async function handleExport() {
     setExportStatus("Saving…");
-    const profileSize = selectedProfile === "production:hero" ? IRIS_HERO.size
-      : selectedProfile === "production:nav" ? IRIS_NAV.size : IRIS_LAB.size;
+    const profileSize =
+      selectedProfile === "production:hero"
+        ? IRIS_HERO.size
+        : selectedProfile === "production:nav"
+          ? IRIS_NAV.size
+          : IRIS_LAB.size;
     const stored: IrisConfig = {
       N: config.N,
       pinDistance: config.pinDistance,
@@ -439,35 +477,52 @@ export default function ApertureV2Lab() {
       bladeColor: grayHex(bladeGray),
       strokeColor: grayHex(strokeGray),
       strokeWidth,
-      interactive: interactive ? {
-        type: "hover" as const,
-        hotzoneScaleH,
-        hotzoneScaleV,
-        easeOutMs,
-        catchupMs,
-      } : undefined,
+      interactive: interactive
+        ? {
+            type: "hover" as const,
+            hotzoneScaleH,
+            hotzoneScaleV,
+            easeOutMs,
+            catchupMs,
+          }
+        : undefined,
       onMount,
       closedFStop,
       chaseTauMs,
     };
-    const key = selectedProfile === "production:hero" ? "IRIS_HERO"
-      : selectedProfile === "production:nav" ? "IRIS_NAV" : "IRIS_LAB";
+    const key =
+      selectedProfile === "production:hero"
+        ? "IRIS_HERO"
+        : selectedProfile === "production:nav"
+          ? "IRIS_NAV"
+          : "IRIS_LAB";
     const res = await exportToConfig(key, stored);
     setExportStatus(res.ok ? `✓ Written to ${key}` : `✗ ${res.error}`);
-    if (res.ok) setTimeout(() => setExportStatus(null), 3000);
+    if (res.ok) {
+      setTimeout(() => setExportStatus(null), 3000);
+    }
   }
 
   // Seed the workspace from IRIS_LAB on first mount.
   useEffect(() => {
-    readFromConfig("IRIS_LAB").then(v => { if (v) applyConfig(v); });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    readFromConfig("IRIS_LAB").then((v) => {
+      if (v) {
+        applyConfig(v);
+      }
+    });
+  }, []);
 
   // Derive geometry-constrained parameters via the shared helper.
   const derivedConfig = useMemo(
     () => buildDerivedConfig(config, R_HOUSING),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [config.N, config.pinDistance, config.slotOffset,
-     config.bladeLength, config.bladeWidth]
+    [
+      config.N,
+      config.pinDistance,
+      config.slotOffset,
+      config.bladeLength,
+      config.bladeWidth,
+    ]
   );
 
   // Physical range: [θ_open, kinRange.max]
@@ -500,7 +555,7 @@ export default function ApertureV2Lab() {
   const [hotzoneScaleH, setHotzoneScaleH] = useState(1.5);
   const [hotzoneScaleV, setHotzoneScaleV] = useState(1.0);
   const [strokeWidth, setStrokeWidth] = useState(0.5);
-  const [bladeGray, setBladeGray] = useState(24);   // 0=black … 255=white; default ≈ zinc-900
+  const [bladeGray, setBladeGray] = useState(24); // 0=black … 255=white; default ≈ zinc-900
   const [strokeGray, setStrokeGray] = useState(63); // default ≈ zinc-700
 
   function grayHex(v: number) {
@@ -512,26 +567,41 @@ export default function ApertureV2Lab() {
   // stays in sync with every slider/input change without requiring a Load.
   // The small right-panel preview renders as non-interactive (interactive: false)
   // to avoid mouse-follow in a thumbnail; the full-size DL stage handles that.
-  const previewConfig = useMemo((): IrisConfig => ({
-    N: config.N,
-    pinDistance: config.pinDistance,
-    slotOffset: config.slotOffset,
-    bladeLength: config.bladeLength,
-    bladeWidth: config.bladeWidth,
-    openFStop,
-    defaultFStop,
-    size: previewSize,
-    bladeColor: grayHex(bladeGray),
-    strokeColor: grayHex(strokeGray),
-    strokeWidth,
-    interactive: undefined,
-    onMount,
-    closedFStop,
-    chaseTauMs,
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [config.N, config.pinDistance, config.slotOffset, config.bladeLength, config.bladeWidth,
-      openFStop, defaultFStop, closedFStop, chaseTauMs,
-      previewSize, bladeGray, strokeGray, strokeWidth, onMount]);
+  const previewConfig = useMemo(
+    (): IrisConfig => ({
+      N: config.N,
+      pinDistance: config.pinDistance,
+      slotOffset: config.slotOffset,
+      bladeLength: config.bladeLength,
+      bladeWidth: config.bladeWidth,
+      openFStop,
+      defaultFStop,
+      size: previewSize,
+      bladeColor: grayHex(bladeGray),
+      strokeColor: grayHex(strokeGray),
+      strokeWidth,
+      interactive: undefined,
+      onMount,
+      closedFStop,
+      chaseTauMs,
+    }),
+    [
+      config.N,
+      config.pinDistance,
+      config.slotOffset,
+      config.bladeLength,
+      config.bladeWidth,
+      openFStop,
+      defaultFStop,
+      closedFStop,
+      chaseTauMs,
+      previewSize,
+      bladeGray,
+      strokeGray,
+      strokeWidth,
+      onMount,
+    ]
+  );
 
   // Animation: theta oscillates between range.min and range.max
   const rafRef = useRef<number | undefined>(undefined);
@@ -545,7 +615,9 @@ export default function ApertureV2Lab() {
 
   useEffect(() => {
     if (!isPlaying) {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
       startRef.current = undefined;
       return;
     }
@@ -572,7 +644,9 @@ export default function ApertureV2Lab() {
 
     rafRef.current = requestAnimationFrame(tick);
     return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
     };
   }, [isPlaying, speed, range]);
 
@@ -595,37 +669,54 @@ export default function ApertureV2Lab() {
   const inradiusCurrent = useMemo(
     () => apertureInradius(theta, derivedConfig),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [theta, derivedConfig.N, derivedConfig.pivotRadius, derivedConfig.pinDistance,
-     derivedConfig.slotOffset, derivedConfig.bladeLength, derivedConfig.bladeWidth,
-     derivedConfig.bladeCurvature]
+    [
+      theta,
+      derivedConfig.N,
+      derivedConfig.pivotRadius,
+      derivedConfig.pinDistance,
+      derivedConfig.slotOffset,
+      derivedConfig.bladeLength,
+      derivedConfig.bladeWidth,
+      derivedConfig.bladeCurvature,
+    ]
   );
   const inradiusOpen = useMemo(
     () => apertureInradius(range.min, derivedConfig),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [range.min, derivedConfig.N, derivedConfig.pivotRadius, derivedConfig.pinDistance,
-     derivedConfig.slotOffset, derivedConfig.bladeLength, derivedConfig.bladeWidth,
-     derivedConfig.bladeCurvature]
+    [
+      range.min,
+      derivedConfig.N,
+      derivedConfig.pivotRadius,
+      derivedConfig.pinDistance,
+      derivedConfig.slotOffset,
+      derivedConfig.bladeLength,
+      derivedConfig.bladeWidth,
+      derivedConfig.bladeCurvature,
+    ]
   );
-  const fStop = inradiusCurrent > 0.5
-    ? openFStop * (inradiusOpen / inradiusCurrent)
-    : Infinity;
+  const fStop =
+    inradiusCurrent > 0.5
+      ? openFStop * (inradiusOpen / inradiusCurrent)
+      : Infinity;
 
   // In Auto mode (openPct === 0) the ring stays pinned at "A" (ring angle 0 = f/1.0 position).
   // The blades render at the theta corresponding to defaultFStop (configurable, default f/5.6).
   const autoTheta = useMemo(
     () => findThetaForFStop(defaultFStop, derivedConfig, range, openFStop),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [defaultFStop, openFStop, range.min, range.max, derivedConfig.N, derivedConfig.pivotRadius,
-     derivedConfig.pinDistance, derivedConfig.slotOffset, derivedConfig.bladeLength,
-     derivedConfig.bladeWidth, derivedConfig.bladeCurvature]
-  );
-  // Theta corresponding to the far-closed end of the follow-mouse range (f/22).
-  const thetaF22 = useMemo(
-    () => findThetaForFStop(22, derivedConfig, range, openFStop),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [openFStop, range.min, range.max, derivedConfig.N, derivedConfig.pivotRadius,
-     derivedConfig.pinDistance, derivedConfig.slotOffset, derivedConfig.bladeLength,
-     derivedConfig.bladeWidth, derivedConfig.bladeCurvature]
+    [
+      defaultFStop,
+      openFStop,
+      range.min,
+      range.max,
+      derivedConfig.N,
+      derivedConfig.pivotRadius,
+      derivedConfig.pinDistance,
+      derivedConfig.slotOffset,
+      derivedConfig.bladeLength,
+      derivedConfig.bladeWidth,
+      derivedConfig.bladeCurvature,
+    ]
   );
   // Ring shows "A" (ring angle 0 → position 0 → f=1.0 in the log-scale mapping)
   // so that the pointer stays at "A" instead of rotating to 5.6.
@@ -646,37 +737,52 @@ export default function ApertureV2Lab() {
   // Entry:  offset recorded on first hotzone frame, decays (1-p)^2 over 300 ms.
   // Leave:  cubic ease-out back to autoTheta over 700 ms.
   // chaseTauMs / easeOutMs / catchupMs / hotzoneScale / closedFStop come from state (controls).
-  const followTargetRef      = useRef(0);
+  const followTargetRef = useRef(0);
   const followEntryOffsetRef = useRef(0);
-  const followEntryTimeRef   = useRef(0);
-  const wasInHotzoneRef      = useRef(false);
-  const followChaseRafRef    = useRef<number | null>(null);
-  const followLeaveRafRef    = useRef<number | null>(null);
-  const followLastFrameRef   = useRef(0);
+  const followEntryTimeRef = useRef(0);
+  const wasInHotzoneRef = useRef(false);
+  const followChaseRafRef = useRef<number | null>(null);
+  const followLeaveRafRef = useRef<number | null>(null);
+  const followLastFrameRef = useRef(0);
 
   // Cleanup all RAFs on unmount.
-  useEffect(() => () => {
-    if (followChaseRafRef.current) cancelAnimationFrame(followChaseRafRef.current);
-    if (followLeaveRafRef.current) cancelAnimationFrame(followLeaveRafRef.current);
-  }, []);
+  useEffect(
+    () => () => {
+      if (followChaseRafRef.current) {
+        cancelAnimationFrame(followChaseRafRef.current);
+      }
+      if (followLeaveRafRef.current) {
+        cancelAnimationFrame(followLeaveRafRef.current);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     if (!interactive) {
       wasInHotzoneRef.current = false;
-      if (followChaseRafRef.current) { cancelAnimationFrame(followChaseRafRef.current); followChaseRafRef.current = null; }
-      if (followLeaveRafRef.current) { cancelAnimationFrame(followLeaveRafRef.current); followLeaveRafRef.current = null; }
+      if (followChaseRafRef.current) {
+        cancelAnimationFrame(followChaseRafRef.current);
+        followChaseRafRef.current = null;
+      }
+      if (followLeaveRafRef.current) {
+        cancelAnimationFrame(followLeaveRafRef.current);
+        followLeaveRafRef.current = null;
+      }
       return;
     }
 
     // Chase loop: runs while in hotzone, smoothly tracks followTargetRef.
     function startChase() {
-      if (followChaseRafRef.current) return; // already running
+      if (followChaseRafRef.current) {
+        return;
+      } // already running
       followLastFrameRef.current = performance.now();
       function chaseTick(now: number) {
         const dt = Math.min(now - followLastFrameRef.current, 64); // cap at ~4 frames
         followLastFrameRef.current = now;
-        const k    = 1 - Math.exp(-dt / chaseTauMs);
-        const cur  = thetaRef.current;
+        const k = 1 - Math.exp(-dt / chaseTauMs);
+        const cur = thetaRef.current;
         const next = cur + (followTargetRef.current - cur) * k;
         setTheta(next);
         thetaRef.current = next;
@@ -686,47 +792,59 @@ export default function ApertureV2Lab() {
     }
 
     function stopChase() {
-      if (followChaseRafRef.current) { cancelAnimationFrame(followChaseRafRef.current); followChaseRafRef.current = null; }
+      if (followChaseRafRef.current) {
+        cancelAnimationFrame(followChaseRafRef.current);
+        followChaseRafRef.current = null;
+      }
     }
 
     function handleMouseMove(e: MouseEvent) {
-      if (!irisContainerRef.current) return;
+      if (!irisContainerRef.current) {
+        return;
+      }
       const rect = irisContainerRef.current.getBoundingClientRect();
 
       // D = actual iris diameter in CSS px.
       // SVG viewBox is 300 units wide; iris black body radius = R_HOUSING − bladeWidth.
-      const scale    = rect.width / 300;
+      const scale = rect.width / 300;
       const irisSVGR = R_HOUSING - derivedConfig.bladeWidth;
-      const D        = 2 * irisSVGR * scale;
+      const D = 2 * irisSVGR * scale;
 
-      const cx = rect.left + rect.width  / 2;
-      const cy = rect.top  + rect.height / 2;
-      const hotLeft   = cx - D * hotzoneScaleH;
-      const hotRight  = cx + D * hotzoneScaleH;
-      const hotTop    = cy - D * hotzoneScaleV;
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const hotLeft = cx - D * hotzoneScaleH;
+      const hotRight = cx + D * hotzoneScaleH;
+      const hotTop = cy - D * hotzoneScaleV;
       const hotBottom = cy + D * hotzoneScaleV;
 
       const inHot =
-        e.clientX >= hotLeft && e.clientX <= hotRight &&
-        e.clientY >= hotTop  && e.clientY <= hotBottom;
+        e.clientX >= hotLeft &&
+        e.clientX <= hotRight &&
+        e.clientY >= hotTop &&
+        e.clientY <= hotBottom;
 
       if (!inHot) {
         if (wasInHotzoneRef.current) {
           wasInHotzoneRef.current = false;
           stopChase();
           // Cubic ease-out back to autoTheta over easeOutMs
-          if (followLeaveRafRef.current) cancelAnimationFrame(followLeaveRafRef.current);
+          if (followLeaveRafRef.current) {
+            cancelAnimationFrame(followLeaveRafRef.current);
+          }
           const fromTheta = thetaRef.current;
-          const toTheta   = autoTheta;
-          const startMs   = performance.now();
+          const toTheta = autoTheta;
+          const startMs = performance.now();
           function leaveTick(now: number) {
-            const p     = Math.min(1, (now - startMs) / easeOutMs);
+            const p = Math.min(1, (now - startMs) / easeOutMs);
             const eased = 1 - (1 - p) ** 3;
-            const v     = fromTheta + (toTheta - fromTheta) * eased;
+            const v = fromTheta + (toTheta - fromTheta) * eased;
             setTheta(v);
             thetaRef.current = v;
-            if (p < 1) followLeaveRafRef.current = requestAnimationFrame(leaveTick);
-            else followLeaveRafRef.current = null;
+            if (p < 1) {
+              followLeaveRafRef.current = requestAnimationFrame(leaveTick);
+            } else {
+              followLeaveRafRef.current = null;
+            }
           }
           followLeaveRafRef.current = requestAnimationFrame(leaveTick);
         }
@@ -734,31 +852,40 @@ export default function ApertureV2Lab() {
       }
 
       // Cancel any in-progress leave animation and ensure chase is running
-      if (followLeaveRafRef.current) { cancelAnimationFrame(followLeaveRafRef.current); followLeaveRafRef.current = null; }
+      if (followLeaveRafRef.current) {
+        cancelAnimationFrame(followLeaveRafRef.current);
+        followLeaveRafRef.current = null;
+      }
       startChase();
 
       // Map horizontal position within hotzone → aperture diameter (inradius) linearly.
       // Left = max open (rOpen), right = r at f/22. Then binary-search for theta.
       // This is a log transform in f-stop space: large-aperture end feels "faster",
       // small-aperture end feels "slower" — matching a physical aperture ring.
-      const t       = Math.max(0, Math.min(1, (e.clientX - hotLeft) / (hotRight - hotLeft)));
-      const rOpen   = inradiusOpen;
-      const r22     = (openFStop * rOpen) / closedFStop;
+      const t = Math.max(
+        0,
+        Math.min(1, (e.clientX - hotLeft) / (hotRight - hotLeft))
+      );
+      const rOpen = inradiusOpen;
+      const r22 = (openFStop * rOpen) / closedFStop;
       const targetR = rOpen + t * (r22 - rOpen); // linear in diameter
       const rawTarget = findThetaForInradius(targetR, derivedConfig, range);
 
       if (!wasInHotzoneRef.current) {
         // First frame: record entry offset for smooth catchup
         followEntryOffsetRef.current = thetaRef.current - rawTarget;
-        followEntryTimeRef.current   = performance.now();
-        wasInHotzoneRef.current      = true;
+        followEntryTimeRef.current = performance.now();
+        wasInHotzoneRef.current = true;
       }
 
       // Quadratic ease-out on entry offset: (1-p)^2 over catchupMs
-      const p                  = Math.min(1, (performance.now() - followEntryTimeRef.current) / catchupMs);
-      const off                = followEntryOffsetRef.current * (1 - p) ** 2;
-      followTargetRef.current  = rawTarget + off; // chase RAF reads this every frame
-      startRef.current         = undefined;
+      const p = Math.min(
+        1,
+        (performance.now() - followEntryTimeRef.current) / catchupMs
+      );
+      const off = followEntryOffsetRef.current * (1 - p) ** 2;
+      followTargetRef.current = rawTarget + off; // chase RAF reads this every frame
+      startRef.current = undefined;
     }
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -767,11 +894,28 @@ export default function ApertureV2Lab() {
       stopChase();
       wasInHotzoneRef.current = false;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [interactive, openFStop, closedFStop, chaseTauMs, easeOutMs, catchupMs, hotzoneScaleH, hotzoneScaleV,
-      range.min, range.max, inradiusOpen, autoTheta, derivedConfig.bladeWidth,
-      derivedConfig.N, derivedConfig.pivotRadius, derivedConfig.pinDistance,
-      derivedConfig.slotOffset, derivedConfig.bladeLength, derivedConfig.bladeCurvature]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    interactive,
+    openFStop,
+    closedFStop,
+    chaseTauMs,
+    easeOutMs,
+    catchupMs,
+    hotzoneScaleH,
+    hotzoneScaleV,
+    range.min,
+    range.max,
+    inradiusOpen,
+    autoTheta,
+    derivedConfig.bladeWidth,
+    derivedConfig.N,
+    derivedConfig.pivotRadius,
+    derivedConfig.pinDistance,
+    derivedConfig.slotOffset,
+    derivedConfig.bladeLength,
+    derivedConfig.bladeCurvature,
+  ]);
 
   return (
     <main
@@ -779,7 +923,10 @@ export default function ApertureV2Lab() {
       className="flex flex-col"
     >
       {/* Header */}
-      <div className="pt-8 pb-4" style={{ paddingLeft: 100, paddingRight: 100 }}>
+      <div
+        className="pt-8 pb-4"
+        style={{ paddingLeft: 100, paddingRight: 100 }}
+      >
         <div className="text-xs text-zinc-600 uppercase tracking-wider mb-1">
           Design Lab
         </div>
@@ -787,19 +934,19 @@ export default function ApertureV2Lab() {
           Iris — Kinematic Parameter Studio
         </h1>
         <p className="text-sm text-zinc-500 mt-1">
-          3-body kinematic model · base plate + actuator ring + {config.N}{" "}
-          rigid blades · solved analytically
+          3-body kinematic model · base plate + actuator ring + {config.N} rigid
+          blades · solved analytically
         </p>
       </div>
 
       {/* Body */}
-      <div className="flex-1 flex pb-8 gap-8 items-start" style={{ paddingLeft: 100, paddingRight: 100 }}>
+      <div
+        className="flex-1 flex pb-8 gap-8 items-start"
+        style={{ paddingLeft: 100, paddingRight: 100 }}
+      >
         {/* Iris display */}
         <div className="flex flex-col items-center gap-5">
-          <div
-            ref={irisContainerRef}
-            style={{ width: 480, height: 480 }}
-          >
+          <div ref={irisContainerRef} style={{ width: 480, height: 480 }}>
             <IrisStage
               config={derivedConfig}
               theta={displayTheta}
@@ -834,19 +981,20 @@ export default function ApertureV2Lab() {
             <div className="flex justify-between text-xs font-mono mt-1">
               <span className="text-zinc-500">open</span>
               <span className="text-zinc-600">
-                {openPct}%
-                <span className="text-zinc-400 ml-2">·</span>
+                {openPct}%<span className="text-zinc-400 ml-2">·</span>
                 <span className="ml-2">{formatFStop(fStop)}</span>
               </span>
               <span className="text-zinc-500">closed</span>
             </div>
           </div>
-
         </div>
 
         {/* Production preview — renders the current config via the real Iris
             component at its actual production pixel size. Stays live with controls. */}
-        <div className="flex flex-col items-center gap-2" style={{ paddingTop: 4 }}>
+        <div
+          className="flex flex-col items-center gap-2"
+          style={{ paddingTop: 4 }}
+        >
           <span className="text-xs font-mono text-zinc-400">
             {previewConfig.size} px
           </span>
@@ -854,75 +1002,130 @@ export default function ApertureV2Lab() {
         </div>
 
         {/* Controls — 3-column grid */}
-        <div style={{ flexShrink: 0, width: 580, display: "grid", gridTemplateColumns: "repeat(3, 1fr)", columnGap: 32, paddingTop: 4 }}>
-
+        <div
+          style={{
+            flexShrink: 0,
+            width: 580,
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            columnGap: 32,
+            paddingTop: 4,
+          }}
+        >
           {/* ── Col 1: Playback & View ── */}
           <div className="space-y-5">
             <section className="space-y-2.5">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Studio</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Studio
+              </p>
               {/* Profile selector — switching does not load; only Load/Export act */}
               <div className="flex gap-1.5">
-                {(["lab", "production:hero", "production:nav"] as const).map((profile) => (
-                  <button
-                    key={profile}
-                    onClick={() => setSelectedProfile(profile)}
-                    className="flex-1 rounded py-1.5 text-xs font-mono font-medium transition-colors"
-                    style={selectedProfile === profile
-                      ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                      : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
-                  >
-                    {profile === "lab" ? "Lab"
-                      : profile === "production:hero" ? "Hero"
-                      : "Nav"}
-                  </button>
-                ))}
+                {(["lab", "production:hero", "production:nav"] as const).map(
+                  (profile) => (
+                    <button
+                      key={profile}
+                      onClick={() => setSelectedProfile(profile)}
+                      className="flex-1 rounded py-1.5 text-xs font-mono font-medium transition-colors"
+                      style={
+                        selectedProfile === profile
+                          ? {
+                              background: "#18181b",
+                              color: "#fff",
+                              border: "1px solid #18181b",
+                            }
+                          : {
+                              background: "#fff",
+                              color: "#3f3f46",
+                              border: "1px solid #d4d4d8",
+                            }
+                      }
+                    >
+                      {profile === "lab"
+                        ? "Lab"
+                        : profile === "production:hero"
+                          ? "Hero"
+                          : "Nav"}
+                    </button>
+                  )
+                )}
               </div>
               <div className="flex gap-1.5">
                 <button
                   onClick={handleLoad}
                   className="flex-1 rounded py-1.5 text-xs font-medium transition-colors"
-                  style={{ background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                  style={{
+                    background: "#fff",
+                    color: "#3f3f46",
+                    border: "1px solid #d4d4d8",
+                  }}
                 >
                   Load
                 </button>
                 <button
                   onClick={handleExport}
                   className="flex-1 rounded py-1.5 text-xs font-medium transition-colors"
-                  style={{ background: "#18181b", color: "#fff", border: "1px solid #18181b" }}
+                  style={{
+                    background: "#18181b",
+                    color: "#fff",
+                    border: "1px solid #18181b",
+                  }}
                 >
                   → Export
                 </button>
               </div>
-              {exportStatus && (
-                exportStatus.startsWith("✓") ? (
-                  <p className="text-xs font-mono text-green-600">{exportStatus}</p>
+              {exportStatus &&
+                (exportStatus.startsWith("✓") ? (
+                  <p className="text-xs font-mono text-green-600">
+                    {exportStatus}
+                  </p>
                 ) : (
                   <pre className="text-xs font-mono text-red-500 whitespace-pre-wrap break-all max-h-48 overflow-y-auto rounded bg-red-50 p-2 border border-red-200">
                     {exportStatus}
                   </pre>
-                )
-              )}
+                ))}
               {/* Production size indicator */}
               {selectedProfile !== "lab" && (
                 <p className="text-xs font-mono text-zinc-400">
-                  {selectedProfile === "production:hero" ? IRIS_HERO.size : IRIS_NAV.size} px production
+                  {selectedProfile === "production:hero"
+                    ? IRIS_HERO.size
+                    : IRIS_NAV.size}{" "}
+                  px production
                 </p>
               )}
             </section>
 
             <section className="space-y-3">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Animation</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Animation
+              </p>
               <button
                 onClick={() => {
-                  if (interactive) return; // disabled in follow-mouse mode
+                  if (interactive) {
+                    return;
+                  } // disabled in follow-mouse mode
                   setIsPlaying((p) => !p);
                 }}
                 className="w-full rounded py-2 text-sm font-medium transition-colors"
-                style={interactive
-                  ? { background: "#fff", color: "#a1a1aa", border: "1px solid #e4e4e7", cursor: "not-allowed" }
-                  : isPlaying
-                    ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                    : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                style={
+                  interactive
+                    ? {
+                        background: "#fff",
+                        color: "#a1a1aa",
+                        border: "1px solid #e4e4e7",
+                        cursor: "not-allowed",
+                      }
+                    : isPlaying
+                      ? {
+                          background: "#18181b",
+                          color: "#fff",
+                          border: "1px solid #18181b",
+                        }
+                      : {
+                          background: "#fff",
+                          color: "#3f3f46",
+                          border: "1px solid #d4d4d8",
+                        }
+                }
               >
                 {isPlaying && !interactive ? "⏸ Pause" : "▶ Play"}
               </button>
@@ -931,9 +1134,15 @@ export default function ApertureV2Lab() {
                   <span>Speed</span>
                   <span className="font-mono">{speed.toFixed(2)} Hz</span>
                 </div>
-                <input type="range" min={0.05} max={1.5} step={0.05} value={speed}
+                <input
+                  type="range"
+                  min={0.05}
+                  max={1.5}
+                  step={0.05}
+                  value={speed}
                   onChange={(e) => setSpeed(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
               {/* Interactive (follow mouse) toggle */}
@@ -966,8 +1175,14 @@ export default function ApertureV2Lab() {
                   checked={onMount !== undefined}
                   onChange={(e) => {
                     const checked = e.target.checked;
-                    setOnMount(checked ? { type: "sweep", sweepMs: 800, totalMs: 1000 } : undefined);
-                    if (checked) setPreviewAnimKey(k => k + 1);
+                    setOnMount(
+                      checked
+                        ? { type: "sweep", sweepMs: 800, totalMs: 1000 }
+                        : undefined
+                    );
+                    if (checked) {
+                      setPreviewAnimKey((k) => k + 1);
+                    }
                   }}
                   style={{ accentColor: "#18181b", width: 14, height: 14 }}
                 />
@@ -978,31 +1193,49 @@ export default function ApertureV2Lab() {
                   <div className="space-y-1">
                     <div className="flex justify-between text-xs">
                       <span className="text-zinc-500">Sweep</span>
-                      <span className="text-zinc-700 font-mono">{onMount.sweepMs} ms</span>
+                      <span className="text-zinc-700 font-mono">
+                        {onMount.sweepMs} ms
+                      </span>
                     </div>
-                    <input type="range" min={200} max={2000} step={50} value={onMount.sweepMs}
+                    <input
+                      type="range"
+                      min={200}
+                      max={2000}
+                      step={50}
+                      value={onMount.sweepMs}
                       onChange={(e) => {
                         const sweepMs = parseFloat(e.target.value);
-                        setOnMount((prev): IrisAnimation | undefined => prev ? { ...prev, sweepMs } : prev);
-                        setPreviewAnimKey(k => k + 1);
+                        setOnMount((prev): IrisAnimation | undefined =>
+                          prev ? { ...prev, sweepMs } : prev
+                        );
+                        setPreviewAnimKey((k) => k + 1);
                       }}
-                      className="w-full" style={{ accentColor: "#18181b" }}
+                      className="w-full"
+                      style={{ accentColor: "#18181b" }}
                     />
                   </div>
                   <div className="space-y-1">
                     <div className="flex justify-between text-xs">
                       <span className="text-zinc-500">Total</span>
-                      <span className="text-zinc-700 font-mono">{onMount.totalMs} ms</span>
+                      <span className="text-zinc-700 font-mono">
+                        {onMount.totalMs} ms
+                      </span>
                     </div>
-                    <input type="range"
-                      min={onMount.sweepMs + 100} max={3000} step={50}
+                    <input
+                      type="range"
+                      min={onMount.sweepMs + 100}
+                      max={3000}
+                      step={50}
                       value={onMount.totalMs}
                       onChange={(e) => {
                         const totalMs = parseFloat(e.target.value);
-                        setOnMount((prev): IrisAnimation | undefined => prev ? { ...prev, totalMs } : prev);
-                        setPreviewAnimKey(k => k + 1);
+                        setOnMount((prev): IrisAnimation | undefined =>
+                          prev ? { ...prev, totalMs } : prev
+                        );
+                        setPreviewAnimKey((k) => k + 1);
                       }}
-                      className="w-full" style={{ accentColor: "#18181b" }}
+                      className="w-full"
+                      style={{ accentColor: "#18181b" }}
                     />
                   </div>
                 </>
@@ -1019,16 +1252,25 @@ export default function ApertureV2Lab() {
                     const v = parseFloat(e.target.value);
                     setOpenFStop(v);
                     // Clamp defaultFStop to be ≥ the new openFStop.
-                    if (defaultFStop < v) setDefaultFStop(v);
+                    if (defaultFStop < v) {
+                      setDefaultFStop(v);
+                    }
                   }}
                   style={{
-                    width: "100%", padding: "5px 8px", borderRadius: 4,
-                    border: "1px solid #d4d4d8", background: "#fff",
-                    color: "#3f3f46", fontSize: 12, fontFamily: "ui-monospace, monospace",
+                    width: "100%",
+                    padding: "5px 8px",
+                    borderRadius: 4,
+                    border: "1px solid #d4d4d8",
+                    background: "#fff",
+                    color: "#3f3f46",
+                    fontSize: 12,
+                    fontFamily: "ui-monospace, monospace",
                   }}
                 >
-                  {FSTOP_OPTIONS.map(f => (
-                    <option key={f} value={f}>{formatFStop(f)}</option>
+                  {FSTOP_OPTIONS.map((f) => (
+                    <option key={f} value={f}>
+                      {formatFStop(f)}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -1042,13 +1284,20 @@ export default function ApertureV2Lab() {
                   value={defaultFStop}
                   onChange={(e) => setDefaultFStop(parseFloat(e.target.value))}
                   style={{
-                    width: "100%", padding: "5px 8px", borderRadius: 4,
-                    border: "1px solid #d4d4d8", background: "#fff",
-                    color: "#3f3f46", fontSize: 12, fontFamily: "ui-monospace, monospace",
+                    width: "100%",
+                    padding: "5px 8px",
+                    borderRadius: 4,
+                    border: "1px solid #d4d4d8",
+                    background: "#fff",
+                    color: "#3f3f46",
+                    fontSize: 12,
+                    fontFamily: "ui-monospace, monospace",
                   }}
                 >
-                  {FSTOP_OPTIONS.filter(f => f >= openFStop).map(f => (
-                    <option key={f} value={f}>{formatFStop(f)}</option>
+                  {FSTOP_OPTIONS.filter((f) => f >= openFStop).map((f) => (
+                    <option key={f} value={f}>
+                      {formatFStop(f)}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -1062,13 +1311,20 @@ export default function ApertureV2Lab() {
                   value={closedFStop}
                   onChange={(e) => setClosedFStop(parseFloat(e.target.value))}
                   style={{
-                    width: "100%", padding: "5px 8px", borderRadius: 4,
-                    border: "1px solid #d4d4d8", background: "#fff",
-                    color: "#3f3f46", fontSize: 12, fontFamily: "ui-monospace, monospace",
+                    width: "100%",
+                    padding: "5px 8px",
+                    borderRadius: 4,
+                    border: "1px solid #d4d4d8",
+                    background: "#fff",
+                    color: "#3f3f46",
+                    fontSize: 12,
+                    fontFamily: "ui-monospace, monospace",
                   }}
                 >
-                  {FSTOP_OPTIONS.filter(f => f > openFStop).map(f => (
-                    <option key={f} value={f}>{formatFStop(f)}</option>
+                  {FSTOP_OPTIONS.filter((f) => f > openFStop).map((f) => (
+                    <option key={f} value={f}>
+                      {formatFStop(f)}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -1076,76 +1332,138 @@ export default function ApertureV2Lab() {
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Chase τ</span>
-                  <span className="text-zinc-700 font-mono">{chaseTauMs} ms</span>
+                  <span className="text-zinc-700 font-mono">
+                    {chaseTauMs} ms
+                  </span>
                 </div>
-                <input type="range" min={10} max={200} step={5} value={chaseTauMs}
+                <input
+                  type="range"
+                  min={10}
+                  max={200}
+                  step={5}
+                  value={chaseTauMs}
                   onChange={(e) => setChaseTauMs(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
               {/* Ease Out — cubic ease-out return duration after mouse leaves (ms). */}
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Ease Out</span>
-                  <span className="text-zinc-700 font-mono">{easeOutMs} ms</span>
+                  <span className="text-zinc-700 font-mono">
+                    {easeOutMs} ms
+                  </span>
                 </div>
-                <input type="range" min={100} max={2000} step={50} value={easeOutMs}
+                <input
+                  type="range"
+                  min={100}
+                  max={2000}
+                  step={50}
+                  value={easeOutMs}
                   onChange={(e) => setEaseOutMs(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
               {/* Catchup — entry offset decay duration (ms). */}
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Catchup</span>
-                  <span className="text-zinc-700 font-mono">{catchupMs} ms</span>
+                  <span className="text-zinc-700 font-mono">
+                    {catchupMs} ms
+                  </span>
                 </div>
-                <input type="range" min={50} max={1000} step={10} value={catchupMs}
+                <input
+                  type="range"
+                  min={50}
+                  max={1000}
+                  step={10}
+                  value={catchupMs}
                   onChange={(e) => setCatchupMs(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
               {/* Hotzone Scale H — horizontal multiplier on iris diameter. */}
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Hotzone H</span>
-                  <span className="text-zinc-700 font-mono">{hotzoneScaleH.toFixed(1)}×</span>
+                  <span className="text-zinc-700 font-mono">
+                    {hotzoneScaleH.toFixed(1)}×
+                  </span>
                 </div>
-                <input type="range" min={0.5} max={3} step={0.1} value={hotzoneScaleH}
+                <input
+                  type="range"
+                  min={0.5}
+                  max={3}
+                  step={0.1}
+                  value={hotzoneScaleH}
                   onChange={(e) => setHotzoneScaleH(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
               {/* Hotzone Scale V — vertical multiplier on iris diameter. */}
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Hotzone V</span>
-                  <span className="text-zinc-700 font-mono">{hotzoneScaleV.toFixed(1)}×</span>
+                  <span className="text-zinc-700 font-mono">
+                    {hotzoneScaleV.toFixed(1)}×
+                  </span>
                 </div>
-                <input type="range" min={0.5} max={3} step={0.1} value={hotzoneScaleV}
+                <input
+                  type="range"
+                  min={0.5}
+                  max={3}
+                  step={0.1}
+                  value={hotzoneScaleV}
                   onChange={(e) => setHotzoneScaleV(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
             </section>
 
             <section className="space-y-2">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Overlay</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Overlay
+              </p>
               <button
                 onClick={() => setShowMechanics((v) => !v)}
                 className="w-full rounded py-2 text-sm font-medium text-left px-3 transition-colors"
-                style={showMechanics
-                  ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                  : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                style={
+                  showMechanics
+                    ? {
+                        background: "#18181b",
+                        color: "#fff",
+                        border: "1px solid #18181b",
+                      }
+                    : {
+                        background: "#fff",
+                        color: "#3f3f46",
+                        border: "1px solid #d4d4d8",
+                      }
+                }
               >
                 {showMechanics ? "◆ " : "◇ "}Mechanics
               </button>
               <button
                 onClick={() => setShowFStopRing((v) => !v)}
                 className="w-full rounded py-2 text-sm font-medium text-left px-3 transition-colors"
-                style={showFStopRing
-                  ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                  : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                style={
+                  showFStopRing
+                    ? {
+                        background: "#18181b",
+                        color: "#fff",
+                        border: "1px solid #18181b",
+                      }
+                    : {
+                        background: "#fff",
+                        color: "#3f3f46",
+                        border: "1px solid #d4d4d8",
+                      }
+                }
               >
                 {showFStopRing ? "◆ " : "◇ "}F-stop Ring
               </button>
@@ -1153,9 +1471,19 @@ export default function ApertureV2Lab() {
                 <button
                   onClick={() => setFStopRingOuter((v) => !v)}
                   className="w-full rounded py-1.5 text-xs font-medium text-left px-3 transition-colors"
-                  style={fStopRingOuter
-                    ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                    : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                  style={
+                    fStopRingOuter
+                      ? {
+                          background: "#18181b",
+                          color: "#fff",
+                          border: "1px solid #18181b",
+                        }
+                      : {
+                          background: "#fff",
+                          color: "#3f3f46",
+                          border: "1px solid #d4d4d8",
+                        }
+                  }
                 >
                   {fStopRingOuter ? "● " : "○ "}Outer
                 </button>
@@ -1166,40 +1494,80 @@ export default function ApertureV2Lab() {
           {/* ── Col 2: Mechanism ── */}
           <div className="space-y-5">
             <section className="space-y-2.5">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Blades</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Blades
+              </p>
               <div className="flex gap-1.5">
                 {[5, 6, 7, 9].map((n) => (
                   <button
                     key={n}
                     onClick={() => setField({ N: n })}
                     className="flex-1 rounded py-1.5 text-sm font-mono font-medium transition-colors"
-                    style={config.N === n
-                      ? { background: "#18181b", color: "#fff", border: "1px solid #18181b" }
-                      : { background: "#fff", color: "#3f3f46", border: "1px solid #d4d4d8" }}
+                    style={
+                      config.N === n
+                        ? {
+                            background: "#18181b",
+                            color: "#fff",
+                            border: "1px solid #18181b",
+                          }
+                        : {
+                            background: "#fff",
+                            color: "#3f3f46",
+                            border: "1px solid #d4d4d8",
+                          }
+                    }
                   >
                     {n}
                   </button>
                 ))}
               </div>
-              {([
-                { label: "Length", field: "bladeLength" as const, min: 80, max: 160, step: 1, fmt: (v: number) => v + " px" },
-                { label: "Width",  field: "bladeWidth"  as const, min: 10, max: 45,  step: 1, fmt: (v: number) => v + " px" },
-              ] as const).map(({ label, field, min, max, step, fmt }) => (
+              {(
+                [
+                  {
+                    label: "Length",
+                    field: "bladeLength" as const,
+                    min: 80,
+                    max: 160,
+                    step: 1,
+                    fmt: (v: number) => v + " px",
+                  },
+                  {
+                    label: "Width",
+                    field: "bladeWidth" as const,
+                    min: 10,
+                    max: 45,
+                    step: 1,
+                    fmt: (v: number) => v + " px",
+                  },
+                ] as const
+              ).map(({ label, field, min, max, step, fmt }) => (
                 <div key={field} className="space-y-1">
                   <div className="flex justify-between text-xs">
                     <span className="text-zinc-500">{label}</span>
-                    <span className="text-zinc-700 font-mono">{fmt(config[field])}</span>
+                    <span className="text-zinc-700 font-mono">
+                      {fmt(config[field])}
+                    </span>
                   </div>
-                  <input type="range" min={min} max={max} step={step} value={config[field]}
-                    onChange={(e) => setField({ [field]: parseFloat(e.target.value) })}
-                    className="w-full" style={{ accentColor: "#18181b" }}
+                  <input
+                    type="range"
+                    min={min}
+                    max={max}
+                    step={step}
+                    value={config[field]}
+                    onChange={(e) =>
+                      setField({ [field]: parseFloat(e.target.value) })
+                    }
+                    className="w-full"
+                    style={{ accentColor: "#18181b" }}
                   />
                 </div>
               ))}
             </section>
 
             <section className="space-y-2.5">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Mechanism</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Mechanism
+              </p>
               <div className="flex justify-between text-xs">
                 <span className="text-zinc-500">Pivot r</span>
                 <span className="text-zinc-500 font-mono">
@@ -1210,13 +1578,21 @@ export default function ApertureV2Lab() {
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Pin dist</span>
-                  <span className="text-zinc-700 font-mono">{config.pinDistance} px</span>
+                  <span className="text-zinc-700 font-mono">
+                    {config.pinDistance} px
+                  </span>
                 </div>
-                <input type="range"
-                  min={derivedConfig.pivotRadius} max={config.bladeLength - 1} step={1}
+                <input
+                  type="range"
+                  min={derivedConfig.pivotRadius}
+                  max={config.bladeLength - 1}
+                  step={1}
                   value={config.pinDistance}
-                  onChange={(e) => setField({ pinDistance: parseFloat(e.target.value) })}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  onChange={(e) =>
+                    setField({ pinDistance: parseFloat(e.target.value) })
+                  }
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
                 <div className="flex justify-between text-xs text-zinc-400 font-mono">
                   <span>{Math.ceil(derivedConfig.pivotRadius)}</span>
@@ -1226,13 +1602,21 @@ export default function ApertureV2Lab() {
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Slot δ</span>
-                  <span className="text-zinc-700 font-mono">{((config.slotOffset * 180) / Math.PI).toFixed(0)}°</span>
+                  <span className="text-zinc-700 font-mono">
+                    {((config.slotOffset * 180) / Math.PI).toFixed(0)}°
+                  </span>
                 </div>
-                <input type="range"
-                  min={Math.PI / 18} max={7 * Math.PI / 18} step={0.01}
+                <input
+                  type="range"
+                  min={Math.PI / 18}
+                  max={(7 * Math.PI) / 18}
+                  step={0.01}
                   value={config.slotOffset}
-                  onChange={(e) => setField({ slotOffset: parseFloat(e.target.value) })}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  onChange={(e) =>
+                    setField({ slotOffset: parseFloat(e.target.value) })
+                  }
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
             </section>
@@ -1241,20 +1625,38 @@ export default function ApertureV2Lab() {
           {/* ── Col 3: Shape & Appearance ── */}
           <div className="space-y-5">
             <section className="space-y-2.5">
-              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">Appearance</p>
+              <p className="text-sm font-semibold text-zinc-800 uppercase tracking-wide pt-3">
+                Appearance
+              </p>
 
               {/* Blade fill gray */}
               <div className="space-y-1">
                 <div className="flex justify-between text-xs items-center">
                   <span className="text-zinc-500">Fill</span>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-zinc-700 font-mono">{grayHex(bladeGray)}</span>
-                    <div style={{ width: 12, height: 12, borderRadius: 2, background: grayHex(bladeGray), border: "1px solid #d4d4d8" }} />
+                    <span className="text-zinc-700 font-mono">
+                      {grayHex(bladeGray)}
+                    </span>
+                    <div
+                      style={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: 2,
+                        background: grayHex(bladeGray),
+                        border: "1px solid #d4d4d8",
+                      }}
+                    />
                   </div>
                 </div>
-                <input type="range" min={0} max={255} step={1} value={bladeGray}
+                <input
+                  type="range"
+                  min={0}
+                  max={255}
+                  step={1}
+                  value={bladeGray}
                   onChange={(e) => setBladeGray(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
 
@@ -1263,13 +1665,29 @@ export default function ApertureV2Lab() {
                 <div className="flex justify-between text-xs items-center">
                   <span className="text-zinc-500">Stroke color</span>
                   <div className="flex items-center gap-1.5">
-                    <span className="text-zinc-700 font-mono">{grayHex(strokeGray)}</span>
-                    <div style={{ width: 12, height: 12, borderRadius: 2, background: grayHex(strokeGray), border: "1px solid #d4d4d8" }} />
+                    <span className="text-zinc-700 font-mono">
+                      {grayHex(strokeGray)}
+                    </span>
+                    <div
+                      style={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: 2,
+                        background: grayHex(strokeGray),
+                        border: "1px solid #d4d4d8",
+                      }}
+                    />
                   </div>
                 </div>
-                <input type="range" min={0} max={255} step={1} value={strokeGray}
+                <input
+                  type="range"
+                  min={0}
+                  max={255}
+                  step={1}
+                  value={strokeGray}
                   onChange={(e) => setStrokeGray(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
 
@@ -1277,14 +1695,21 @@ export default function ApertureV2Lab() {
               <div className="space-y-1">
                 <div className="flex justify-between text-xs">
                   <span className="text-zinc-500">Stroke width</span>
-                  <span className="text-zinc-700 font-mono">{strokeWidth.toFixed(1)} px</span>
+                  <span className="text-zinc-700 font-mono">
+                    {strokeWidth.toFixed(1)} px
+                  </span>
                 </div>
-                <input type="range" min={0} max={10} step={0.1} value={strokeWidth}
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  step={0.1}
+                  value={strokeWidth}
                   onChange={(e) => setStrokeWidth(parseFloat(e.target.value))}
-                  className="w-full" style={{ accentColor: "#18181b" }}
+                  className="w-full"
+                  style={{ accentColor: "#18181b" }}
                 />
               </div>
-
             </section>
 
             <button
@@ -1294,12 +1719,15 @@ export default function ApertureV2Lab() {
                 startRef.current = undefined;
               }}
               className="w-full rounded py-1.5 text-xs font-medium transition-colors"
-              style={{ background: "#fff", color: "#71717a", border: "1px solid #d4d4d8" }}
+              style={{
+                background: "#fff",
+                color: "#71717a",
+                border: "1px solid #d4d4d8",
+              }}
             >
               Reset defaults
             </button>
           </div>
-
         </div>
       </div>
     </main>

--- a/src/app/[locale]/design-lab/layout.tsx
+++ b/src/app/[locale]/design-lab/layout.tsx
@@ -1,6 +1,12 @@
 import { notFound } from "next/navigation";
 
-export default function DesignLabLayout({ children }: { children: React.ReactNode }) {
-  if (process.env.NODE_ENV === "production") notFound();
+export default function DesignLabLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
   return <>{children}</>;
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -20,7 +20,7 @@ export const viewport: Viewport = {
   viewportFit: "cover",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: SITE.themeColor.light },
-    { media: "(prefers-color-scheme: dark)",  color: SITE.themeColor.dark  },
+    { media: "(prefers-color-scheme: dark)", color: SITE.themeColor.dark },
   ],
 };
 
@@ -61,7 +61,7 @@ export async function generateMetadata({
       // instead of a white flash during the WebKit startup gap.
       startupImage: SPLASH_DEVICES.flatMap((device) =>
         (["light", "dark"] as const).map((scheme) => ({
-          url:   splashUrl(device.label, scheme),
+          url: splashUrl(device.label, scheme),
           media: splashMedia(device, scheme),
         }))
       ),
@@ -89,36 +89,34 @@ export function generateStaticParams() {
 
 export default async function LocaleLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  const { locale } = await params;
   const messages = await getMessages();
 
   return (
     <NextIntlClientProvider messages={messages}>
       <MountPreferenceProvider>
-      <CompareProvider>
-        <ScrollContainerProvider>
-          <ConsoleEgg />
-          <Nav />
-          {/* Offset fixed nav and iOS home indicator. Body also carries
+        <CompareProvider>
+          <ScrollContainerProvider>
+            <ConsoleEgg />
+            <Nav />
+            {/* Offset fixed nav and iOS home indicator. Body also carries
               bg-background, so the safe-area strip and any short-page gap
               render as a single seamless canvas color. */}
-          <div className="pt-[var(--nav-height)] pb-[var(--safe-inset-bottom)] min-h-svh">
-            {TESTHOOK_ALLOWED ? (
-              <TestHookProvider>
-                {children}
-                <TestHookPanel />
-              </TestHookProvider>
-            ) : (
-              children
-            )}
-          </div>
-        </ScrollContainerProvider>
-      </CompareProvider>
+            <div className="pt-[var(--nav-height)] pb-[var(--safe-inset-bottom)] min-h-svh">
+              {TESTHOOK_ALLOWED ? (
+                <TestHookProvider>
+                  {children}
+                  <TestHookPanel />
+                </TestHookProvider>
+              ) : (
+                children
+              )}
+            </div>
+          </ScrollContainerProvider>
+        </CompareProvider>
       </MountPreferenceProvider>
     </NextIntlClientProvider>
   );

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -9,7 +9,6 @@ import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens-spec-groups";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens-spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
-import { Link } from "@/i18n/navigation";
 import AddToCompareButton from "@/components/AddToCompareButton";
 import BackButton from "@/components/BackButton";
 import BackToTopButton from "@/components/BackToTopButton";
@@ -62,7 +61,13 @@ function StructuredLines({ lines }: { lines: StructuredLine[] }) {
 
 function renderRowValue(
   resolved: ResolvedSpecRow,
-  labels: { yes: string; no: string; partial: string; unknown: string; missing: string },
+  labels: {
+    yes: string;
+    no: string;
+    partial: string;
+    unknown: string;
+    missing: string;
+  }
 ) {
   if (resolved.kind === "bool") {
     return (
@@ -82,7 +87,11 @@ function renderRowValue(
       </div>
     );
   }
-  if (resolved.kind === "numeric" && resolved.structuredLines && resolved.structuredLines.length > 0) {
+  if (
+    resolved.kind === "numeric" &&
+    resolved.structuredLines &&
+    resolved.structuredLines.length > 0
+  ) {
     return (
       <div>
         <StructuredLines lines={resolved.structuredLines} />
@@ -97,7 +106,9 @@ function renderRowValue(
   // resolved is ResolvedTextRow here
   return (
     <div>
-      <span className="whitespace-pre-line">{resolved.displayValue ?? labels.missing}</span>
+      <span className="whitespace-pre-line">
+        {resolved.displayValue ?? labels.missing}
+      </span>
       {resolved.subValue && (
         <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
           {resolved.subValue}
@@ -209,125 +220,176 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   const priceSelection = pickPriceEntry(lens.pricing, locale);
   const reportableFields = [
     ...resolvedGroups.flatMap((group) =>
-      group.rows.map((row) => ({ label: row.label, currentValue: row.plainText, group: group.label }))
+      group.rows.map((row) => ({
+        label: row.label,
+        currentValue: row.plainText,
+        group: group.label,
+      }))
     ),
     ...(priceSelection
-      ? [{ label: tPricing("fieldLabel"), currentValue: formatPriceForReport(priceSelection, locale, tPricing), group: tPricing("groupLabel") }]
+      ? [
+          {
+            label: tPricing("fieldLabel"),
+            currentValue: formatPriceForReport(
+              priceSelection,
+              locale,
+              tPricing
+            ),
+            group: tPricing("groupLabel"),
+          },
+        ]
       : []),
-    ...(url ? [{ label: t("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel }] : []),
-    { label: t("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true },
+    ...(url
+      ? [
+          {
+            label: t("fieldOfficialLink"),
+            currentValue: url,
+            group: mediaGroupLabel,
+          },
+        ]
+      : []),
+    {
+      label: t("fieldLensImage"),
+      currentValue: getLensImageUrl(lens.id),
+      group: mediaGroupLabel,
+      hideCurrentValue: true,
+    },
   ];
 
   return (
     <>
-    <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
-      {/* Back button */}
-      <BackButton fallbackHref={`/lenses/${mount}`} />
+      <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
+        {/* Back button */}
+        <BackButton fallbackHref={`/lenses/${mount}`} />
 
-      {/* Header: image + key info side by side */}
-      <div className="flex flex-col sm:flex-row gap-8">
-        {/* Image */}
-        <div className="w-full max-w-56 mx-auto sm:mx-0 shrink-0 sm:w-56">
-          <div className="flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-zinc-100 bg-zinc-50/70 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
-            <div className="relative aspect-square w-full overflow-hidden">
-              <Image
-                src={getLensImageUrl(lens.id)}
-                alt={lens.model}
-                fill
-                sizes="224px"
-                style={lensImageStyle}
-                className="object-contain"
-                priority
+        {/* Header: image + key info side by side */}
+        <div className="flex flex-col sm:flex-row gap-8">
+          {/* Image */}
+          <div className="w-full max-w-56 mx-auto sm:mx-0 shrink-0 sm:w-56">
+            <div className="flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-zinc-100 bg-zinc-50/70 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+              <div className="relative aspect-square w-full overflow-hidden">
+                <Image
+                  src={getLensImageUrl(lens.id)}
+                  alt={lens.model}
+                  fill
+                  sizes="224px"
+                  style={lensImageStyle}
+                  className="object-contain"
+                  priority
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Info: title → price → actions */}
+          <div className="flex-1 flex flex-col gap-5">
+            {/* Title */}
+            <div>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                {tBrand(lens.brand)}
+                {lens.series ? ` · ${lens.series}` : ""}
+              </p>
+              <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mt-1 font-heading">
+                {lens.model}
+              </h1>
+            </div>
+
+            {/* Price */}
+            <PriceSection lens={lens} />
+
+            {/* Actions */}
+            <div className="flex flex-wrap gap-3">
+              <AddToCompareButton lensId={lens.id} />
+              {url ? (
+                <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>
+                  {t("officialSite")}
+                </ExternalLink>
+              ) : (
+                <span
+                  className={
+                    ACTION_OUTLINE_CLS + " cursor-not-allowed opacity-40"
+                  }
+                >
+                  {t("officialSite")}
+                </span>
+              )}
+              <ShareButton
+                lenses={[lens]}
+                triggerClassName={ACTION_OUTLINE_CLS}
               />
+              <FeedbackTrigger
+                type="data_issue"
+                context={{
+                  lensId: lens.id,
+                  lensModel: lens.model,
+                  lensBrand: tBrand(lens.brand),
+                }}
+                fields={reportableFields}
+                className={ACTION_OUTLINE_CLS}
+              >
+                <Flag size={14} />
+                {t("reportIssue")}
+              </FeedbackTrigger>
             </div>
           </div>
         </div>
 
-        {/* Info: title → price → actions */}
-        <div className="flex-1 flex flex-col gap-5">
-          {/* Title */}
-          <div>
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              {tBrand(lens.brand)}
-              {lens.series ? ` · ${lens.series}` : ""}
-            </p>
-            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mt-1 font-heading">
-              {lens.model}
-            </h1>
-          </div>
-
-          {/* Price */}
-          <PriceSection lens={lens} />
-
-          {/* Actions */}
-          <div className="flex flex-wrap gap-3">
-            <AddToCompareButton lensId={lens.id} />
-            {url ? (
-              <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>
-                {t("officialSite")}
-              </ExternalLink>
-            ) : (
-              <span className={ACTION_OUTLINE_CLS + " cursor-not-allowed opacity-40"}>
-                {t("officialSite")}
-              </span>
-            )}
-            <ShareButton lenses={[lens]} triggerClassName={ACTION_OUTLINE_CLS} />
-            <FeedbackTrigger
-              type="data_issue"
-              context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
-              fields={reportableFields}
-              className={ACTION_OUTLINE_CLS}
+        {/* Grouped spec table — full-width section below the header */}
+        <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+          {resolvedGroups.map((group, groupIdx) => (
+            <div
+              key={group.label}
+              className={
+                groupIdx > 0
+                  ? "border-t border-zinc-200 dark:border-zinc-800"
+                  : ""
+              }
             >
-              <Flag size={14} />
-              {t("reportIssue")}
-            </FeedbackTrigger>
-          </div>
+              {/* Group header */}
+              <div className="px-4 py-2 bg-zinc-100/80 dark:bg-zinc-800/60">
+                <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {group.label}
+                </span>
+              </div>
+
+              {/* Rows */}
+              <table className="w-full text-sm">
+                <tbody>
+                  {group.rows.map((resolved) => (
+                    <tr
+                      key={resolved.label}
+                      className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
+                    >
+                      <td className="px-4 py-2.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/30 w-40 align-top">
+                        <div className="flex items-center gap-1">
+                          <span className="whitespace-nowrap">
+                            {resolved.label}
+                          </span>
+                          {resolved.labelNote && (
+                            <FieldNotePopover
+                              note={resolved.labelNote}
+                              variant={resolved.labelNoteVariant}
+                            />
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-2.5 text-zinc-700 dark:text-zinc-300">
+                        <div className="flex items-center gap-1.5">
+                          {renderRowValue(resolved, valueCellLabels)}
+                          {resolved.note && (
+                            <FieldNotePopover note={resolved.note} />
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
         </div>
       </div>
-
-      {/* Grouped spec table — full-width section below the header */}
-      <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
-            {resolvedGroups.map((group, groupIdx) => (
-              <div
-                key={group.label}
-                className={groupIdx > 0 ? "border-t border-zinc-200 dark:border-zinc-800" : ""}
-              >
-                {/* Group header */}
-                <div className="px-4 py-2 bg-zinc-100/80 dark:bg-zinc-800/60">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {group.label}
-                  </span>
-                </div>
-
-                {/* Rows */}
-                <table className="w-full text-sm">
-                  <tbody>
-                    {group.rows.map((resolved) => (
-                      <tr
-                        key={resolved.label}
-                        className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
-                      >
-                        <td className="px-4 py-2.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/30 w-40 align-top">
-                          <div className="flex items-center gap-1">
-                            <span className="whitespace-nowrap">{resolved.label}</span>
-                            {resolved.labelNote && <FieldNotePopover note={resolved.labelNote} variant={resolved.labelNoteVariant} />}
-                          </div>
-                        </td>
-                        <td className="px-4 py-2.5 text-zinc-700 dark:text-zinc-300">
-                          <div className="flex items-center gap-1.5">
-                            {renderRowValue(resolved, valueCellLabels)}
-                            {resolved.note && <FieldNotePopover note={resolved.note} />}
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ))}
-          </div>
-    </div>
-    <BackToTopButton />
+      <BackToTopButton />
     </>
   );
 }

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -26,7 +26,9 @@ export async function generateMetadata({
 export default async function LensesPage({ params }: { params: Params }) {
   const { mount } = await params;
   const resolvedMount = urlSegmentToMount(mount);
-  if (!resolvedMount) notFound();
+  if (!resolvedMount) {
+    notFound();
+  }
   const lenses = getLensesByMount(resolvedMount);
 
   return (

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -11,7 +11,12 @@ import { buildAlternates } from "@/lib/seo";
 import { notFound } from "next/navigation";
 
 type Params = Promise<{ locale: string; mount: string }>;
-type SearchParams = Promise<{ ids?: string; from?: "lens" | "home"; lensId?: string; preset?: string }>;
+type SearchParams = Promise<{
+  ids?: string;
+  from?: "lens" | "home";
+  lensId?: string;
+  preset?: string;
+}>;
 
 export async function generateMetadata({
   params,
@@ -24,7 +29,9 @@ export async function generateMetadata({
   const { locale, mount } = await params;
   const { ids, preset } = await searchParams;
   const resolvedMount = urlSegmentToMount(mount);
-  if (!resolvedMount) return { title: t("title") };
+  if (!resolvedMount) {
+    return { title: t("title") };
+  }
 
   const lenses = parseLensIds(ids, resolvedMount);
   const alternates = buildAlternates(locale, `lenses/${mount}/compare`);
@@ -60,27 +67,41 @@ export default async function ComparePage({
   const { locale, mount } = await params;
   const { ids, from, lensId, preset } = await searchParams;
   const resolvedMount = urlSegmentToMount(mount);
-  if (!resolvedMount) notFound();
+  if (!resolvedMount) {
+    notFound();
+  }
 
   const lenses = parseLensIds(ids, resolvedMount);
   const seg = mountToUrlSegment(resolvedMount);
 
   const lang = locale === "zh" ? "zh" : "en";
-  const presetTitle = preset ? (getPresetBySlug(preset)?.title[lang] ?? undefined) : undefined;
+  const presetTitle = preset
+    ? (getPresetBySlug(preset)?.title[lang] ?? undefined)
+    : undefined;
 
   const fallbackHref =
-    from === "lens" && lensId ? `/lenses/${seg}/${lensId}` :
-    from === "home" ? "/" :
-    `/lenses/${seg}`;
+    from === "lens" && lensId
+      ? `/lenses/${seg}/${lensId}`
+      : from === "home"
+        ? "/"
+        : `/lenses/${seg}`;
 
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
-      <ComparePageHeader lenses={lenses} fallbackHref={fallbackHref} minColumns={2} presetTitle={presetTitle} />
-      <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
+      <ComparePageHeader
+        lenses={lenses}
+        fallbackHref={fallbackHref}
+        minColumns={2}
+        presetTitle={presetTitle}
+      />
+      <CompareTable
+        key={lenses.length === 0 ? "_empty_" : ids}
+        lenses={lenses}
+        minColumns={2}
+        hideBodyWhenEmpty
+      />
       {resolvedMount === "X" && <CuratedComparisons />}
-      {lenses.length > 0 && (
-        <BackButton fallbackHref={fallbackHref} />
-      )}
+      {lenses.length > 0 && <BackButton fallbackHref={fallbackHref} />}
     </div>
   );
 }

--- a/src/app/[locale]/lenses/[mount]/layout.tsx
+++ b/src/app/[locale]/lenses/[mount]/layout.tsx
@@ -13,6 +13,8 @@ export default async function MountLayout({
   children: React.ReactNode;
 }) {
   const { mount } = await params;
-  if (!urlSegmentToMount(mount)) notFound();
+  if (!urlSegmentToMount(mount)) {
+    notFound();
+  }
   return <>{children}</>;
 }

--- a/src/app/[locale]/lenses/compare/page.tsx
+++ b/src/app/[locale]/lenses/compare/page.tsx
@@ -5,15 +5,28 @@ export default async function CompareRedirect({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ ids?: string; from?: string; lensId?: string; preset?: string }>;
+  searchParams: Promise<{
+    ids?: string;
+    from?: string;
+    lensId?: string;
+    preset?: string;
+  }>;
 }) {
   const { locale } = await params;
   const sp = await searchParams;
   const qs = new URLSearchParams();
-  if (sp.ids) qs.set("ids", sp.ids);
-  if (sp.from) qs.set("from", sp.from);
-  if (sp.lensId) qs.set("lensId", sp.lensId);
-  if (sp.preset) qs.set("preset", sp.preset);
+  if (sp.ids) {
+    qs.set("ids", sp.ids);
+  }
+  if (sp.from) {
+    qs.set("from", sp.from);
+  }
+  if (sp.lensId) {
+    qs.set("lensId", sp.lensId);
+  }
+  if (sp.preset) {
+    qs.set("preset", sp.preset);
+  }
   const query = qs.toString();
   redirect(`/${locale}/lenses/x/compare${query ? `?${query}` : ""}`);
 }

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -5,8 +5,6 @@ import FeedbackTrigger from "@/components/FeedbackTrigger";
 import AnthropicLogo from "@/components/logos/AnthropicLogo";
 import GeminiLogo from "@/components/logos/GeminiLogo";
 import { ExternalLink } from "@/components/ui/external-link";
-import { Link } from "@/i18n/navigation";
-import { cn } from "@/lib/utils";
 import type { FeedbackType } from "@/components/FeedbackDialog";
 import { xLenses, gfxLenses } from "@/lib/lens";
 import coverageMeta from "@/data/coverage-meta.json";
@@ -22,7 +20,13 @@ function Dash() {
 }
 
 function MountCoverageTable({
-  title, brands, counts, meta, brandNames, col, rowTotal,
+  title,
+  brands,
+  counts,
+  meta,
+  brandNames,
+  col,
+  rowTotal,
 }: {
   title: string;
   brands: string[];
@@ -35,35 +39,59 @@ function MountCoverageTable({
   const total = brands.reduce((s, b) => s + (counts[b] ?? 0), 0);
   return (
     <div className="flex flex-col gap-2">
-      <p className="text-sm font-medium text-zinc-600 dark:text-zinc-400">{title}</p>
+      <p className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+        {title}
+      </p>
       <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden self-start">
         <table className="text-sm">
           <thead>
             <tr className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-              <th className="px-3 py-2 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 w-28">{col.brand}</th>
-              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.active}</th>
-              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.discontinued}</th>
-              <th className="px-3 py-2 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 whitespace-nowrap">{col.count}</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 w-28">
+                {col.brand}
+              </th>
+              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">
+                {col.active}
+              </th>
+              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">
+                {col.discontinued}
+              </th>
+              <th className="px-3 py-2 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                {col.count}
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/60">
             {brands.map((b) => {
-              const m: CoverageMeta = (meta as Record<string, CoverageMeta>)[b] ?? { active: false, discontinued: false, notes: "" };
+              const m: CoverageMeta = (meta as Record<string, CoverageMeta>)[
+                b
+              ] ?? { active: false, discontinued: false, notes: "" };
               return (
                 <tr key={b}>
-                  <td className="px-3 py-2 font-medium text-zinc-800 dark:text-zinc-200 whitespace-nowrap">{brandNames[b] ?? b}</td>
-                  <td className="px-3 py-2 text-center">{m.active ? <Check /> : <Dash />}</td>
-                  <td className="px-3 py-2 text-center">{m.discontinued ? <Check /> : <Dash />}</td>
-                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">{counts[b] ?? 0}</td>
+                  <td className="px-3 py-2 font-medium text-zinc-800 dark:text-zinc-200 whitespace-nowrap">
+                    {brandNames[b] ?? b}
+                  </td>
+                  <td className="px-3 py-2 text-center">
+                    {m.active ? <Check /> : <Dash />}
+                  </td>
+                  <td className="px-3 py-2 text-center">
+                    {m.discontinued ? <Check /> : <Dash />}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">
+                    {counts[b] ?? 0}
+                  </td>
                 </tr>
               );
             })}
           </tbody>
           <tfoot>
             <tr className="border-t border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-              <td className="px-3 py-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">{rowTotal}</td>
+              <td className="px-3 py-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                {rowTotal}
+              </td>
               <td colSpan={2} />
-              <td className="px-3 py-2 text-right tabular-nums text-xs font-semibold text-zinc-700 dark:text-zinc-300">{total}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-xs font-semibold text-zinc-700 dark:text-zinc-300">
+                {total}
+              </td>
             </tr>
           </tfoot>
         </table>
@@ -98,13 +126,28 @@ export default async function AboutContent() {
     getLocale(),
   ]);
 
-  const xCounts = (xLenses as { brand: string }[]).reduce<Record<string, number>>(
-    (acc, l) => { acc[l.brand] = (acc[l.brand] ?? 0) + 1; return acc; }, {}
-  );
-  const gCounts = (gfxLenses as { brand: string }[]).reduce<Record<string, number>>(
-    (acc, l) => { acc[l.brand] = (acc[l.brand] ?? 0) + 1; return acc; }, {}
-  );
-  const X_BRANDS = ["fujifilm","sigma","tamron","viltrox","7artisans","ttartisan","brightinstar","sgimage"];
+  const xCounts = (xLenses as { brand: string }[]).reduce<
+    Record<string, number>
+  >((acc, l) => {
+    acc[l.brand] = (acc[l.brand] ?? 0) + 1;
+    return acc;
+  }, {});
+  const gCounts = (gfxLenses as { brand: string }[]).reduce<
+    Record<string, number>
+  >((acc, l) => {
+    acc[l.brand] = (acc[l.brand] ?? 0) + 1;
+    return acc;
+  }, {});
+  const X_BRANDS = [
+    "fujifilm",
+    "sigma",
+    "tamron",
+    "viltrox",
+    "7artisans",
+    "ttartisan",
+    "brightinstar",
+    "sgimage",
+  ];
   const G_BRANDS = ["fujifilm"];
 
   const faqItems = [
@@ -119,7 +162,11 @@ export default async function AboutContent() {
     type: FeedbackType;
     icon: React.ReactNode;
   }[] = [
-    { label: t("feedbackReport"), type: "data_issue", icon: <Flag size={13} /> },
+    {
+      label: t("feedbackReport"),
+      type: "data_issue",
+      icon: <Flag size={13} />,
+    },
   ];
 
   const pipelineStages = [
@@ -194,18 +241,40 @@ export default async function AboutContent() {
       {/* Coverage */}
       <Section id="coverage" title={t("coverageTitle")}>
         <div className="flex flex-col gap-4">
-          {([
-            { key: "coverageBrandsX", brands: X_BRANDS, counts: xCounts, meta: coverageMeta.x },
-            { key: "coverageBrandsG", brands: G_BRANDS, counts: gCounts, meta: coverageMeta.g },
-          ] as const).map(({ key, brands, counts, meta }) => (
+          {(
+            [
+              {
+                key: "coverageBrandsX",
+                brands: X_BRANDS,
+                counts: xCounts,
+                meta: coverageMeta.x,
+              },
+              {
+                key: "coverageBrandsG",
+                brands: G_BRANDS,
+                counts: gCounts,
+                meta: coverageMeta.g,
+              },
+            ] as const
+          ).map(({ key, brands, counts, meta }) => (
             <MountCoverageTable
               key={key}
               title={t(key)}
               brands={[...brands]}
               counts={counts}
               meta={meta as Record<string, CoverageMeta>}
-              brandNames={Object.fromEntries(brands.map((b) => [b, tBrand(b as Parameters<typeof tBrand>[0])]))}
-              col={{ brand: t("coverageColBrand"), count: t("coverageColCount"), active: t("coverageColActive"), discontinued: t("coverageColDiscontinued") }}
+              brandNames={Object.fromEntries(
+                brands.map((b) => [
+                  b,
+                  tBrand(b as Parameters<typeof tBrand>[0]),
+                ])
+              )}
+              col={{
+                brand: t("coverageColBrand"),
+                count: t("coverageColCount"),
+                active: t("coverageColActive"),
+                discontinued: t("coverageColDiscontinued"),
+              }}
               rowTotal={t("coverageRowTotal")}
             />
           ))}
@@ -264,7 +333,9 @@ export default async function AboutContent() {
 
         {/* Update cadence */}
         <p className="text-xs text-zinc-500 dark:text-zinc-500">
-          {t("dataUpdateNote")}{"  "}{t("dataVersionNote")}
+          {t("dataUpdateNote")}
+          {"  "}
+          {t("dataVersionNote")}
         </p>
 
         {/* GitHub link */}
@@ -356,8 +427,17 @@ export default async function AboutContent() {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2.5 px-4 py-2.5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/60 text-sm font-semibold text-zinc-800 dark:text-zinc-200 transition-all duration-200 hover:scale-[1.02] hover:shadow-sm"
             >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.311zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z" fill="#FF5E5B"/>
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.311zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z"
+                  fill="#FF5E5B"
+                />
               </svg>
               {t("donationKofi")}
             </a>
@@ -373,23 +453,24 @@ export default async function AboutContent() {
 
         {/* Card + story pairs — card IS the accordion trigger */}
         <div className="flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800">
-          {ackCredits.map(({ roles, company, product, logoComponent, glowColor }, i) => {
-            const storyKey = i === 0 ? "1" : "2";
-            const body = t(`ackStory${storyKey}Body` as "ackStory1Body");
-            return (
-              <AckCard
-                key={`${company}-${product}`}
-                roles={roles}
-                company={company}
-                product={product}
-                logoComponent={logoComponent}
-                glowColor={glowColor}
-                body={body}
-                isClaudeCard={i === 0}
-                locale={locale}
-              />
-            );
-          })}
+          {ackCredits.map(
+            ({ roles, company, product, logoComponent, glowColor }, i) => {
+              const storyKey = i === 0 ? "1" : "2";
+              const body = t(`ackStory${storyKey}Body` as "ackStory1Body");
+              return (
+                <AckCard
+                  key={`${company}-${product}`}
+                  roles={roles}
+                  company={company}
+                  product={product}
+                  logoComponent={logoComponent}
+                  glowColor={glowColor}
+                  body={body}
+                  isClaudeCard={i === 0}
+                />
+              );
+            }
+          )}
         </div>
 
         {/* Closing line */}
@@ -420,7 +501,9 @@ export default async function AboutContent() {
             href="mailto:xglass@sentacraft.com"
             className="inline-flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors self-start"
           >
-            <span className="text-zinc-400 dark:text-zinc-500"><Mail size={13} /></span>
+            <span className="text-zinc-400 dark:text-zinc-500">
+              <Mail size={13} />
+            </span>
             {t("feedbackEmailLabel")}
           </a>
         </div>

--- a/src/components/AckCard.tsx
+++ b/src/components/AckCard.tsx
@@ -11,7 +11,6 @@ interface AckCardProps {
   glowColor: string;
   body: string;
   isClaudeCard?: boolean;
-  locale?: string;
 }
 
 export default function AckCard({
@@ -22,7 +21,6 @@ export default function AckCard({
   glowColor,
   body,
   isClaudeCard,
-  locale,
 }: AckCardProps) {
   const [open, setOpen] = useState(false);
   const paragraphs = body.split("\n\n");
@@ -56,7 +54,9 @@ export default function AckCard({
             <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100 whitespace-nowrap">
               {product}
             </p>
-            <p className="text-xs text-zinc-400 dark:text-zinc-500">{company}</p>
+            <p className="text-xs text-zinc-400 dark:text-zinc-500">
+              {company}
+            </p>
           </div>
           <span className="ml-auto flex items-center justify-center w-6 h-6 rounded-full transition-colors group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800">
             <svg
@@ -90,18 +90,26 @@ export default function AckCard({
               if (isClaudeCard && j === 0) {
                 const parts = para.split("Iris");
                 return (
-                  <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                  <p
+                    key={j}
+                    className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed"
+                  >
                     {parts.map((part, k) => (
                       <span key={k}>
                         {part}
-                        {k < parts.length - 1 && <IrisTooltip>Iris</IrisTooltip>}
+                        {k < parts.length - 1 && (
+                          <IrisTooltip>Iris</IrisTooltip>
+                        )}
                       </span>
                     ))}
                   </p>
                 );
               }
               return (
-                <p key={j} className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                <p
+                  key={j}
+                  className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed"
+                >
                   {para}
                 </p>
               );

--- a/src/components/ApertureStrip.tsx
+++ b/src/components/ApertureStrip.tsx
@@ -29,7 +29,10 @@ const SPACING = 31; // reduced 30% from original 48, then an additional 10%
 function nearestNumericIndex(fStop: number): number {
   let best = 1;
   for (let i = 2; i < MARKS.length; i++) {
-    if (Math.abs((MARKS[i] as number) - fStop) < Math.abs((MARKS[best] as number) - fStop)) {
+    if (
+      Math.abs((MARKS[i] as number) - fStop) <
+      Math.abs((MARKS[best] as number) - fStop)
+    ) {
       best = i;
     }
   }
@@ -52,23 +55,32 @@ function indexToFStop(idx: number, defaultFStop: number): number {
   }
   const lo = Math.floor(idx);
   const hi = Math.min(MARKS.length - 1, lo + 1);
-  return (MARKS[lo] as number) + ((MARKS[hi] as number) - (MARKS[lo] as number)) * (idx - lo);
+  return (
+    (MARKS[lo] as number) +
+    ((MARKS[hi] as number) - (MARKS[lo] as number)) * (idx - lo)
+  );
 }
 
 // Continuous mark index for a given f-stop value (inverse of indexToFStop).
 function fStopToIndex(fStop: number): number {
-  if (fStop <= (MARKS[1] as number)) return 1;
+  if (fStop <= (MARKS[1] as number)) {
+    return 1;
+  }
   for (let i = 1; i < MARKS.length - 1; i++) {
     const lo = MARKS[i] as number;
     const hi = MARKS[i + 1] as number;
-    if (fStop <= hi) return i + (fStop - lo) / (hi - lo);
+    if (fStop <= hi) {
+      return i + (fStop - lo) / (hi - lo);
+    }
   }
   return MARKS.length - 1;
 }
 
 function formatMark(mark: Mark): string {
-  if (mark === "A") return "A";
-  return (mark === 1.4 || mark === 2.8 || mark === 5.6)
+  if (mark === "A") {
+    return "A";
+  }
+  return mark === 1.4 || mark === 2.8 || mark === 5.6
     ? (mark as number).toFixed(1)
     : String(mark);
 }
@@ -104,30 +116,41 @@ export default function ApertureStrip({
   // defaultIdx: the mark index that sits at centre when offset = 0.
   const defaultIdx = nearestNumericIndex(defaultFStop);
 
-  const [visible,  setVisible]  = useState(false);
-  const [offset,   setOffset]   = useState(() => defaultIdx * SPACING); // start at A
+  const [visible, setVisible] = useState(false);
+  const [offset, setOffset] = useState(() => defaultIdx * SPACING); // start at A
   const [snapping, setSnapping] = useState(false);
 
-  const dragRef              = useRef<{ startX: number; startOffset: number } | null>(null);
-  const lastValidOffsetRef   = useRef(0);
-  const snappingRef          = useRef(false);
+  const dragRef = useRef<{ startX: number; startOffset: number } | null>(null);
+  const lastValidOffsetRef = useRef(0);
+  const snappingRef = useRef(false);
   const userHasInteractedRef = useRef(false);
 
   // Clamp limits: rightmost = "A" at index 0, leftmost = f/22 at last index.
-  const maxOffset =  defaultIdx * SPACING;
+  const maxOffset = defaultIdx * SPACING;
   const minOffset = -(MARKS.length - 1 - defaultIdx) * SPACING;
 
   useEffect(() => {
     const t = setTimeout(() => setVisible(true), showDelay);
     return () => clearTimeout(t);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Sync offset from external fStop — only while animating and before user touch.
   useEffect(() => {
-    if (!animating || fStop === undefined || userHasInteractedRef.current || dragRef.current || snappingRef.current) return;
-    const idx    = fStopToIndex(fStop);
-    const target = Math.max(minOffset, Math.min(maxOffset, (defaultIdx - idx) * SPACING));
+    if (
+      !animating ||
+      fStop === undefined ||
+      userHasInteractedRef.current ||
+      dragRef.current ||
+      snappingRef.current
+    ) {
+      return;
+    }
+    const idx = fStopToIndex(fStop);
+    const target = Math.max(
+      minOffset,
+      Math.min(maxOffset, (defaultIdx - idx) * SPACING)
+    );
     setOffset(target);
   }, [animating, fStop, defaultIdx, minOffset, maxOffset]);
 
@@ -139,7 +162,11 @@ export default function ApertureStrip({
     if (!prevAnimatingRef.current && animating) {
       userHasInteractedRef.current = false;
     }
-    if (prevAnimatingRef.current && !animating && !userHasInteractedRef.current) {
+    if (
+      prevAnimatingRef.current &&
+      !animating &&
+      !userHasInteractedRef.current
+    ) {
       setOffset(maxOffset);
     }
     prevAnimatingRef.current = animating;
@@ -148,7 +175,7 @@ export default function ApertureStrip({
   // Resolve the f-stop value for a given mark index.
   // A (idx 0) maps to defaultFStop; all others map to their numeric value.
   function markFStopValue(idx: number): number {
-    return idx === 0 ? defaultFStop : MARKS[idx] as number;
+    return idx === 0 ? defaultFStop : (MARKS[idx] as number);
   }
 
   function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
@@ -159,7 +186,9 @@ export default function ApertureStrip({
   }
 
   function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
-    if (!dragRef.current) return;
+    if (!dragRef.current) {
+      return;
+    }
     // If the button was released outside the browser window, pointerup never
     // fired — detect this here and end the drag cleanly.
     if (e.buttons === 0) {
@@ -167,7 +196,8 @@ export default function ApertureStrip({
       snapToNearest(lastValidOffsetRef.current);
       return;
     }
-    const raw     = dragRef.current.startOffset + (e.clientX - dragRef.current.startX);
+    const raw =
+      dragRef.current.startOffset + (e.clientX - dragRef.current.startX);
     const clamped = Math.max(minOffset, Math.min(maxOffset, raw));
     lastValidOffsetRef.current = clamped;
     setOffset(clamped);
@@ -179,20 +209,28 @@ export default function ApertureStrip({
     const nearestIdx = Math.round(continuous);
     setSnapping(true);
     snappingRef.current = true;
-    setTimeout(() => { setSnapping(false); snappingRef.current = false; }, 220);
+    setTimeout(() => {
+      setSnapping(false);
+      snappingRef.current = false;
+    }, 220);
     setOffset((defaultIdx - nearestIdx) * SPACING);
     onDrive(markFStopValue(nearestIdx));
   }
 
   function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
-    if (!dragRef.current) return;
-    const raw = dragRef.current.startOffset + (e.clientX - dragRef.current.startX);
+    if (!dragRef.current) {
+      return;
+    }
+    const raw =
+      dragRef.current.startOffset + (e.clientX - dragRef.current.startX);
     dragRef.current = null;
     snapToNearest(Math.max(minOffset, Math.min(maxOffset, raw)));
   }
 
   function onPointerCancel() {
-    if (!dragRef.current) return;
+    if (!dragRef.current) {
+      return;
+    }
     dragRef.current = null;
     snapToNearest(lastValidOffsetRef.current);
   }
@@ -200,14 +238,14 @@ export default function ApertureStrip({
   // Total pixel width of the marks row.
   const rowWidth = MARKS.length * SPACING;
   // Left edge so that mark[defaultIdx] sits at container centre when offset = 0.
-  const rowLeft  = `calc(50% - ${(defaultIdx + 0.5) * SPACING}px)`;
+  const rowLeft = `calc(50% - ${(defaultIdx + 0.5) * SPACING}px)`;
 
   return (
     <div
       className="relative"
       style={{
-        opacity:       visible ? 1 : 0,
-        transition:    "opacity 0.6s ease",
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.6s ease",
         pointerEvents: visible ? "auto" : "none",
       }}
     >
@@ -221,8 +259,10 @@ export default function ApertureStrip({
       <div
         className="mt-2.5 h-[25px] overflow-hidden cursor-grab active:cursor-grabbing touch-none select-none text-zinc-500 dark:text-zinc-400"
         style={{
-          maskImage:       "linear-gradient(to right, transparent 0%, black 22%, black 78%, transparent 100%)",
-          WebkitMaskImage: "linear-gradient(to right, transparent 0%, black 22%, black 78%, transparent 100%)",
+          maskImage:
+            "linear-gradient(to right, transparent 0%, black 22%, black 78%, transparent 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to right, transparent 0%, black 22%, black 78%, transparent 100%)",
         }}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
@@ -233,13 +273,13 @@ export default function ApertureStrip({
         <div
           className="absolute flex items-center h-full will-change-transform"
           style={{
-            width:      rowWidth,
-            left:       rowLeft,
-            transform:  `translateX(${offset}px)`,
+            width: rowWidth,
+            left: rowLeft,
+            transform: `translateX(${offset}px)`,
             transition: snapping ? "transform 0.22s ease-out" : "none",
           }}
         >
-          {MARKS.map((mark, i) => (
+          {MARKS.map((mark, i) =>
             mark === "A" ? (
               <div
                 key={i}
@@ -257,7 +297,7 @@ export default function ApertureStrip({
                 {formatMark(mark)}
               </div>
             )
-          ))}
+          )}
         </div>
       </div>
     </div>

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -14,7 +14,10 @@ interface Props {
   triggerClassName?: string;
 }
 
-export default function CompareAddLensButton({ lenses, triggerClassName }: Props) {
+export default function CompareAddLensButton({
+  lenses,
+  triggerClassName,
+}: Props) {
   const t = useTranslations("Compare");
   const router = useRouter();
   const { buildCompareUrl } = useCompareUrl();
@@ -24,7 +27,9 @@ export default function CompareAddLensButton({ lenses, triggerClassName }: Props
 
   const handleSelectLens = useCallback(
     (lens: Lens) => {
-      if (currentIds.includes(lens.id) || currentIds.length >= MAX_COMPARE) return;
+      if (currentIds.includes(lens.id) || currentIds.length >= MAX_COMPARE) {
+        return;
+      }
       const nextIds = [...currentIds, lens.id];
       router.replace(buildCompareUrl(nextIds));
     },
@@ -39,8 +44,7 @@ export default function CompareAddLensButton({ lenses, triggerClassName }: Props
           ? t("compareFull")
           : t("addToCompareAction"),
       disabled:
-        currentIds.includes(candidate.id) ||
-        currentIds.length >= MAX_COMPARE,
+        currentIds.includes(candidate.id) || currentIds.length >= MAX_COMPARE,
     }),
     [currentIds, t]
   );
@@ -54,7 +58,9 @@ export default function CompareAddLensButton({ lenses, triggerClassName }: Props
       timerRef.current = setTimeout(() => setHintOpen(false), 1500);
     }
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
     };
   }, [hintOpen]);
 

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -37,7 +37,9 @@ export default function CompareBar() {
 
   useEffect(() => {
     const el = barRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     const observer = new ResizeObserver(([entry]) => {
       document.documentElement.style.setProperty(
         "--compare-bar-height",
@@ -57,7 +59,9 @@ export default function CompareBar() {
   // Extract lens ID if currently on a lens detail page (/lenses/[mount]/[id])
   const currentLensId = useMemo(() => {
     const seg = mountToUrlSegment(mount);
-    const match = pathname.match(new RegExp(`\\/lenses\\/${seg}\\/(?!compare\\b)([^/]+)$`));
+    const match = pathname.match(
+      new RegExp(`\\/lenses\\/${seg}\\/(?!compare\\b)([^/]+)$`)
+    );
     return match?.[1] ?? null;
   }, [pathname, mount]);
 
@@ -108,8 +112,13 @@ export default function CompareBar() {
                       </span>
                       <button
                         onClick={() => toggleCompare(lens.id)}
-                        className={cn(ICON_CLOSE_BTN_CLS, "h-5 w-5 -mr-0.5 mt-0.5")}
-                        aria-label={tCompare("removeLens", { model: displayName })}
+                        className={cn(
+                          ICON_CLOSE_BTN_CLS,
+                          "h-5 w-5 -mr-0.5 mt-0.5"
+                        )}
+                        aria-label={tCompare("removeLens", {
+                          model: displayName,
+                        })}
                       >
                         <X className="h-3 w-3" />
                       </button>

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -21,7 +21,12 @@ interface Props {
   presetTitle?: string;
 }
 
-export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0, presetTitle }: Props) {
+export default function ComparePageHeader({
+  lenses,
+  fallbackHref,
+  minColumns = 0,
+  presetTitle,
+}: Props) {
   const t = useTranslations("Compare");
   const tList = useTranslations("LensList");
   const { clearCompare } = useMountedCompare();
@@ -32,10 +37,12 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
   // Show the FAB when the header row scrolls behind the nav bar
   useEffect(() => {
     const el = headerRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     const observer = new IntersectionObserver(
       ([entry]) => setShowFab(!entry.isIntersecting),
-      { root: null, rootMargin: "0px", threshold: 0 },
+      { root: null, rootMargin: "0px", threshold: 0 }
     );
     observer.observe(el);
     return () => observer.disconnect();
@@ -48,10 +55,15 @@ export default function ComparePageHeader({ lenses, fallbackHref, minColumns = 0
         <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h1>
-        {lenses.length >= minColumns && <CompareAddLensButton lenses={lenses} />}
+        {lenses.length >= minColumns && (
+          <CompareAddLensButton lenses={lenses} />
+        )}
         {lenses.length > 0 && (
           <button
-            onClick={() => { clearCompare(); router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`); }}
+            onClick={() => {
+              clearCompare();
+              router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`);
+            }}
             className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
           >
             {tList("clearCompare")}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -33,11 +33,7 @@ import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 
 // --- LensHeaderContent: shared inner card content ---
 
-function LensHeaderContent({
-  lens,
-}: {
-  lens: Lens;
-}) {
+function LensHeaderContent({ lens }: { lens: Lens }) {
   const tBrand = useTranslations("Brands");
 
   return (
@@ -167,7 +163,11 @@ interface Props {
 const LABEL_COLUMN_WIDTH = "6rem";
 const LENS_COLUMN_MIN_WIDTH = "9rem";
 
-export default function CompareTable({ lenses: initialLenses, minColumns = 0, hideBodyWhenEmpty = false }: Props) {
+export default function CompareTable({
+  lenses: initialLenses,
+  minColumns = 0,
+  hideBodyWhenEmpty = false,
+}: Props) {
   const t = useTranslations("Compare");
   const td = useTranslations("LensDetail");
   const tBrand = useTranslations("Brands");
@@ -214,7 +214,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
 
   const handleAddLens = useCallback(
     (lens: Lens) => {
-      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {return;}
+      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
+        return;
+      }
       updateCompare([...compareIds, lens.id]);
     },
     [compareIds, updateCompare]
@@ -233,13 +235,16 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     [compareIds, t]
   );
 
-  const valueCellLabels = {
-    yes: td("yes"),
-    no: td("no"),
-    partial: td("partial"),
-    unknown: td("unknown"),
-    missing: td("missing"),
-  };
+  const valueCellLabels = useMemo(
+    () => ({
+      yes: td("yes"),
+      no: td("no"),
+      partial: td("partial"),
+      unknown: td("unknown"),
+      missing: td("missing"),
+    }),
+    [td]
+  );
 
   function handleRemoveLens(lensId: string) {
     updateCompare(compareIds.filter((id) => id !== lensId));
@@ -248,7 +253,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   function handleShiftLens(lensId: string, direction: -1 | 1) {
     const index = compareIds.indexOf(lensId);
     const newIndex = index + direction;
-    if (newIndex < 0 || newIndex >= compareIds.length) {return;}
+    if (newIndex < 0 || newIndex >= compareIds.length) {
+      return;
+    }
     const next = [...compareIds];
     [next[index], next[newIndex]] = [next[newIndex], next[index]];
     updateCompare(next);
@@ -336,7 +343,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
       for (const group of allGroups) {
         for (const row of group.rows) {
           const resolved = resolveSpecRow(row, lens, valueCellLabels);
-          if (resolved) {rowMap.set(row.label, resolved);}
+          if (resolved) {
+            rowMap.set(row.label, resolved);
+          }
         }
       }
       map.set(lens.id, rowMap);
@@ -365,25 +374,57 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     const mediaGroupLabel = td("fieldGroupMedia");
     for (const lens of orderedLenses) {
       const rowMap = resolvedPerLens.get(lens.id);
-      if (!rowMap) {continue;}
+      if (!rowMap) {
+        continue;
+      }
       const fields: FeedbackField[] = [];
       for (const group of allGroups) {
         for (const row of group.rows) {
           const resolved = rowMap.get(row.label);
-          if (resolved) {fields.push({ label: resolved.label, currentValue: resolved.plainText, group: group.label });}
+          if (resolved) {
+            fields.push({
+              label: resolved.label,
+              currentValue: resolved.plainText,
+              group: group.label,
+            });
+          }
         }
       }
       const url = getLensUrl(lens, locale);
-      if (url) {fields.push({ label: td("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel });}
-      fields.push({ label: td("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true });
+      if (url) {
+        fields.push({
+          label: td("fieldOfficialLink"),
+          currentValue: url,
+          group: mediaGroupLabel,
+        });
+      }
+      fields.push({
+        label: td("fieldLensImage"),
+        currentValue: getLensImageUrl(lens.id),
+        group: mediaGroupLabel,
+        hideCurrentValue: true,
+      });
       const priceSelection = pickPriceEntry(lens.pricing, locale);
       if (priceSelection) {
-        fields.push({ label: priceFieldLabel, currentValue: formatPriceForReport(priceSelection, locale, tPricing), group: priceGroupLabel });
+        fields.push({
+          label: priceFieldLabel,
+          currentValue: formatPriceForReport(priceSelection, locale, tPricing),
+          group: priceGroupLabel,
+        });
       }
       map.set(lens.id, fields);
     }
     return map;
-  }, [resolvedPerLens, allGroups, orderedLenses, td, tPricing, priceFieldLabel, priceGroupLabel]);
+  }, [
+    resolvedPerLens,
+    allGroups,
+    orderedLenses,
+    td,
+    tPricing,
+    priceFieldLabel,
+    priceGroupLabel,
+    locale,
+  ]);
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const { lockNav } = useNavLock();
@@ -398,10 +439,12 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
 
   useEffect(() => {
     const thead = theadRef.current;
-    if (!thead) {return;}
+    if (!thead) {
+      return;
+    }
     const observer = new IntersectionObserver(
       ([entry]) => setShowPhantom(!entry.isIntersecting),
-      { root: null, rootMargin: "0px", threshold: 0 },
+      { root: null, rootMargin: "0px", threshold: 0 }
     );
     observer.observe(thead);
     return () => observer.disconnect();
@@ -412,19 +455,25 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const phantomVisible = showPhantom && orderedLenses.length > 0;
 
   useEffect(() => {
-    if (!isPwa) {lockNav(phantomVisible);}
+    if (!isPwa) {
+      lockNav(phantomVisible);
+    }
   }, [phantomVisible, lockNav, isPwa]);
 
   useEffect(() => {
     const container = containerRef.current;
     const thead = theadRef.current;
-    if (!container || !thead) {return;}
+    if (!container || !thead) {
+      return;
+    }
 
     const update = () => {
       const row = thead.querySelector("tr");
       if (row) {
         const cells = row.querySelectorAll("th");
-        setColWidths(Array.from(cells).map((c) => c.getBoundingClientRect().width));
+        setColWidths(
+          Array.from(cells).map((c) => c.getBoundingClientRect().width)
+        );
       }
     };
     update();
@@ -436,7 +485,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   useEffect(() => {
     const container = containerRef.current;
     const thead = theadRef.current;
-    if (!container || !thead) {return;}
+    if (!container || !thead) {
+      return;
+    }
     const onScroll = () => {
       if (phantomInnerRef.current) {
         phantomInnerRef.current.style.transform = `translateX(-${container.scrollLeft}px)`;
@@ -448,463 +499,543 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
 
   return (
     <>
-    {/* Phantom sticky header: h-0 so it takes no layout space; sticky (not fixed)
+      {/* Phantom sticky header: h-0 so it takes no layout space; sticky (not fixed)
         so it bounces with content during iOS overscroll instead of staying put */}
-    <div data-testid="compare-phantom-container" className={`sticky z-20 h-0 overflow-x-clip ${isPwa ? "top-[var(--nav-height)]" : "top-[var(--safe-inset-top)] sm:top-[var(--nav-height)]"}`}>
       <div
-        data-testid="compare-phantom-header"
-        data-visible={String(phantomVisible)}
-        className={`absolute left-0 right-0 top-0 transition-all duration-200 ${
-          phantomVisible
-            ? "opacity-100 translate-y-0"
-            : "opacity-0 -translate-y-1 pointer-events-none"
-        }`}
+        data-testid="compare-phantom-container"
+        className={`sticky z-20 h-0 overflow-x-clip ${isPwa ? "top-[var(--nav-height)]" : "top-[var(--safe-inset-top)] sm:top-[var(--nav-height)]"}`}
       >
-      <div className="overflow-hidden border-b border-zinc-200 bg-white/95 backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-950/95">
-      <div className="flex">
-        {/* Fixed blank area matching the sticky label column — never scrolls */}
-        {colWidths[0] != null && (
-          <div style={{ width: colWidths[0], flexShrink: 0 }} />
-        )}
-        {/* Lens columns only — translateX syncs with table horizontal scroll */}
-        <div className="flex-1 overflow-hidden">
-          <div ref={phantomInnerRef} className="flex">
-            {orderedLenses.map((lens, i) => (
-              <div
-                key={lens.id}
-                style={{ width: colWidths[i + 1], flexShrink: 0 }}
-                className="px-2 py-1.5 text-center"
-              >
-                <p className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">
-                  {tBrand(lens.brand)}
-                </p>
-                <p className="truncate text-xs font-semibold text-zinc-900 dark:text-zinc-50">
-                  {lens.model}
-                </p>
+        <div
+          data-testid="compare-phantom-header"
+          data-visible={String(phantomVisible)}
+          className={`absolute left-0 right-0 top-0 transition-all duration-200 ${
+            phantomVisible
+              ? "opacity-100 translate-y-0"
+              : "opacity-0 -translate-y-1 pointer-events-none"
+          }`}
+        >
+          <div className="overflow-hidden border-b border-zinc-200 bg-white/95 backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-950/95">
+            <div className="flex">
+              {/* Fixed blank area matching the sticky label column — never scrolls */}
+              {colWidths[0] != null && (
+                <div style={{ width: colWidths[0], flexShrink: 0 }} />
+              )}
+              {/* Lens columns only — translateX syncs with table horizontal scroll */}
+              <div className="flex-1 overflow-hidden">
+                <div ref={phantomInnerRef} className="flex">
+                  {orderedLenses.map((lens, i) => (
+                    <div
+                      key={lens.id}
+                      style={{ width: colWidths[i + 1], flexShrink: 0 }}
+                      className="px-2 py-1.5 text-center"
+                    >
+                      <p className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">
+                        {tBrand(lens.brand)}
+                      </p>
+                      <p className="truncate text-xs font-semibold text-zinc-900 dark:text-zinc-50">
+                        {lens.model}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
-            ))}
+            </div>
           </div>
         </div>
       </div>
-      </div>
-      </div>
-    </div>
-    <div ref={containerRef} className="isolate overflow-x-auto overflow-y-clip rounded-xl border border-zinc-200 dark:border-zinc-800">
-      <table
-        className={cn("w-full table-fixed text-sm border-collapse", orderedLenses.length > 0 && "min-w-max")}
-        style={
-          orderedLenses.length > 0
-            ? { minWidth: `calc(${LABEL_COLUMN_WIDTH} + ${orderedLenses.length} * ${LENS_COLUMN_MIN_WIDTH})` }
-            : undefined
-        }
+      <div
+        ref={containerRef}
+        className="isolate overflow-x-auto overflow-y-clip rounded-xl border border-zinc-200 dark:border-zinc-800"
       >
-        <colgroup>
-          <col style={{ width: LABEL_COLUMN_WIDTH }} />
-          {orderedLenses.map((lens) => (
-            <col key={lens.id} style={{ width: LENS_COLUMN_MIN_WIDTH }} />
-          ))}
-          {Array.from({ length: emptySlotCount }).map((_, i) => (
-            // Empty state: no fixed width — table-fixed distributes remaining space evenly
-            <col key={`empty-col-${i}`} style={orderedLenses.length > 0 ? { width: LENS_COLUMN_MIN_WIDTH } : undefined} />
-          ))}
-        </colgroup>
-
-        <thead ref={theadRef}>
-          <tr className="border-b border-zinc-200 dark:border-zinc-800">
-            <th className="sticky left-0 z-30 bg-zinc-50 px-3 py-3 dark:bg-zinc-900">
-              {orderedLenses.length === 0 && (
-                <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                  {t("emptyHint", { count: MAX_COMPARE })}
-                </span>
-              )}
-            </th>
-            {orderedLenses.map((lens, index) => (
-              <LensHeader
-                key={lens.id}
-                lens={lens}
-                removeLabel={t("removeLens", { model: lens.model })}
-                shiftLeftLabel={t("shiftLeft")}
-                shiftRightLabel={t("shiftRight")}
-                canShiftLeft={index > 0}
-                canShiftRight={index < orderedLenses.length - 1}
-                onRemove={() => handleRemoveLens(lens.id)}
-                onShiftLeft={() => handleShiftLens(lens.id, -1)}
-                onShiftRight={() => handleShiftLens(lens.id, 1)}
-              />
+        <table
+          className={cn(
+            "w-full table-fixed text-sm border-collapse",
+            orderedLenses.length > 0 && "min-w-max"
+          )}
+          style={
+            orderedLenses.length > 0
+              ? {
+                  minWidth: `calc(${LABEL_COLUMN_WIDTH} + ${orderedLenses.length} * ${LENS_COLUMN_MIN_WIDTH})`,
+                }
+              : undefined
+          }
+        >
+          <colgroup>
+            <col style={{ width: LABEL_COLUMN_WIDTH }} />
+            {orderedLenses.map((lens) => (
+              <col key={lens.id} style={{ width: LENS_COLUMN_MIN_WIDTH }} />
             ))}
             {Array.from({ length: emptySlotCount }).map((_, i) => (
-              <EmptyLensHeader
-                key={`empty-header-${i}`}
-                addLensLabel={
-                  orderedLenses.length === 0
-                    ? i === 0 ? t("selectFirst") : t("addMore")
-                    : t("addLens")
+              // Empty state: no fixed width — table-fixed distributes remaining space evenly
+              <col
+                key={`empty-col-${i}`}
+                style={
+                  orderedLenses.length > 0
+                    ? { width: LENS_COLUMN_MIN_WIDTH }
+                    : undefined
                 }
-                onSelectLens={handleAddLens}
-                getResultState={getAddResultState}
               />
             ))}
-          </tr>
-        </thead>
+          </colgroup>
 
-        <tbody>
-          {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
-          {orderedLenses.length === 0 && !hideBodyWhenEmpty && allGroups.map((group) => (
-            <React.Fragment key={group.label}>
-              <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                <td colSpan={totalColSpan} className="h-8 text-center">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {group.label}
+          <thead ref={theadRef}>
+            <tr className="border-b border-zinc-200 dark:border-zinc-800">
+              <th className="sticky left-0 z-30 bg-zinc-50 px-3 py-3 dark:bg-zinc-900">
+                {orderedLenses.length === 0 && (
+                  <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                    {t("emptyHint", { count: MAX_COMPARE })}
                   </span>
-                </td>
-              </tr>
-              {group.rows.map((row) => (
-                <tr key={row.label} className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
-                  <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                    <div className="flex items-center justify-end gap-1">
-                      {row.labelNote && <FieldNotePopover note={row.labelNote} variant={row.labelNoteVariant} />}
-                      <span>{row.label}</span>
-                    </div>
-                  </td>
-                  {Array.from({ length: emptySlotCount }).map((_, i) => (
-                    <td key={i} className="px-3 py-3 text-center text-xs text-zinc-200 dark:text-zinc-800">
-                      —
-                    </td>
-                  ))}
-                </tr>
+                )}
+              </th>
+              {orderedLenses.map((lens, index) => (
+                <LensHeader
+                  key={lens.id}
+                  lens={lens}
+                  removeLabel={t("removeLens", { model: lens.model })}
+                  shiftLeftLabel={t("shiftLeft")}
+                  shiftRightLabel={t("shiftRight")}
+                  canShiftLeft={index > 0}
+                  canShiftRight={index < orderedLenses.length - 1}
+                  onRemove={() => handleRemoveLens(lens.id)}
+                  onShiftLeft={() => handleShiftLens(lens.id, -1)}
+                  onShiftRight={() => handleShiftLens(lens.id, 1)}
+                />
               ))}
-            </React.Fragment>
-          ))}
-
-          {/* Pricing group — shown when at least one lens has pricing data */}
-          {orderedLenses.length > 0 && orderedLenses.some(l => pickPriceEntry(l.pricing, locale) !== null) && (
-            <React.Fragment>
-              <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                <td colSpan={totalColSpan} className="h-8 text-center">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {tPricing("groupLabel")}
-                  </span>
-                </td>
-              </tr>
-              <tr className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
-                <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                  {tPricing("fieldLabel")}
-                </td>
-                {orderedLenses.map((lens) => {
-                  const sel = pickPriceEntry(lens.pricing, locale);
-                  if (!sel) {
-                    return (
-                      <td key={lens.id} className="px-3 py-3 text-center text-zinc-400 dark:text-zinc-600">
-                        {valueCellLabels.missing}
-                      </td>
-                    );
+              {Array.from({ length: emptySlotCount }).map((_, i) => (
+                <EmptyLensHeader
+                  key={`empty-header-${i}`}
+                  addLensLabel={
+                    orderedLenses.length === 0
+                      ? i === 0
+                        ? t("selectFirst")
+                        : t("addMore")
+                      : t("addLens")
                   }
+                  onSelectLens={handleAddLens}
+                  getResultState={getAddResultState}
+                />
+              ))}
+            </tr>
+          </thead>
+
+          <tbody>
+            {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
+            {orderedLenses.length === 0 &&
+              !hideBodyWhenEmpty &&
+              allGroups.map((group) => (
+                <React.Fragment key={group.label}>
+                  <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
+                    <td colSpan={totalColSpan} className="h-8 text-center">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                        {group.label}
+                      </span>
+                    </td>
+                  </tr>
+                  {group.rows.map((row) => (
+                    <tr
+                      key={row.label}
+                      className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
+                    >
+                      <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
+                        <div className="flex items-center justify-end gap-1">
+                          {row.labelNote && (
+                            <FieldNotePopover
+                              note={row.labelNote}
+                              variant={row.labelNoteVariant}
+                            />
+                          )}
+                          <span>{row.label}</span>
+                        </div>
+                      </td>
+                      {Array.from({ length: emptySlotCount }).map((_, i) => (
+                        <td
+                          key={i}
+                          className="px-3 py-3 text-center text-xs text-zinc-200 dark:text-zinc-800"
+                        >
+                          —
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </React.Fragment>
+              ))}
+
+            {/* Pricing group — shown when at least one lens has pricing data */}
+            {orderedLenses.length > 0 &&
+              orderedLenses.some(
+                (l) => pickPriceEntry(l.pricing, locale) !== null
+              ) && (
+                <React.Fragment>
+                  <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
+                    <td colSpan={totalColSpan} className="h-8 text-center">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                        {tPricing("groupLabel")}
+                      </span>
+                    </td>
+                  </tr>
+                  <tr className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+                    <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
+                      {tPricing("fieldLabel")}
+                    </td>
+                    {orderedLenses.map((lens) => {
+                      const sel = pickPriceEntry(lens.pricing, locale);
+                      if (!sel) {
+                        return (
+                          <td
+                            key={lens.id}
+                            className="px-3 py-3 text-center text-zinc-400 dark:text-zinc-600"
+                          >
+                            {valueCellLabels.missing}
+                          </td>
+                        );
+                      }
+                      return (
+                        <td key={lens.id} className="px-3 py-3">
+                          <div className="flex justify-center">
+                            <PriceBand lens={lens} compact />
+                          </div>
+                        </td>
+                      );
+                    })}
+                    {Array.from({ length: emptySlotCount }).map((_, i) => (
+                      <td
+                        key={`empty-price-${i}`}
+                        className="border-l border-zinc-100 bg-white dark:border-zinc-800/60 dark:bg-zinc-950"
+                      />
+                    ))}
+                  </tr>
+                </React.Fragment>
+              )}
+
+            {/* Populated table: only rendered when at least one lens is selected */}
+            {orderedLenses.length > 0 &&
+              visibleGroups.map((group) => {
+                return (
+                  <React.Fragment key={group.label}>
+                    {/* Group header row.
+                    The label is absolutely positioned at --section-center (updated
+                    on scroll/resize) so it stays centered in the visible content
+                    pane regardless of horizontal scroll position. */}
+                    <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
+                      <td colSpan={totalColSpan} className="h-8 text-center">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                          {group.label}
+                        </span>
+                      </td>
+                    </tr>
+
+                    {/* Data rows */}
+                    {group.rows.map((row) => {
+                      // Compute best value for numeric rows using pre-resolved comparables.
+                      let bestVal: number | null = null;
+                      if (row.kind === "numeric" && row.bestDir) {
+                        const vals = orderedLenses
+                          .map((l) => {
+                            const r = resolvedPerLens.get(l.id)?.get(row.label);
+                            return r?.kind === "numeric"
+                              ? r.comparable
+                              : undefined;
+                          })
+                          .filter((v): v is number => v !== undefined);
+                        if (vals.length > 1) {
+                          bestVal =
+                            row.bestDir === "min"
+                              ? Math.min(...vals)
+                              : Math.max(...vals);
+                        }
+                      }
+
+                      return (
+                        <tr
+                          key={row.label}
+                          className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
+                        >
+                          {/* Label cell */}
+                          <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
+                            <div className="flex items-center justify-end gap-1">
+                              {row.labelNote && (
+                                <FieldNotePopover
+                                  note={row.labelNote}
+                                  variant={row.labelNoteVariant}
+                                />
+                              )}
+                              <span>{row.label}</span>
+                            </div>
+                          </td>
+
+                          {/* Value cells — filled lenses */}
+                          {orderedLenses.map((lens) => {
+                            const resolved = resolvedPerLens
+                              .get(lens.id)
+                              ?.get(row.label);
+
+                            // Lens has no data for this row — render empty cell.
+                            if (!resolved) {
+                              return (
+                                <td
+                                  key={lens.id}
+                                  className="px-3 py-3 text-center text-zinc-400 dark:text-zinc-600"
+                                >
+                                  {valueCellLabels.missing}
+                                </td>
+                              );
+                            }
+
+                            if (resolved.kind === "bool") {
+                              return (
+                                <td
+                                  key={lens.id}
+                                  className="px-3 py-3 text-center text-zinc-700 dark:text-zinc-300"
+                                >
+                                  <div className="flex items-center justify-center gap-1">
+                                    <div>
+                                      <BoolCell
+                                        value={resolved.boolValue}
+                                        yes={valueCellLabels.yes}
+                                        no={valueCellLabels.no}
+                                        partial={valueCellLabels.partial}
+                                        unknown={valueCellLabels.missing}
+                                      />
+                                      {resolved.subValue && (
+                                        <p className="mt-0.5 text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
+                                          {resolved.subValue}
+                                        </p>
+                                      )}
+                                    </div>
+                                    {resolved.note && (
+                                      <FieldNotePopover note={resolved.note} />
+                                    )}
+                                  </div>
+                                </td>
+                              );
+                            }
+
+                            if (resolved.kind === "numeric") {
+                              const isBest =
+                                bestVal !== null &&
+                                resolved.comparable === bestVal;
+                              const fragment = isBest
+                                ? resolved.highlightFragment
+                                : undefined;
+
+                              // --- Structured multi-line rendering ---
+                              if (
+                                resolved.structuredLines &&
+                                resolved.structuredLines.length > 0
+                              ) {
+                                return (
+                                  <td
+                                    key={lens.id}
+                                    className="px-3 py-3 text-center font-medium tabular-nums text-zinc-700 dark:text-zinc-300 break-words"
+                                  >
+                                    <div className="flex items-center justify-center gap-1">
+                                      <div className="flex flex-col items-center gap-0.5">
+                                        {resolved.structuredLines.map(
+                                          (line: StructuredLine, i: number) => {
+                                            const lineHighlighted =
+                                              isBest && fragment === line.value;
+                                            return (
+                                              <div
+                                                key={i}
+                                                className={`flex items-baseline gap-1 ${lineHighlighted ? "text-blue-600 dark:text-blue-400" : ""}`}
+                                              >
+                                                <span>{line.value}</span>
+                                                {lineHighlighted && (
+                                                  <span className="text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
+                                                    ★
+                                                  </span>
+                                                )}
+                                                {line.label && (
+                                                  <span
+                                                    className={`text-[11px] ${lineHighlighted ? "text-blue-400/70 dark:text-blue-400/60" : "text-zinc-400 dark:text-zinc-500"}`}
+                                                  >
+                                                    ({line.label})
+                                                  </span>
+                                                )}
+                                              </div>
+                                            );
+                                          }
+                                        )}
+                                        {resolved.subValue && (
+                                          <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
+                                            {resolved.subValue}
+                                          </p>
+                                        )}
+                                      </div>
+                                      {resolved.note && (
+                                        <FieldNotePopover
+                                          note={resolved.note}
+                                        />
+                                      )}
+                                    </div>
+                                  </td>
+                                );
+                              }
+
+                              // --- Plain string rendering ---
+                              const displayVal = resolved.displayValue;
+                              const usePartialHighlight =
+                                isBest &&
+                                fragment !== undefined &&
+                                displayVal !== undefined &&
+                                displayVal.includes(fragment) &&
+                                displayVal !== fragment;
+
+                              let primaryNode: React.ReactNode;
+                              if (displayVal === undefined) {
+                                primaryNode = valueCellLabels.missing;
+                              } else if (usePartialHighlight && fragment) {
+                                const idx = displayVal.indexOf(fragment);
+                                const before = displayVal.slice(0, idx);
+                                const after = displayVal.slice(
+                                  idx + fragment.length
+                                );
+                                primaryNode = (
+                                  <>
+                                    {before}
+                                    <span className="text-blue-600 dark:text-blue-400">
+                                      {fragment}
+                                    </span>
+                                    <span className="ml-0.5 text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
+                                      ★
+                                    </span>
+                                    {after}
+                                  </>
+                                );
+                              } else {
+                                primaryNode = (
+                                  <>
+                                    {displayVal}
+                                    {isBest && (
+                                      <span className="ml-1.5 text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
+                                        ★
+                                      </span>
+                                    )}
+                                  </>
+                                );
+                              }
+
+                              return (
+                                <td
+                                  key={lens.id}
+                                  className={`px-3 py-3 text-center font-medium tabular-nums break-words ${
+                                    isBest && !usePartialHighlight
+                                      ? "text-blue-600 dark:text-blue-400"
+                                      : "text-zinc-700 dark:text-zinc-300"
+                                  }`}
+                                >
+                                  <div className="flex items-center justify-center gap-1">
+                                    <div>
+                                      <span className="whitespace-pre-line">
+                                        {primaryNode}
+                                      </span>
+                                      {resolved.subValue && (
+                                        <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
+                                          {resolved.subValue}
+                                        </p>
+                                      )}
+                                    </div>
+                                    {resolved.note && (
+                                      <FieldNotePopover note={resolved.note} />
+                                    )}
+                                  </div>
+                                </td>
+                              );
+                            }
+
+                            // text row
+                            return (
+                              <td
+                                key={lens.id}
+                                className="px-3 py-3 text-center text-zinc-700 dark:text-zinc-300 break-words"
+                              >
+                                <div className="flex items-center justify-center gap-1">
+                                  <div>
+                                    <span className="whitespace-pre-line">
+                                      {resolved.displayValue ??
+                                        valueCellLabels.missing}
+                                    </span>
+                                    {resolved.subValue && (
+                                      <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
+                                        {resolved.subValue}
+                                      </p>
+                                    )}
+                                  </div>
+                                  {resolved.note && (
+                                    <FieldNotePopover note={resolved.note} />
+                                  )}
+                                </div>
+                              </td>
+                            );
+                          })}
+                          {/* Empty slot cells for unfilled columns */}
+                          {Array.from({ length: emptySlotCount }).map(
+                            (_, i) => (
+                              <td
+                                key={`empty-cell-${i}`}
+                                className="border-l border-zinc-100 bg-white dark:border-zinc-800/60 dark:bg-zinc-950"
+                              />
+                            )
+                          )}
+                        </tr>
+                      );
+                    })}
+                  </React.Fragment>
+                );
+              })}
+          </tbody>
+
+          {orderedLenses.length > 0 && (
+            <tfoot>
+              {/* Footer row: official site + report links per lens */}
+              <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
+                <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
+                {orderedLenses.map((lens) => {
+                  const url = getLensUrl(lens, locale);
+                  const fields = lensFields.get(lens.id);
                   return (
-                    <td key={lens.id} className="px-3 py-3">
-                      <div className="flex justify-center">
-                        <PriceBand lens={lens} compact />
+                    <td key={lens.id} className="px-3 py-2">
+                      <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+                        {url ? (
+                          <ExternalLink
+                            href={url}
+                            className="inline-flex items-center gap-1 text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                          >
+                            {t("officialSite")}
+                          </ExternalLink>
+                        ) : (
+                          <span className="inline-flex cursor-not-allowed items-center gap-1 text-xs text-zinc-300 dark:text-zinc-600">
+                            {t("officialSite")}
+                          </span>
+                        )}
+                        <FeedbackTrigger
+                          type="data_issue"
+                          context={{
+                            lensId: lens.id,
+                            lensModel: lens.model,
+                            lensBrand: tBrand(lens.brand),
+                          }}
+                          fields={fields}
+                          className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
+                        >
+                          <Flag className="h-3 w-3" />
+                          {t("reportIssue")}
+                        </FeedbackTrigger>
                       </div>
                     </td>
                   );
                 })}
                 {Array.from({ length: emptySlotCount }).map((_, i) => (
-                  <td key={`empty-price-${i}`} className="border-l border-zinc-100 bg-white dark:border-zinc-800/60 dark:bg-zinc-950" />
+                  <td
+                    key={`empty-foot-${i}`}
+                    className="border-l border-zinc-200 dark:border-zinc-800"
+                  />
                 ))}
               </tr>
-            </React.Fragment>
+            </tfoot>
           )}
-
-          {/* Populated table: only rendered when at least one lens is selected */}
-          {orderedLenses.length > 0 && visibleGroups.map((group) => {
-            return (
-              <React.Fragment key={group.label}>
-                {/* Group header row.
-                    The label is absolutely positioned at --section-center (updated
-                    on scroll/resize) so it stays centered in the visible content
-                    pane regardless of horizontal scroll position. */}
-                <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
-                  <td colSpan={totalColSpan} className="h-8 text-center">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                      {group.label}
-                    </span>
-                  </td>
-                </tr>
-
-                {/* Data rows */}
-                {group.rows.map((row) => {
-                  // Compute best value for numeric rows using pre-resolved comparables.
-                  let bestVal: number | null = null;
-                  if (row.kind === "numeric" && row.bestDir) {
-                    const vals = orderedLenses
-                      .map((l) => {
-                        const r = resolvedPerLens.get(l.id)?.get(row.label);
-                        return r?.kind === "numeric" ? r.comparable : undefined;
-                      })
-                      .filter((v): v is number => v !== undefined);
-                    if (vals.length > 1) {
-                      bestVal =
-                        row.bestDir === "min"
-                          ? Math.min(...vals)
-                          : Math.max(...vals);
-                    }
-                  }
-
-                  return (
-                    <tr
-                      key={row.label}
-                      className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0"
-                    >
-                      {/* Label cell */}
-                      <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                        <div className="flex items-center justify-end gap-1">
-                          {row.labelNote && <FieldNotePopover note={row.labelNote} variant={row.labelNoteVariant} />}
-                          <span>{row.label}</span>
-                        </div>
-                      </td>
-
-                      {/* Value cells — filled lenses */}
-                      {orderedLenses.map((lens) => {
-                        const resolved = resolvedPerLens.get(lens.id)?.get(row.label);
-
-                        // Lens has no data for this row — render empty cell.
-                        if (!resolved) {
-                          return (
-                            <td
-                              key={lens.id}
-                              className="px-3 py-3 text-center text-zinc-400 dark:text-zinc-600"
-                            >
-                              {valueCellLabels.missing}
-                            </td>
-                          );
-                        }
-
-                        if (resolved.kind === "bool") {
-                          return (
-                            <td
-                              key={lens.id}
-                              className="px-3 py-3 text-center text-zinc-700 dark:text-zinc-300"
-                            >
-                              <div className="flex items-center justify-center gap-1">
-                                <div>
-                                  <BoolCell
-                                    value={resolved.boolValue}
-                                    yes={valueCellLabels.yes}
-                                    no={valueCellLabels.no}
-                                    partial={valueCellLabels.partial}
-                                    unknown={valueCellLabels.missing}
-                                  />
-                                  {resolved.subValue && (
-                                    <p className="mt-0.5 text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                      {resolved.subValue}
-                                    </p>
-                                  )}
-                                </div>
-                                {resolved.note && <FieldNotePopover note={resolved.note} />}
-                              </div>
-                            </td>
-                          );
-                        }
-
-                        if (resolved.kind === "numeric") {
-                          const isBest =
-                            bestVal !== null && resolved.comparable === bestVal;
-                          const fragment = isBest ? resolved.highlightFragment : undefined;
-
-                          // --- Structured multi-line rendering ---
-                          if (resolved.structuredLines && resolved.structuredLines.length > 0) {
-                            return (
-                              <td
-                                key={lens.id}
-                                className="px-3 py-3 text-center font-medium tabular-nums text-zinc-700 dark:text-zinc-300 break-words"
-                              >
-                                <div className="flex items-center justify-center gap-1">
-                                  <div className="flex flex-col items-center gap-0.5">
-                                    {resolved.structuredLines.map(
-                                      (line: StructuredLine, i: number) => {
-                                        const lineHighlighted =
-                                          isBest && fragment === line.value;
-                                        return (
-                                          <div
-                                            key={i}
-                                            className={`flex items-baseline gap-1 ${lineHighlighted ? "text-blue-600 dark:text-blue-400" : ""}`}
-                                          >
-                                            <span>{line.value}</span>
-                                            {lineHighlighted && (
-                                              <span className="text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
-                                                ★
-                                              </span>
-                                            )}
-                                            {line.label && (
-                                              <span
-                                                className={`text-[11px] ${lineHighlighted ? "text-blue-400/70 dark:text-blue-400/60" : "text-zinc-400 dark:text-zinc-500"}`}
-                                              >
-                                                ({line.label})
-                                              </span>
-                                            )}
-                                          </div>
-                                        );
-                                      }
-                                    )}
-                                    {resolved.subValue && (
-                                      <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                        {resolved.subValue}
-                                      </p>
-                                    )}
-                                  </div>
-                                  {resolved.note && <FieldNotePopover note={resolved.note} />}
-                                </div>
-                              </td>
-                            );
-                          }
-
-                          // --- Plain string rendering ---
-                          const displayVal = resolved.displayValue;
-                          const usePartialHighlight =
-                            isBest &&
-                            fragment !== undefined &&
-                            displayVal !== undefined &&
-                            displayVal.includes(fragment) &&
-                            displayVal !== fragment;
-
-                          let primaryNode: React.ReactNode;
-                          if (displayVal === undefined) {
-                            primaryNode = valueCellLabels.missing;
-                          } else if (usePartialHighlight && fragment) {
-                            const idx = displayVal.indexOf(fragment);
-                            const before = displayVal.slice(0, idx);
-                            const after = displayVal.slice(
-                              idx + fragment.length
-                            );
-                            primaryNode = (
-                              <>
-                                {before}
-                                <span className="text-blue-600 dark:text-blue-400">
-                                  {fragment}
-                                </span>
-                                <span className="ml-0.5 text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
-                                  ★
-                                </span>
-                                {after}
-                              </>
-                            );
-                          } else {
-                            primaryNode = (
-                              <>
-                                {displayVal}
-                                {isBest && (
-                                  <span className="ml-1.5 text-[10px] font-semibold text-blue-500 dark:text-blue-400 uppercase tracking-wide">
-                                    ★
-                                  </span>
-                                )}
-                              </>
-                            );
-                          }
-
-                          return (
-                            <td
-                              key={lens.id}
-                              className={`px-3 py-3 text-center font-medium tabular-nums break-words ${
-                                isBest && !usePartialHighlight
-                                  ? "text-blue-600 dark:text-blue-400"
-                                  : "text-zinc-700 dark:text-zinc-300"
-                              }`}
-                            >
-                              <div className="flex items-center justify-center gap-1">
-                                <div>
-                                  <span className="whitespace-pre-line">
-                                    {primaryNode}
-                                  </span>
-                                  {resolved.subValue && (
-                                    <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed font-normal text-zinc-400 dark:text-zinc-500">
-                                      {resolved.subValue}
-                                    </p>
-                                  )}
-                                </div>
-                                {resolved.note && <FieldNotePopover note={resolved.note} />}
-                              </div>
-                            </td>
-                          );
-                        }
-
-                        // text row
-                        return (
-                          <td
-                            key={lens.id}
-                            className="px-3 py-3 text-center text-zinc-700 dark:text-zinc-300 break-words"
-                          >
-                            <div className="flex items-center justify-center gap-1">
-                              <div>
-                                <span className="whitespace-pre-line">
-                                  {resolved.displayValue ?? valueCellLabels.missing}
-                                </span>
-                                {resolved.subValue && (
-                                  <p className="mt-0.5 whitespace-pre-line text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">
-                                    {resolved.subValue}
-                                  </p>
-                                )}
-                              </div>
-                              {resolved.note && <FieldNotePopover note={resolved.note} />}
-                            </div>
-                          </td>
-                        );
-                      })}
-                      {/* Empty slot cells for unfilled columns */}
-                      {Array.from({ length: emptySlotCount }).map((_, i) => (
-                        <td
-                          key={`empty-cell-${i}`}
-                          className="border-l border-zinc-100 bg-white dark:border-zinc-800/60 dark:bg-zinc-950"
-                        />
-                      ))}
-                    </tr>
-                  );
-                })}
-              </React.Fragment>
-            );
-          })}
-        </tbody>
-
-        {orderedLenses.length > 0 && <tfoot>
-          {/* Footer row: official site + report links per lens */}
-          <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
-            <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
-            {orderedLenses.map((lens) => {
-              const url = getLensUrl(lens, locale);
-              const fields = lensFields.get(lens.id);
-              return (
-                <td key={lens.id} className="px-3 py-2">
-                  <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
-                    {url ? (
-                      <ExternalLink
-                        href={url}
-                        className="inline-flex items-center gap-1 text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
-                      >
-                        {t("officialSite")}
-                      </ExternalLink>
-                    ) : (
-                      <span className="inline-flex cursor-not-allowed items-center gap-1 text-xs text-zinc-300 dark:text-zinc-600">
-                        {t("officialSite")}
-                      </span>
-                    )}
-                    <FeedbackTrigger
-                      type="data_issue"
-                      context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
-                      fields={fields}
-                      className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
-                    >
-                      <Flag className="h-3 w-3" />
-                      {t("reportIssue")}
-                    </FeedbackTrigger>
-                  </div>
-                </td>
-              );
-            })}
-            {Array.from({ length: emptySlotCount }).map((_, i) => (
-              <td key={`empty-foot-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
-            ))}
-          </tr>
-        </tfoot>}
-      </table>
-    </div>
+        </table>
+      </div>
     </>
   );
 }

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -10,7 +10,13 @@ import { trendingPresets, type TrendingPreset } from "@/lib/trending";
 import { allLenses } from "@/lib/lens";
 import { cn } from "@/lib/utils";
 
-export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSelect?: () => void }) {
+export function PresetCard({
+  preset,
+  onSelect,
+}: {
+  preset: TrendingPreset;
+  onSelect?: () => void;
+}) {
   const router = useRouter();
   const locale = useLocale();
   const lang = locale === "zh" ? "zh" : "en";
@@ -41,7 +47,9 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
       {/* Lens model badge strip */}
       <div className="mt-2.5 flex flex-wrap gap-1">
         {lenses.map((lens) => {
-          if (!lens) return null;
+          if (!lens) {
+            return null;
+          }
           return (
             <span
               key={lens.id}
@@ -70,14 +78,18 @@ export default function CuratedComparisons() {
 
   function updateScrollState() {
     const el = scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     setCanScrollLeft(el.scrollLeft > 4);
     setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 4);
   }
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     updateScrollState();
     el.addEventListener("scroll", updateScrollState, { passive: true });
     const ro = new ResizeObserver(updateScrollState);
@@ -90,12 +102,16 @@ export default function CuratedComparisons() {
 
   function scrollToDir(dir: -1 | 1) {
     const el = scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     const approxCardWidth = el.scrollWidth / trendingPresets.length;
     el.scrollBy({ left: dir * approxCardWidth, behavior: "smooth" });
   }
 
-  if (compareIds.length > 0) return null;
+  if (compareIds.length > 0) {
+    return null;
+  }
 
   return (
     <div className="mb-2">
@@ -111,7 +127,9 @@ export default function CuratedComparisons() {
           aria-label="Scroll left"
           className={cn(
             "absolute left-0 top-0 bottom-0 z-10 flex items-center pl-1 pr-6 bg-gradient-to-r from-white/90 to-transparent transition-opacity dark:from-zinc-950/90",
-            canScrollLeft ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+            canScrollLeft
+              ? "opacity-100 pointer-events-auto"
+              : "opacity-0 pointer-events-none"
           )}
         >
           <ChevronLeft className="h-5 w-5 text-zinc-500 dark:text-zinc-400" />
@@ -124,7 +142,10 @@ export default function CuratedComparisons() {
         >
           <div className="flex items-stretch gap-2 px-4 pb-0.5">
             {trendingPresets.map((preset) => (
-              <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
+              <div
+                key={preset.slug}
+                className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]"
+              >
                 <PresetCard preset={preset} />
               </div>
             ))}
@@ -138,7 +159,9 @@ export default function CuratedComparisons() {
           aria-label="Scroll right"
           className={cn(
             "absolute right-0 top-0 bottom-0 z-10 flex items-center pl-6 pr-1 bg-gradient-to-l from-white/90 to-transparent transition-opacity dark:from-zinc-950/90",
-            canScrollRight ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+            canScrollRight
+              ? "opacity-100 pointer-events-auto"
+              : "opacity-0 pointer-events-none"
           )}
         >
           <ChevronRight className="h-5 w-5 text-zinc-500 dark:text-zinc-400" />

--- a/src/components/CuratedPresetsButton.tsx
+++ b/src/components/CuratedPresetsButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
 import { LayoutGrid } from "lucide-react";
@@ -10,26 +10,28 @@ import { trendingPresets } from "@/lib/trending";
 import { PresetCard } from "@/components/CuratedComparisons";
 import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
 
+function subscribeToDesktopChange(onChange: () => void) {
+  const query = window.matchMedia("(min-width: 640px)");
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getDesktopSnapshot() {
+  return window.matchMedia("(min-width: 640px)").matches;
+}
+
+function useIsDesktop() {
+  return useSyncExternalStore(
+    subscribeToDesktopChange,
+    getDesktopSnapshot,
+    () => true
+  );
+}
+
 export default function CuratedPresetsButton() {
   const t = useTranslations("Compare");
   const [open, setOpen] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(true);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-    const mq = window.matchMedia("(min-width: 640px)");
-    setIsDesktop(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-
-  const trigger = (
-    <span className={`${ICON_NAV_BTN_CLS} h-8 w-8`} title={t("curatedTitle")}>
-      <LayoutGrid className="h-4 w-4" />
-    </span>
-  );
+  const isDesktop = useIsDesktop();
 
   const panelContent = (
     <div className="p-3 flex flex-col gap-2">
@@ -46,18 +48,13 @@ export default function CuratedPresetsButton() {
     </div>
   );
 
-  if (!mounted) {
-    return (
-      <button className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
-        <LayoutGrid className="h-4 w-4" />
-      </button>
-    );
-  }
-
   if (isDesktop) {
     return (
       <Popover.Root open={open} onOpenChange={setOpen}>
-        <Popover.Trigger className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
+        <Popover.Trigger
+          className={`${ICON_NAV_BTN_CLS} h-8 w-8`}
+          aria-label={t("curatedTitle")}
+        >
           <LayoutGrid className="h-4 w-4" />
         </Popover.Trigger>
         <Popover.Portal>
@@ -73,18 +70,23 @@ export default function CuratedPresetsButton() {
 
   return (
     <Drawer.Root open={open} onOpenChange={setOpen} swipeDirection="down">
-      <Drawer.Trigger className={`${ICON_NAV_BTN_CLS} h-8 w-8`} aria-label={t("curatedTitle")}>
+      <Drawer.Trigger
+        className={`${ICON_NAV_BTN_CLS} h-8 w-8`}
+        aria-label={t("curatedTitle")}
+      >
         <LayoutGrid className="h-4 w-4" />
       </Drawer.Trigger>
       <Drawer.Portal>
-        <Drawer.Backdrop className={`fixed inset-0 ${Z.overlay} bg-black/40 transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`} />
-        <Drawer.Popup className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[var(--safe-inset-bottom)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}>
+        <Drawer.Backdrop
+          className={`fixed inset-0 ${Z.overlay} bg-black/40 transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`}
+        />
+        <Drawer.Popup
+          className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[var(--safe-inset-bottom)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}
+        >
           <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
             <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
           </div>
-          <div className="overflow-y-auto pb-8">
-            {panelContent}
-          </div>
+          <div className="overflow-y-auto pb-8">{panelContent}</div>
         </Drawer.Popup>
       </Drawer.Portal>
     </Drawer.Root>

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -24,14 +24,19 @@ export default function DataInfo() {
     );
 
   const formatDate = (dateStr: string) =>
-    new Intl.DateTimeFormat(locale, { year: "numeric", month: "long", day: "numeric" }).format(
-      new Date(dateStr)
-    );
+    new Intl.DateTimeFormat(locale, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(new Date(dateStr));
 
   const dateLabel = (() => {
-    if (clickState === "version")
+    if (clickState === "version") {
       return `${meta.version} Build ${meta.buildNumber}`;
-    if (clickState === "easter") return h("dataSnapshot");
+    }
+    if (clickState === "easter") {
+      return h("dataSnapshot");
+    }
     return `${t("updatedPrefix")} ${formatDate(meta.lastUpdated)}`;
   })();
 

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -134,7 +134,9 @@ export default function FeedbackDialog({
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
-    if (status === "submitting") return;
+    if (status === "submitting") {
+      return;
+    }
     if (!hasContent) {
       setSubmitAttempted(true);
       return;
@@ -154,16 +156,20 @@ export default function FeedbackDialog({
           context: {
             ...(context ?? {}),
             ...(selectedFieldLabel ? { field: selectedFieldLabel } : {}),
-            ...(selectedField?.currentValue ? { currentValue: selectedField.currentValue } : {}),
-            ...(suggestedCorrection.trim() ? { suggestedCorrection: suggestedCorrection.trim() } : {}),
+            ...(selectedField?.currentValue
+              ? { currentValue: selectedField.currentValue }
+              : {}),
+            ...(suggestedCorrection.trim()
+              ? { suggestedCorrection: suggestedCorrection.trim() }
+              : {}),
           },
         }),
       });
 
       if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as
-          | { error?: string }
-          | null;
+        const data = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         throw new Error(data?.error ?? "request_failed");
       }
 
@@ -180,13 +186,12 @@ export default function FeedbackDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        layerRef={dialogLayerRef}
-        className="max-w-md"
-      >
+      <DialogContent layerRef={dialogLayerRef} className="max-w-md">
         <DialogHeader>
           <DialogTitle>{t(titleKey)}</DialogTitle>
-          {status !== "success" && <DialogDescription>{t(descriptionKey)}</DialogDescription>}
+          {status !== "success" && (
+            <DialogDescription>{t(descriptionKey)}</DialogDescription>
+          )}
         </DialogHeader>
 
         {status === "success" ? (
@@ -194,7 +199,10 @@ export default function FeedbackDialog({
             {t("success")}
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-2">
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-3 px-5 pb-2"
+          >
             {lensHeader && (
               <div className="flex flex-col gap-0.5 border-b border-zinc-200 dark:border-zinc-800 pb-3">
                 <span className="text-[11px] font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
@@ -230,7 +238,10 @@ export default function FeedbackDialog({
                     setSelectedFieldLabel(v ?? "");
                     setSuggestedCorrection("");
                   }}
-                  items={fields.map((f) => ({ value: f.label, label: f.label }))}
+                  items={fields.map((f) => ({
+                    value: f.label,
+                    label: f.label,
+                  }))}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={t("fieldPickerPlaceholder")} />
@@ -238,7 +249,9 @@ export default function FeedbackDialog({
                   <SelectContent portalContainer={dialogLayerRef}>
                     {groupedFields.map((group) => (
                       <SelectGroup key={group.label}>
-                        {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                        {group.label && (
+                          <SelectLabel>{group.label}</SelectLabel>
+                        )}
                         {group.fields.map((f) => (
                           <SelectItem key={f.label} value={f.label}>
                             {f.label}
@@ -251,16 +264,17 @@ export default function FeedbackDialog({
 
                 {selectedField && (
                   <div className="flex flex-col gap-2 rounded-lg bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 px-3 py-2.5">
-                    {selectedField.currentValue && !selectedField.hideCurrentValue && (
-                      <div className="flex items-baseline gap-2">
-                        <span className="shrink-0 text-xs text-zinc-400 dark:text-zinc-500">
-                          {t("currentValueLabel")}
-                        </span>
-                        <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
-                          {selectedField.currentValue}
-                        </span>
-                      </div>
-                    )}
+                    {selectedField.currentValue &&
+                      !selectedField.hideCurrentValue && (
+                        <div className="flex items-baseline gap-2">
+                          <span className="shrink-0 text-xs text-zinc-400 dark:text-zinc-500">
+                            {t("currentValueLabel")}
+                          </span>
+                          <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                            {selectedField.currentValue}
+                          </span>
+                        </div>
+                      )}
                     <div className="flex flex-col gap-1">
                       <label
                         htmlFor={correctionId}

--- a/src/components/InstallPage.tsx
+++ b/src/components/InstallPage.tsx
@@ -11,19 +11,21 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 type Platform =
-  | "loading"       // initial — waiting for beforeinstallprompt or timeout
-  | "installed"     // already running as a standalone PWA
-  | "prompt"        // Chrome/Edge/Android — programmatic install available
-  | "ios"           // iOS — manual Add to Home Screen flow
-  | "macos-safari"  // macOS Safari — Share → Add to Dock
-  | "generic";      // everything else — show browser menu hint
+  | "loading" // initial — waiting for beforeinstallprompt or timeout
+  | "installed" // already running as a standalone PWA
+  | "prompt" // Chrome/Edge/Android — programmatic install available
+  | "ios" // iOS — manual Add to Home Screen flow
+  | "macos-safari" // macOS Safari — Share → Add to Dock
+  | "generic"; // everything else — show browser menu hint
 
 function detectSync(): Platform | null {
   // Check standalone mode first (works everywhere).
   const standalone =
     window.matchMedia("(display-mode: standalone)").matches ||
     (navigator as { standalone?: boolean }).standalone === true;
-  if (standalone) return "installed";
+  if (standalone) {
+    return "installed";
+  }
 
   const ua = navigator.userAgent;
   if (/iPad|iPhone|iPod/.test(ua)) {
@@ -43,13 +45,17 @@ const MACOS_STEPS = ["macosStep1", "macosStep2", "macosStep3"] as const;
 
 export default function InstallPage() {
   const t = useTranslations("Install");
-  const [platform, setPlatform] = useState<Platform>("loading");
-  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [platform, setPlatform] = useState<Platform>(() => {
+    if (typeof window === "undefined") {
+      return "loading";
+    }
+    return detectSync() ?? "loading";
+  });
+  const [promptEvent, setPromptEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
-    const sync = detectSync();
-    if (sync) {
-      setPlatform(sync);
+    if (platform !== "loading") {
       return;
     }
 
@@ -69,17 +75,23 @@ export default function InstallPage() {
       window.removeEventListener("beforeinstallprompt", handler);
       clearTimeout(timer);
     };
-  }, []);
+  }, [platform]);
 
   async function handleInstall() {
-    if (!promptEvent) return;
+    if (!promptEvent) {
+      return;
+    }
     await promptEvent.prompt();
     const { outcome } = await promptEvent.userChoice;
-    if (outcome === "accepted") setPlatform("installed");
+    if (outcome === "accepted") {
+      setPlatform("installed");
+    }
   }
 
   // Render nothing during the brief detection window to avoid layout flash.
-  if (platform === "loading") return null;
+  if (platform === "loading") {
+    return null;
+  }
 
   return (
     <div className="flex flex-col items-center justify-center min-h-full px-6 py-16 text-center">
@@ -96,7 +108,9 @@ export default function InstallPage() {
           <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("installedTitle")}
           </h1>
-          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("installedBody")}</p>
+          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">
+            {t("installedBody")}
+          </p>
           <Link
             href="/lenses/x"
             className="mt-8 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 font-medium text-sm hover:opacity-90 transition-opacity"
@@ -111,7 +125,9 @@ export default function InstallPage() {
           <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("promptTitle")}
           </h1>
-          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("promptBody")}</p>
+          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">
+            {t("promptBody")}
+          </p>
           <button
             onClick={handleInstall}
             className="mt-8 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 font-medium text-sm hover:opacity-90 transition-opacity"
@@ -126,7 +142,9 @@ export default function InstallPage() {
           <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("iosTitle")}
           </h1>
-          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("iosSubtitle")}</p>
+          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">
+            {t("iosSubtitle")}
+          </p>
           <ol className="mt-6 space-y-3 text-left">
             {IOS_STEPS.map((key, i) => (
               <li
@@ -136,7 +154,9 @@ export default function InstallPage() {
                 <span className="shrink-0 w-6 h-6 rounded-full bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 text-xs font-bold flex items-center justify-center mt-0.5">
                   {i + 1}
                 </span>
-                <span className="text-sm text-zinc-700 dark:text-zinc-300">{t(key)}</span>
+                <span className="text-sm text-zinc-700 dark:text-zinc-300">
+                  {t(key)}
+                </span>
               </li>
             ))}
           </ol>
@@ -148,7 +168,9 @@ export default function InstallPage() {
           <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("macosTitle")}
           </h1>
-          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("macosSubtitle")}</p>
+          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">
+            {t("macosSubtitle")}
+          </p>
           <ol className="mt-6 space-y-3 text-left">
             {MACOS_STEPS.map((key, i) => (
               <li
@@ -158,7 +180,9 @@ export default function InstallPage() {
                 <span className="shrink-0 w-6 h-6 rounded-full bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 text-xs font-bold flex items-center justify-center mt-0.5">
                   {i + 1}
                 </span>
-                <span className="text-sm text-zinc-700 dark:text-zinc-300">{t(key)}</span>
+                <span className="text-sm text-zinc-700 dark:text-zinc-300">
+                  {t(key)}
+                </span>
               </li>
             ))}
           </ol>
@@ -170,7 +194,9 @@ export default function InstallPage() {
           <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("genericTitle")}
           </h1>
-          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("genericBody")}</p>
+          <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">
+            {t("genericBody")}
+          </p>
         </div>
       )}
     </div>

--- a/src/components/Iris.tsx
+++ b/src/components/Iris.tsx
@@ -33,7 +33,11 @@ import {
   findThetaForInradius,
   findThetaForFStop,
 } from "@/lib/iris-kinematics";
-import { R_HOUSING, type IrisConfig, type IrisAnimation } from "@/config/iris-config";
+import {
+  R_HOUSING,
+  type IrisConfig,
+  type IrisAnimation,
+} from "@/config/iris-config";
 import ApertureStrip from "@/components/ApertureStrip";
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -71,143 +75,96 @@ export default function Iris({
   const size = sizeProp ?? configSize;
 
   // Derive interaction mode flags and hover-specific config.
-  const isHover     = interactive?.type === "hover";
-  const isTap       = interactive?.type === "tap";
+  const isHover = interactive?.type === "hover";
+  const isTap = interactive?.type === "tap";
   const hoverConfig = isHover ? interactive : null;
   const hotzoneScaleH = hoverConfig?.hotzoneScaleH ?? 1;
   const hotzoneScaleV = hoverConfig?.hotzoneScaleV ?? 1;
-  const easeOutMs     = hoverConfig?.easeOutMs     ?? 700;
+  const easeOutMs = hoverConfig?.easeOutMs ?? 700;
 
-  const dc = useMemo(() => buildDerivedConfig(rawConfig, R_HOUSING), [rawConfig]);
+  const dc = useMemo(
+    () => buildDerivedConfig(rawConfig, R_HOUSING),
+    [rawConfig]
+  );
   const thetaOpen = useMemo(() => computeThetaOpen(dc, R_HOUSING), [dc]);
-  const thetaMax  = useMemo(() => thetaRange(dc).max, [dc]);
+  const thetaMax = useMemo(() => thetaRange(dc).max, [dc]);
 
-  const inradiusOpen = useMemo(() => apertureInradius(thetaOpen, dc), [thetaOpen, dc]);
+  const inradiusOpen = useMemo(
+    () => apertureInradius(thetaOpen, dc),
+    [thetaOpen, dc]
+  );
 
-  const DEFAULT_THETA = useMemo(() =>
-    findThetaForFStop(rawConfig.defaultFStop, dc, { min: thetaOpen, max: thetaMax }, rawConfig.openFStop),
-  [rawConfig.defaultFStop, rawConfig.openFStop, dc, thetaOpen, thetaMax]);
+  const DEFAULT_THETA = useMemo(
+    () =>
+      findThetaForFStop(
+        rawConfig.defaultFStop,
+        dc,
+        { min: thetaOpen, max: thetaMax },
+        rawConfig.openFStop
+      ),
+    [rawConfig.defaultFStop, rawConfig.openFStop, dc, thetaOpen, thetaMax]
+  );
 
   const [theta, setTheta] = useState<number>(DEFAULT_THETA);
   const [isAnimating, setIsAnimating] = useState(!!onMount);
-  const thetaRef       = useRef<number>(DEFAULT_THETA);
-  const animRef        = useRef<number | null>(null);
-  const chaseRef       = useRef<number | null>(null);
-  const initAnimRef    = useRef<number | null>(null);
+  const thetaRef = useRef<number>(DEFAULT_THETA);
+  const animRef = useRef<number | null>(null);
+  const chaseRef = useRef<number | null>(null);
+  const initAnimRef = useRef<number | null>(null);
   const targetThetaRef = useRef<number>(DEFAULT_THETA);
-  const lastFrameRef   = useRef<number>(0);
+  const lastFrameRef = useRef<number>(0);
   const defaultThetaRef = useRef(DEFAULT_THETA);
-  defaultThetaRef.current = DEFAULT_THETA;
 
   const blades = useMemo(
     () => solveAllBlades(theta, dc),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- solveAllBlades is a pure
+
     // function imported from a stable module; adding it to deps would be noise.
     [theta, dc]
   );
   const shape = useMemo(() => bladeShapePath(dc), [dc]);
 
-  useEffect(() => () => {
-    if (animRef.current)     cancelAnimationFrame(animRef.current);
-    if (chaseRef.current)    cancelAnimationFrame(chaseRef.current);
-    if (initAnimRef.current) cancelAnimationFrame(initAnimRef.current);
-  }, []);
+  useEffect(() => {
+    defaultThetaRef.current = DEFAULT_THETA;
+  }, [DEFAULT_THETA]);
+
+  useEffect(
+    () => () => {
+      if (animRef.current) {
+        cancelAnimationFrame(animRef.current);
+      }
+      if (chaseRef.current) {
+        cancelAnimationFrame(chaseRef.current);
+      }
+      if (initAnimRef.current) {
+        cancelAnimationFrame(initAnimRef.current);
+      }
+    },
+    []
+  );
 
   // When not in hover mode, keep theta in sync with DEFAULT_THETA so the iris
   // reflects any config change (e.g. Design Lab parameter tuning).
   useEffect(() => {
-    if (isHover) return;
+    if (isHover) {
+      return;
+    }
     thetaRef.current = DEFAULT_THETA;
     setTheta(DEFAULT_THETA);
   }, [DEFAULT_THETA, isHover]);
 
-  // ── Animation engine ──────────────────────────────────────────────────────
-  // Shared by mount animation and tap interaction. Cancels any in-flight
-  // animations before starting, so the two triggers can never overlap.
-  // startChase / stopChase are function declarations hoisted to the top of
-  // this render function — accessible here even though defined below.
-
-  function playAnimation(anim: IrisAnimation) {
-    if (anim.type !== "sweep") return;
-    const { sweepMs, totalMs } = anim;
-
-    if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
-    if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
-
-    thetaRef.current = thetaOpen;
-    targetThetaRef.current = thetaOpen;
-    setTheta(thetaOpen);
-    setIsAnimating(true);
-    startChase();
-
-    const startTime = performance.now();
-    function tick(now: number) {
-      const elapsed = now - startTime;
-      if (elapsed < sweepMs) {
-        targetThetaRef.current = thetaOpen + (elapsed / sweepMs) * (thetaMax - thetaOpen);
-        initAnimRef.current = requestAnimationFrame(tick);
-      } else if (elapsed < totalMs) {
-        const p2 = (elapsed - sweepMs) / (totalMs - sweepMs);
-        targetThetaRef.current = thetaMax + p2 * (defaultThetaRef.current - thetaMax);
-        initAnimRef.current = requestAnimationFrame(tick);
-      } else {
-        targetThetaRef.current = defaultThetaRef.current;
-        initAnimRef.current = null;
-        setIsAnimating(false);
-      }
-    }
-    initAnimRef.current = requestAnimationFrame(tick);
-  }
-
-  // ── Mount animation ───────────────────────────────────────────────────────
-  useEffect(() => {
-    if (!onMount) return;
-    playAnimation(onMount);
-    return () => {
-      if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
-      stopChase();
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only init effect;
-  // thetaOpen/thetaMax read at mount time, stable for the component's lifetime.
-  }, []);
-
-  // ── Imperative controls (used by ApertureStrip) ───────────────────────────
-
-  function driveToFStop(fStop: number) {
-    if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
-    if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
-    const t = findThetaForFStop(fStop, dc, { min: thetaOpen, max: thetaMax }, rawConfig.openFStop);
-    targetThetaRef.current = Math.max(thetaOpen, Math.min(thetaMax, t));
-    startChase();
-  }
-
-  // ── Derived geometry ──────────────────────────────────────────────────────
-
-  const { N } = dc;
-  const stepDeg = 360 / N;
-  const maskCount = Math.floor((N - 1) / 2);
-
-  if (blades.length === 0) return null;
-
-  const b0 = blades[0];
-  const b0AngleDeg = (b0.bladeAngle * 180) / Math.PI;
-  const b0Transform = `translate(${b0.pivotPos.x.toFixed(3)},${b0.pivotPos.y.toFixed(3)}) rotate(${b0AngleDeg.toFixed(3)})`;
-
-  // ViewBox is tight around the visible blade area (clipped at R_HOUSING − bladeWidth).
-  // A 2-unit pad prevents subpixel fringing at the clip boundary.
-  const vbHalf  = R_HOUSING - dc.bladeWidth + 2;
-  const viewBox = `${-vbHalf} ${-vbHalf} ${vbHalf * 2} ${vbHalf * 2}`;
-
   // ── Chase loop ────────────────────────────────────────────────────────────
 
   function startChase() {
-    if (chaseRef.current) return;
+    if (chaseRef.current) {
+      return;
+    }
     lastFrameRef.current = performance.now();
     function chaseTick(now: number) {
-      const dt   = Math.min(now - lastFrameRef.current, 64);
+      const dt = Math.min(now - lastFrameRef.current, 64);
       lastFrameRef.current = now;
-      const k    = 1 - Math.exp(-dt / chaseTauMs);
-      const next = thetaRef.current + (targetThetaRef.current - thetaRef.current) * k;
+      const k = 1 - Math.exp(-dt / chaseTauMs);
+      const next =
+        thetaRef.current + (targetThetaRef.current - thetaRef.current) * k;
       thetaRef.current = next;
       setTheta(next);
       const delta = Math.abs(next - targetThetaRef.current);
@@ -234,8 +191,112 @@ export default function Iris({
   }
 
   function stopChase() {
-    if (chaseRef.current) { cancelAnimationFrame(chaseRef.current); chaseRef.current = null; }
+    if (chaseRef.current) {
+      cancelAnimationFrame(chaseRef.current);
+      chaseRef.current = null;
+    }
   }
+
+  // ── Animation engine ──────────────────────────────────────────────────────
+  // Shared by mount animation and tap interaction. Cancels any in-flight
+  // animations before starting, so the two triggers can never overlap.
+
+  function playAnimation(anim: IrisAnimation) {
+    if (anim.type !== "sweep") {
+      return;
+    }
+    const { sweepMs, totalMs } = anim;
+
+    if (animRef.current) {
+      cancelAnimationFrame(animRef.current);
+      animRef.current = null;
+    }
+    if (initAnimRef.current) {
+      cancelAnimationFrame(initAnimRef.current);
+      initAnimRef.current = null;
+    }
+
+    thetaRef.current = thetaOpen;
+    targetThetaRef.current = thetaOpen;
+    setTheta(thetaOpen);
+    setIsAnimating(true);
+    startChase();
+
+    const startTime = performance.now();
+    function tick(now: number) {
+      const elapsed = now - startTime;
+      if (elapsed < sweepMs) {
+        targetThetaRef.current =
+          thetaOpen + (elapsed / sweepMs) * (thetaMax - thetaOpen);
+        initAnimRef.current = requestAnimationFrame(tick);
+      } else if (elapsed < totalMs) {
+        const p2 = (elapsed - sweepMs) / (totalMs - sweepMs);
+        targetThetaRef.current =
+          thetaMax + p2 * (defaultThetaRef.current - thetaMax);
+        initAnimRef.current = requestAnimationFrame(tick);
+      } else {
+        targetThetaRef.current = defaultThetaRef.current;
+        initAnimRef.current = null;
+        setIsAnimating(false);
+      }
+    }
+    initAnimRef.current = requestAnimationFrame(tick);
+  }
+
+  // ── Mount animation ───────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!onMount) {
+      return;
+    }
+    playAnimation(onMount);
+    return () => {
+      if (initAnimRef.current) {
+        cancelAnimationFrame(initAnimRef.current);
+        initAnimRef.current = null;
+      }
+      stopChase();
+    };
+    // thetaOpen/thetaMax read at mount time, stable for the component's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Imperative controls (used by ApertureStrip) ───────────────────────────
+
+  function driveToFStop(fStop: number) {
+    if (animRef.current) {
+      cancelAnimationFrame(animRef.current);
+      animRef.current = null;
+    }
+    if (initAnimRef.current) {
+      cancelAnimationFrame(initAnimRef.current);
+      initAnimRef.current = null;
+    }
+    const t = findThetaForFStop(
+      fStop,
+      dc,
+      { min: thetaOpen, max: thetaMax },
+      rawConfig.openFStop
+    );
+    targetThetaRef.current = Math.max(thetaOpen, Math.min(thetaMax, t));
+    startChase();
+  }
+
+  // ── Derived geometry ──────────────────────────────────────────────────────
+
+  const { N } = dc;
+  const stepDeg = 360 / N;
+  const maskCount = Math.floor((N - 1) / 2);
+
+  const b0 = blades[0] ?? null;
+  const b0AngleDeg = b0 ? (b0.bladeAngle * 180) / Math.PI : 0;
+  const b0Transform = b0
+    ? `translate(${b0.pivotPos.x.toFixed(3)},${b0.pivotPos.y.toFixed(3)}) rotate(${b0AngleDeg.toFixed(3)})`
+    : "";
+
+  // ViewBox is tight around the visible blade area (clipped at R_HOUSING − bladeWidth).
+  // A 2-unit pad prevents subpixel fringing at the clip boundary.
+  const vbHalf = R_HOUSING - dc.bladeWidth + 2;
+  const viewBox = `${-vbHalf} ${-vbHalf} ${vbHalf * 2} ${vbHalf * 2}`;
 
   // ── Hover interaction ─────────────────────────────────────────────────────
   // Events fire on the hotzone wrapper div (sized by hotzoneScaleH/V), not
@@ -243,41 +304,58 @@ export default function Iris({
 
   function posToDiameterTheta(clientX: number, rect: DOMRect): number {
     const rawPos = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-    if (inradiusOpen <= 0) return thetaOpen + rawPos * (thetaMax - thetaOpen);
-    const r22     = (rawConfig.openFStop * inradiusOpen) / closedFStop;
+    if (inradiusOpen <= 0) {
+      return thetaOpen + rawPos * (thetaMax - thetaOpen);
+    }
+    const r22 = (rawConfig.openFStop * inradiusOpen) / closedFStop;
     const targetR = inradiusOpen + rawPos * (r22 - inradiusOpen);
     return findThetaForInradius(targetR, dc, { min: thetaOpen, max: thetaMax });
   }
 
   function handleMouseEnter(e: React.MouseEvent<HTMLDivElement>) {
-    if (!isHover) return;
-    if (animRef.current)     { cancelAnimationFrame(animRef.current);     animRef.current = null; }
-    if (initAnimRef.current) { cancelAnimationFrame(initAnimRef.current); initAnimRef.current = null; }
+    if (!isHover) {
+      return;
+    }
+    if (animRef.current) {
+      cancelAnimationFrame(animRef.current);
+      animRef.current = null;
+    }
+    if (initAnimRef.current) {
+      cancelAnimationFrame(initAnimRef.current);
+      initAnimRef.current = null;
+    }
     const rect = e.currentTarget.getBoundingClientRect();
     targetThetaRef.current = posToDiameterTheta(e.clientX, rect);
     startChase();
   }
 
   function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
-    if (!isHover) return;
+    if (!isHover) {
+      return;
+    }
     const rect = e.currentTarget.getBoundingClientRect();
     targetThetaRef.current = posToDiameterTheta(e.clientX, rect);
     startChase();
   }
 
   function handleMouseLeave() {
-    if (!isHover) return;
+    if (!isHover) {
+      return;
+    }
     stopChase();
     const startTheta = thetaRef.current;
-    const startTime  = performance.now();
+    const startTime = performance.now();
     function tick(now: number) {
-      const p        = Math.min(1, (now - startTime) / easeOutMs);
-      const eased    = 1 - (1 - p) ** 3;
+      const p = Math.min(1, (now - startTime) / easeOutMs);
+      const eased = 1 - (1 - p) ** 3;
       const newTheta = startTheta + (DEFAULT_THETA - startTheta) * eased;
       thetaRef.current = newTheta;
       setTheta(newTheta);
-      if (p < 1) animRef.current = requestAnimationFrame(tick);
-      else animRef.current = null;
+      if (p < 1) {
+        animRef.current = requestAnimationFrame(tick);
+      } else {
+        animRef.current = null;
+      }
     }
     animRef.current = requestAnimationFrame(tick);
   }
@@ -285,7 +363,9 @@ export default function Iris({
   // ── Tap interaction ───────────────────────────────────────────────────────
 
   function handleClick() {
-    if (interactive?.type !== "tap") return;
+    if (interactive?.type !== "tap") {
+      return;
+    }
     playAnimation(interactive.animation);
   }
 
@@ -298,9 +378,15 @@ export default function Iris({
   // is rendered. apertureStrip consumers still receive it via props as before.
   const currentFStop = useMemo(() => {
     const r = apertureInradius(theta, dc);
-    if (r <= 0 || inradiusOpen <= 0) return closedFStop;
-    return Math.min(closedFStop, rawConfig.openFStop * inradiusOpen / r);
+    if (r <= 0 || inradiusOpen <= 0) {
+      return closedFStop;
+    }
+    return Math.min(closedFStop, (rawConfig.openFStop * inradiusOpen) / r);
   }, [theta, dc, inradiusOpen, closedFStop, rawConfig.openFStop]);
+
+  if (blades.length === 0) {
+    return null;
+  }
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -310,7 +396,12 @@ export default function Iris({
   return (
     <div
       className={className}
-      style={{ display: "inline-flex", flexDirection: "column", alignItems: "center", flexShrink: 0 }}
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        flexShrink: 0,
+      }}
       data-testid="iris"
       data-fstop={currentFStop?.toFixed(2)}
       data-animating={isAnimating}
@@ -318,12 +409,12 @@ export default function Iris({
       {/* Hotzone wrapper — captures mouse/tap events */}
       <div
         style={{
-          width:          wrapperW,
-          height:         wrapperH,
-          display:        "flex",
-          alignItems:     "center",
+          width: wrapperW,
+          height: wrapperH,
+          display: "flex",
+          alignItems: "center",
           justifyContent: "center",
-          cursor:         isTap ? "pointer" : undefined,
+          cursor: isTap ? "pointer" : undefined,
         }}
         onMouseEnter={isHover ? handleMouseEnter : undefined}
         onMouseMove={isHover ? handleMouseMove : undefined}
@@ -347,7 +438,10 @@ export default function Iris({
                 {Array.from({ length: maskCount }, (_, k) => {
                   const j = (i + 1 + k) % N;
                   return (
-                    <g key={j} transform={`rotate(${(stepDeg * j).toFixed(3)})`}>
+                    <g
+                      key={j}
+                      transform={`rotate(${(stepDeg * j).toFixed(3)})`}
+                    >
                       <g transform={b0Transform}>
                         <path d={shape} fill="black" />
                       </g>
@@ -365,7 +459,11 @@ export default function Iris({
                 <g transform={b0Transform}>
                   <path
                     d={shape}
-                    className={bladeColor ? undefined : "fill-zinc-900 dark:fill-zinc-100"}
+                    className={
+                      bladeColor
+                        ? undefined
+                        : "fill-zinc-900 dark:fill-zinc-100"
+                    }
                     fill={bladeColor}
                     stroke="none"
                   />

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Aperture, Plus, Check } from "lucide-react";
+import { Plus, Check } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
@@ -31,8 +31,13 @@ export default function LensCard({
   const t = useTranslations("LensList");
   const tBrand = useTranslations("Brands");
   const hookAttr = useUiHookAttr();
-  const equivDisplay = fmt.focalRangeDisplay(fmt.focalEquiv(lens.focalLengthMin, lens.mount), fmt.focalEquiv(lens.focalLengthMax, lens.mount));
-  const mfdDisplay = lens.minFocusDistance ? `${lens.minFocusDistance.cm}cm` : "—";
+  const equivDisplay = fmt.focalRangeDisplay(
+    fmt.focalEquiv(lens.focalLengthMin, lens.mount),
+    fmt.focalEquiv(lens.focalLengthMax, lens.mount)
+  );
+  const mfdDisplay = lens.minFocusDistance
+    ? `${lens.minFocusDistance.cm}cm`
+    : "—";
   const filterDisplay = fmt.filterSizeDisplay(lens.filterMm);
   const weightDisplay = fmt.weightDisplay(lens.weightG, "g") ?? "—";
   const badges = [
@@ -176,7 +181,11 @@ export default function LensCard({
               : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700"
         }`}
       >
-        {isSelected ? <Check className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+        {isSelected ? (
+          <Check className="h-4 w-4" />
+        ) : (
+          <Plus className="h-4 w-4" />
+        )}
       </button>
 
       {/* Compare toggle */}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -18,7 +18,6 @@ import {
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
-import { Z } from "@/config/ui";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
 import { Button } from "@/components/ui/button";
@@ -46,14 +45,18 @@ export default function LensListClient({ lenses }: Props) {
   const pathname = usePathname();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-  const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
+  const [filters, setFilters] = useState<FilterState>(() =>
+    parseFilters(searchParams)
+  );
   const { compareIds, toggleCompare, canToggle } = useMountedCompare();
 
   const brands = useMemo(() => getUniqueBrands(lenses), [lenses]);
 
   const availableSpecialtyTags = useMemo(
     () =>
-      [...new Set(lenses.flatMap((l) => l.specialtyTags ?? []))] as SpecialtyTag[],
+      [
+        ...new Set(lenses.flatMap((l) => l.specialtyTags ?? [])),
+      ] as SpecialtyTag[],
     [lenses]
   );
 
@@ -77,10 +80,14 @@ export default function LensListClient({ lenses }: Props) {
     { value: "weightG", label: t("sortWeight") },
   ] as const satisfies readonly { value: SortKey; label: string }[];
 
-  function updateFilters(updater: FilterState | ((prev: FilterState) => FilterState)) {
+  function updateFilters(
+    updater: FilterState | ((prev: FilterState) => FilterState)
+  ) {
     setFilters((prev) => {
       const next = typeof updater === "function" ? updater(prev) : updater;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
       debounceRef.current = setTimeout(() => {
         const qs = serializeFilters(next).toString();
         router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
@@ -112,7 +119,9 @@ export default function LensListClient({ lenses }: Props) {
           <div>
             <div className="flex flex-wrap items-center gap-3">
               <div className="flex items-center gap-3 text-sm text-zinc-500 dark:text-zinc-400">
-                <p className="whitespace-nowrap">{t("resultsCount", { count: displayed.length })}</p>
+                <p className="whitespace-nowrap">
+                  {t("resultsCount", { count: displayed.length })}
+                </p>
                 {hasActiveFilters ? (
                   <button
                     type="button"

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -51,15 +51,16 @@ export default function LensSearchDialog({
   const tBrand = useTranslations("Brands");
   const router = useRouter();
   const mount = useEffectiveMount();
-  const lensSearchIndex = useMemo(() => buildLensSearchIndex(getLensesByMount(mount)), [mount]);
+  const lensSearchIndex = useMemo(
+    () => buildLensSearchIndex(getLensesByMount(mount)),
+    [mount]
+  );
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputId = useId();
-  const titleId = useId();
-  const descriptionId = useId();
   const resultsId = useId();
   const deferredQuery = useDeferredValue(query);
 
@@ -74,18 +75,20 @@ export default function LensSearchDialog({
     }
   }, [open]);
 
-  // Reset state on close
-  useEffect(() => {
-    if (!open) {
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
       setQuery("");
       setActiveIndex(0);
     }
-  }, [open]);
+  }
 
   // Scroll active result into view when navigating with keyboard
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container) return;
+    if (!container) {
+      return;
+    }
     const activeItem = container.querySelector('[aria-selected="true"]');
     if (activeItem) {
       (activeItem as HTMLElement).scrollIntoView({ block: "nearest" });
@@ -94,11 +97,11 @@ export default function LensSearchDialog({
 
   const results = useMemo(
     () => searchLensIndex(lensSearchIndex, deferredQuery),
-    [deferredQuery]
+    [lensSearchIndex, deferredQuery]
   );
 
   function handleSelect(lens: Lens) {
-    setOpen(false);
+    handleOpenChange(false);
 
     if (onSelectLens) {
       onSelectLens(lens);
@@ -111,15 +114,21 @@ export default function LensSearchDialog({
   function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      if (results.length === 0) return;
+      if (results.length === 0) {
+        return;
+      }
       setActiveIndex((current) => (current + 1) % results.length);
       return;
     }
 
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      if (results.length === 0) return;
-      setActiveIndex((current) => (current - 1 + results.length) % results.length);
+      if (results.length === 0) {
+        return;
+      }
+      setActiveIndex(
+        (current) => (current - 1 + results.length) % results.length
+      );
       return;
     }
 
@@ -145,9 +154,7 @@ export default function LensSearchDialog({
           triggerClassName
         )}
       >
-        {triggerVariant === "icon" && (
-          <Search className="h-4 w-4" />
-        )}
+        {triggerVariant === "icon" && <Search className="h-4 w-4" />}
         {triggerVariant === "button" && (
           <>
             <Search className="h-4 w-4" />
@@ -164,7 +171,7 @@ export default function LensSearchDialog({
         )}
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent
           className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
           showCloseButton
@@ -285,7 +292,9 @@ export default function LensSearchDialog({
                         <p className="truncate text-xs uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
                           {tBrand(lens.brand)}
                           {lens.series ? ` · ${lens.series}` : ""}
-                          {lens.generation ? ` · ${t("generation", { value: lens.generation })}` : ""}
+                          {lens.generation
+                            ? ` · ${t("generation", { value: lens.generation })}`
+                            : ""}
                         </p>
                         <p className="mt-0.5 truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
                           {lens.model}

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -9,7 +9,6 @@ import { useMountPreference } from "@/context/MountPreferenceProvider";
 import { mountToUrlSegment } from "@/lib/mount";
 import type { Mount } from "@/lib/types";
 
-
 export default function MountSwitcher() {
   const t = useTranslations("MountSwitcher");
   const router = useRouter();
@@ -22,12 +21,16 @@ export default function MountSwitcher() {
   // Sync URL mount → preference so navigating to /lenses/gfx
   // keeps the badge on GFX after navigating away.
   useEffect(() => {
-    if (urlMount) setPreference(urlMount);
+    if (urlMount) {
+      setPreference(urlMount);
+    }
   }, [urlMount, setPreference]);
 
   // Close on outside click
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     function onPointerDown(e: PointerEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -28,7 +28,9 @@ export default function Nav() {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isPwa) return;
+    if (isPwa) {
+      return;
+    }
     const onScroll = () => {
       const y = window.scrollY;
       const threshold = headerRef.current?.offsetHeight ?? 56;
@@ -45,6 +47,8 @@ export default function Nav() {
 
   // Close mobile menu + reset scroll on navigation
   useEffect(() => {
+    // Navigation resets are intentionally synchronized with pathname changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHidden(false);
     setMobileMenuOpen(false);
     lastScrollY.current = 0;
@@ -52,12 +56,18 @@ export default function Nav() {
   }, [pathname, setHidden, lockNav]);
 
   useEffect(() => {
-    if (!navLocked) setHidden(false);
+    // Unlocking nav should immediately reveal the header.
+    if (!navLocked) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setHidden(false);
+    }
   }, [navLocked]);
 
   // Close mobile menu on outside click
   useEffect(() => {
-    if (!mobileMenuOpen) return;
+    if (!mobileMenuOpen) {
+      return;
+    }
     function onPointerDown(e: PointerEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setMobileMenuOpen(false);
@@ -70,9 +80,10 @@ export default function Nav() {
   const compareIds = compareState[effectiveMount];
   const seg = mountToUrlSegment(effectiveMount);
   const browseHref = `/lenses/${seg}`;
-  const compareHref = compareIds.length > 0
-    ? `/lenses/${seg}/compare?ids=${compareIds.join(",")}`
-    : `/lenses/${seg}/compare`;
+  const compareHref =
+    compareIds.length > 0
+      ? `/lenses/${seg}/compare?ids=${compareIds.join(",")}`
+      : `/lenses/${seg}/compare`;
 
   const linkCls = (active: boolean) =>
     `text-xs sm:text-sm transition-colors px-1.5 sm:px-2 ${
@@ -88,7 +99,8 @@ export default function Nav() {
         : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-50 dark:hover:bg-zinc-900"
     }`;
 
-  const isBrowseActive = pathname.startsWith("/lenses") && !pathname.includes("/compare");
+  const isBrowseActive =
+    pathname.startsWith("/lenses") && !pathname.includes("/compare");
   const isCompareActive = pathname.includes("/compare");
   const showMountSwitcher = pathname === "/" || pathname.startsWith("/lenses");
 
@@ -102,7 +114,9 @@ export default function Nav() {
         "transition-transform duration-300 ease-in-out",
         !isPwa && (hidden || navLocked) && "-translate-y-full sm:translate-y-0"
       )}
-      style={{ paddingTop: "calc(var(--safe-inset-top) + var(--titlebar-height))" }}
+      style={{
+        paddingTop: "calc(var(--safe-inset-top) + var(--titlebar-height))",
+      }}
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         {/* Left: brand / mount-scope path (GitHub namespace pattern) */}
@@ -117,7 +131,12 @@ export default function Nav() {
           </Link>
           {showMountSwitcher && (
             <>
-              <span className="text-zinc-400 dark:text-zinc-600 select-none font-light text-base sm:text-lg px-0" aria-hidden="true">/</span>
+              <span
+                className="text-zinc-400 dark:text-zinc-600 select-none font-light text-base sm:text-lg px-0"
+                aria-hidden="true"
+              >
+                /
+              </span>
               <MountSwitcher />
             </>
           )}
@@ -135,10 +154,7 @@ export default function Nav() {
             {t("about")}
           </Link>
           {!isPwa && (
-            <Link
-              href="/get"
-              className={linkCls(pathname === "/get")}
-            >
+            <Link href="/get" className={linkCls(pathname === "/get")}>
               <span className="text-sm">{t("getApp")}</span>
             </Link>
           )}
@@ -149,7 +165,13 @@ export default function Nav() {
             className="text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors px-1"
             aria-label="GitHub"
           >
-            <svg viewBox="0 0 24 24" width="17" height="17" fill="currentColor" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="17"
+              height="17"
+              fill="currentColor"
+              aria-hidden="true"
+            >
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
             </svg>
           </a>
@@ -170,7 +192,13 @@ export default function Nav() {
             className="text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors px-1.5"
             aria-label="GitHub"
           >
-            <svg viewBox="0 0 24 24" width="17" height="17" fill="currentColor" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="17"
+              height="17"
+              fill="currentColor"
+              aria-hidden="true"
+            >
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
             </svg>
           </a>
@@ -186,11 +214,17 @@ export default function Nav() {
 
             {mobileMenuOpen && (
               <div className="absolute right-0 top-full mt-1.5 w-48 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 py-1 overflow-hidden">
-                <Link href="/about" className={mobileLinkCls(pathname === "/about")}>
+                <Link
+                  href="/about"
+                  className={mobileLinkCls(pathname === "/about")}
+                >
                   {t("about")}
                 </Link>
                 {!isPwa && (
-                  <Link href="/get" className={mobileLinkCls(pathname === "/get")}>
+                  <Link
+                    href="/get"
+                    className={mobileLinkCls(pathname === "/get")}
+                  >
                     {t("getApp")}
                   </Link>
                 )}

--- a/src/components/PriceBand.tsx
+++ b/src/components/PriceBand.tsx
@@ -17,18 +17,20 @@ import { cn } from "@/lib/utils";
 function PriceInfoPopover({
   selection,
   locale,
-  tier,
 }: {
   selection: PriceSelection;
   locale: string;
-  tier: 1 | 2 | 3 | 4 | 5;
 }) {
   const t = useTranslations("Pricing");
   const { entry, condition } = selection;
   const isUsed = condition === "used";
-  const symbol = t("tierSymbol");
-  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
-  const rangeDisplay = formatTierRange(tier, entry.currency, locale);
+  const priceDisplay = formatPrice(
+    entry.price,
+    entry.currency,
+    locale,
+    condition,
+    t
+  );
   const sourceDisplay = entry.source;
   const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
@@ -116,7 +118,7 @@ export function PriceBand({ lens, compact = false }: Props) {
             {t("usedBadge")}
           </span>
         )}
-        <PriceInfoPopover selection={selection} locale={locale} tier={tier} />
+        <PriceInfoPopover selection={selection} locale={locale} />
       </div>
       {/* Range subtext — matches the subValue pattern used elsewhere in CompareTable */}
       <p className="tabular-nums text-[11px] text-zinc-400 dark:text-zinc-500">

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -34,15 +34,25 @@ export function PriceSection({ lens }: Props) {
   const [noteOpen, setNoteOpen] = useState(false);
 
   const selection = pickPriceEntry(lens.pricing, locale);
-  if (!selection) return null;
+  if (!selection) {
+    return null;
+  }
 
   const { entry, condition } = selection;
   const tier = priceTier(entry.price, entry.currency);
-  if (tier === undefined) return null;
+  if (tier === undefined) {
+    return null;
+  }
 
   const isUsed = condition === "used";
 
-  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
+  const priceDisplay = formatPrice(
+    entry.price,
+    entry.currency,
+    locale,
+    condition,
+    t
+  );
   const sourceDisplay = entry.source;
   const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
@@ -73,10 +83,11 @@ export function PriceSection({ lens }: Props) {
         >
           <AlertTriangle className="size-3 shrink-0 text-amber-500" />
           <span>{t("disclaimerTrigger")}</span>
-          {noteOpen
-            ? <ChevronUp className="size-3 shrink-0" />
-            : <ChevronDown className="size-3 shrink-0" />
-          }
+          {noteOpen ? (
+            <ChevronUp className="size-3 shrink-0" />
+          ) : (
+            <ChevronDown className="size-3 shrink-0" />
+          )}
         </button>
         {noteOpen && (
           <p className="mt-1.5 text-[11px] leading-relaxed text-zinc-400 dark:text-zinc-500">

--- a/src/components/RegisterSW.tsx
+++ b/src/components/RegisterSW.tsx
@@ -6,7 +6,9 @@ import { useEffect } from "react";
 // Mounted in the root layout so it runs on every page.
 export default function RegisterSW() {
   useEffect(() => {
-    if (!("serviceWorker" in navigator)) return;
+    if (!("serviceWorker" in navigator)) {
+      return;
+    }
 
     if (process.env.NODE_ENV === "development") {
       // In dev, unregister any SW (e.g. left over from a prod build) so that

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -6,7 +6,17 @@ import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
 import { Tabs } from "@base-ui/react/tabs";
 import { useTranslations, useLocale } from "next-intl";
-import { Share2, Copy, Check, Download, Loader2, Expand, SlidersHorizontal, ChevronDown, X } from "lucide-react";
+import {
+  Share2,
+  Copy,
+  Check,
+  Download,
+  Loader2,
+  Expand,
+  SlidersHorizontal,
+  ChevronDown,
+  X,
+} from "lucide-react";
 import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { Z } from "@/config/ui";
@@ -16,15 +26,18 @@ import { rasterizePoster } from "@/lib/share-image";
 // ── Poster title / slogan auto-generation ────────────────────────────────────
 
 /** One title line per lens: "{Brand} {model}" */
-function computePosterTitle(lenses: Lens[], tBrand: (key: string) => string): string[] {
+function computePosterTitle(
+  lenses: Lens[],
+  tBrand: (key: string) => string
+): string[] {
   return lenses.map((l) => `${tBrand(l.brand)} ${l.model}`);
 }
 
-import { SharePoster, type PosterLabels } from "@/components/poster/SharePoster";
 import {
-  Dialog,
-  DialogContent,
-} from "@/components/ui/dialog";
+  SharePoster,
+  type PosterLabels,
+} from "@/components/poster/SharePoster";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 // Scale the 750px poster down to fit the panel content area
 const POSTER_W = 750;
@@ -41,7 +54,12 @@ interface ShareButtonProps {
   presetTitle?: string;
 }
 
-export function ShareButton({ lenses, variant = "default", triggerClassName, presetTitle }: ShareButtonProps) {
+export function ShareButton({
+  lenses,
+  variant = "default",
+  triggerClassName,
+  presetTitle,
+}: ShareButtonProps) {
   const t = useTranslations("Share");
   const locale = useLocale();
   const tImage = useTranslations("ShareImage");
@@ -85,7 +103,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     if ("canShare" in navigator) {
       const testFile = new File(["x"], "test.png", { type: "image/png" });
       setCanShareFile(
-        (navigator as Navigator & { canShare: (d: object) => boolean }).canShare({
+        (
+          navigator as Navigator & { canShare: (d: object) => boolean }
+        ).canShare({
           files: [testFile],
         })
       );
@@ -111,7 +131,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
 
   // Keep shareUrl in sync when panel opens
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     setShareUrl(window.location.href);
     slugRef.current = lenses
       .map((l) => l.model.replace(/\s+/g, "-").toLowerCase())
@@ -187,7 +209,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   }, [lenses]);
 
   const handleDownload = useCallback(async () => {
-    if (!posterRef.current) return;
+    if (!posterRef.current) {
+      return;
+    }
     setPosterGenerating(true);
     try {
       const url = await rasterizePoster(posterRef.current);
@@ -203,7 +227,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   }, []);
 
   const handleShareImage = useCallback(async () => {
-    if (!posterRef.current) return;
+    if (!posterRef.current) {
+      return;
+    }
     setPosterGenerating(true);
     let url: string | undefined;
     try {
@@ -218,7 +244,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
       });
     } catch (err) {
       // User cancelled — no fallback needed
-      if (err instanceof Error && err.name === "AbortError") return;
+      if (err instanceof Error && err.name === "AbortError") {
+        return;
+      }
       // Share API unsupported or failed — fall back to download
       if (url) {
         const link = document.createElement("a");
@@ -233,7 +261,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
 
   const handleOpenLightbox = useCallback(async () => {
     setLightboxOpen(true);
-    if (!posterRef.current) return;
+    if (!posterRef.current) {
+      return;
+    }
     setLightboxImageLoading(true);
     try {
       const url = await rasterizePoster(posterRef.current);
@@ -248,7 +278,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   const truncatedUrl =
     shareUrl.length > 56 ? shareUrl.slice(0, 56) + "…" : shareUrl;
 
-  const lensCaption = lenses.map((l) => `${tBrand(l.brand)} · ${l.model}`).join(" / ");
+  const lensCaption = lenses
+    .map((l) => `${tBrand(l.brand)} · ${l.model}`)
+    .join(" / ");
 
   const triggerLabel = (
     <>
@@ -386,7 +418,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
               backdropClassName="bg-zinc-950/75 transition-[background-color] duration-150"
               showCloseButton={false}
               onClick={(e) => {
-                if (e.target === e.currentTarget) setLightboxOpen(false);
+                if (e.target === e.currentTarget) {
+                  setLightboxOpen(false);
+                }
               }}
             >
               {/* Wrapper: anchor for the mobile close button only; NOT the resize-observed element */}
@@ -411,22 +445,33 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
                   <div
                     ref={lightboxScrollRef}
                     className="max-h-[calc(100svh-3rem-10px)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100svh-3rem)]"
-                    onScroll={() => { if (!hasScrolled) setHasScrolled(true); }}
+                    onScroll={() => {
+                      if (!hasScrolled) {
+                        setHasScrolled(true);
+                      }
+                    }}
                   >
                     {lightboxImageLoading ? (
                       <div className="flex h-48 items-center justify-center">
                         <Loader2 className="size-6 animate-spin text-zinc-400" />
                       </div>
                     ) : lightboxImageUrl ? (
-                      <img
-                        src={lightboxImageUrl}
-                        alt=""
-                        className="w-full"
-                        onLoad={() => {
-                          const el = lightboxScrollRef.current;
-                          if (el) setIsScrollable(el.scrollHeight > el.clientHeight + 1);
-                        }}
-                      />
+                      <>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={lightboxImageUrl}
+                          alt=""
+                          className="w-full"
+                          onLoad={() => {
+                            const el = lightboxScrollRef.current;
+                            if (el) {
+                              setIsScrollable(
+                                el.scrollHeight > el.clientHeight + 1
+                              );
+                            }
+                          }}
+                        />
+                      </>
                     ) : null}
                   </div>
 
@@ -444,83 +489,96 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
 
           {/* Action row — Customize Popover on the left, share actions on the right */}
           <div className="flex gap-2">
-              {/* Customize — Popover anchored to this trigger button */}
-              <Popover.Root open={customOpen} onOpenChange={setCustomOpen}>
-                <Popover.Trigger
-                  title={t("customize")}
-                  className={cn(
-                    "flex items-center justify-center rounded-lg border px-3 py-2.5 outline-none transition-colors",
-                    customOpen
-                      ? "border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
-                      : "border-zinc-200 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
-                  )}
+            {/* Customize — Popover anchored to this trigger button */}
+            <Popover.Root open={customOpen} onOpenChange={setCustomOpen}>
+              <Popover.Trigger
+                title={t("customize")}
+                className={cn(
+                  "flex items-center justify-center rounded-lg border px-3 py-2.5 outline-none transition-colors",
+                  customOpen
+                    ? "border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-50 dark:bg-zinc-50 dark:text-zinc-900"
+                    : "border-zinc-200 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                )}
+              >
+                <SlidersHorizontal className="size-4" />
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Positioner
+                  side="top"
+                  align="start"
+                  sideOffset={8}
+                  className={Z.overlay}
                 >
-                  <SlidersHorizontal className="size-4" />
-                </Popover.Trigger>
-                <Popover.Portal>
-                  <Popover.Positioner side="top" align="start" sideOffset={8} className={Z.overlay}>
-                    <Popover.Popup className="w-72 origin-(--transform-origin) rounded-xl border border-zinc-200 bg-white p-3 shadow-lg duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
-                      <div className="flex flex-col gap-3">
-                        <div className="flex flex-col gap-1">
-                          <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                            {t("customizeTitle")}
-                          </label>
-                          <input
-                            type="text"
-                            value={customTitle}
-                            onChange={(e) => setCustomTitle(e.target.value)}
-                            placeholder={computedPosterTitle.join(" · ")}
-                            className={inputClass}
-                          />
-                        </div>
-                        <div className="flex flex-col gap-1">
-                          <label className="text-xs text-zinc-400 dark:text-zinc-500">
-                            {t("customizeSlogan")}
-                          </label>
-                          <input
-                            type="text"
-                            value={customSlogan}
-                            onChange={(e) => setCustomSlogan(e.target.value)}
-                            placeholder={t("customizeSloganPlaceholder")}
-                            className={inputClass}
-                          />
-                        </div>
+                  <Popover.Popup className="w-72 origin-(--transform-origin) rounded-xl border border-zinc-200 bg-white p-3 shadow-lg duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
+                    <div className="flex flex-col gap-3">
+                      <div className="flex flex-col gap-1">
+                        <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                          {t("customizeTitle")}
+                        </label>
+                        <input
+                          type="text"
+                          value={customTitle}
+                          onChange={(e) => setCustomTitle(e.target.value)}
+                          placeholder={computedPosterTitle.join(" · ")}
+                          className={inputClass}
+                        />
                       </div>
-                    </Popover.Popup>
-                  </Popover.Positioner>
-                </Popover.Portal>
-              </Popover.Root>
+                      <div className="flex flex-col gap-1">
+                        <label className="text-xs text-zinc-400 dark:text-zinc-500">
+                          {t("customizeSlogan")}
+                        </label>
+                        <input
+                          type="text"
+                          value={customSlogan}
+                          onChange={(e) => setCustomSlogan(e.target.value)}
+                          placeholder={t("customizeSloganPlaceholder")}
+                          className={inputClass}
+                        />
+                      </div>
+                    </div>
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
 
-              {/* Share + Download */}
-              {canShareFile ? (
-                <>
-                  <button
-                    onClick={handleShareImage}
-                    disabled={posterGenerating}
-                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-                  >
-                    {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Share2 className="size-4" />}
-                    {t("posterShare")}
-                  </button>
-                  <button
-                    onClick={handleDownload}
-                    disabled={posterGenerating}
-                    title={t("posterDownload")}
-                    className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  >
-                    <Download className="size-4" />
-                  </button>
-                </>
-              ) : (
+            {/* Share + Download */}
+            {canShareFile ? (
+              <>
                 <button
-                  onClick={handleDownload}
+                  onClick={handleShareImage}
                   disabled={posterGenerating}
                   className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
                 >
-                  {posterGenerating ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-                  {t("posterDownload")}
+                  {posterGenerating ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Share2 className="size-4" />
+                  )}
+                  {t("posterShare")}
                 </button>
-              )}
+                <button
+                  onClick={handleDownload}
+                  disabled={posterGenerating}
+                  title={t("posterDownload")}
+                  className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                >
+                  <Download className="size-4" />
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={handleDownload}
+                disabled={posterGenerating}
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-50 transition-colors hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {posterGenerating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Download className="size-4" />
+                )}
+                {t("posterDownload")}
+              </button>
+            )}
           </div>
         </Tabs.Panel>
       </Tabs.Root>
@@ -536,11 +594,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   const fabTriggerClass =
     "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-900 text-white shadow-lg outline-none transition-colors hover:bg-zinc-700 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200";
 
-  const triggerContent = isFab ? (
-    <Share2 className="size-5" />
-  ) : (
-    triggerLabel
-  );
+  const triggerContent = isFab ? <Share2 className="size-5" /> : triggerLabel;
 
   // Before mount: static placeholder — must use the same class as the
   // mounted trigger so there is no visual jump after hydration.
@@ -548,17 +602,27 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     <button
       disabled
       aria-hidden
-      className={isFab ? fabTriggerClass + " cursor-default opacity-0" : defaultTriggerClass}
+      className={
+        isFab
+          ? fabTriggerClass + " cursor-default opacity-0"
+          : defaultTriggerClass
+      }
     >
       {triggerContent}
     </button>
   ) : isDesktop ? (
     <Popover.Root open={open} onOpenChange={(nextOpen) => setOpen(nextOpen)}>
-      <Popover.Trigger className={isFab ? fabTriggerClass : defaultTriggerClass}>
+      <Popover.Trigger
+        className={isFab ? fabTriggerClass : defaultTriggerClass}
+      >
         {triggerContent}
       </Popover.Trigger>
       <Popover.Portal>
-        <Popover.Positioner side={isFab ? "top" : "bottom"} align="end" sideOffset={8}>
+        <Popover.Positioner
+          side={isFab ? "top" : "bottom"}
+          align="end"
+          sideOffset={8}
+        >
           <Popover.Popup className="w-96 max-h-[calc(100svh-80px)] overflow-y-auto origin-(--transform-origin) rounded-xl bg-white shadow-lg ring-1 ring-zinc-200 duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-zinc-900 dark:ring-zinc-800">
             {panelContent}
           </Popover.Popup>
@@ -577,18 +641,20 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
       <Drawer.Portal>
         {/* When the lightbox is open its own backdrop (z-60) covers everything;
             suppress the Drawer backdrop to avoid double-darkening the top half. */}
-        <Drawer.Backdrop className={cn(
-          `fixed inset-0 ${Z.overlay} transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
-          lightboxOpen ? "bg-transparent" : "bg-black/40"
-        )} />
-        <Drawer.Popup className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[var(--safe-inset-bottom)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}>
+        <Drawer.Backdrop
+          className={cn(
+            `fixed inset-0 ${Z.overlay} transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+            lightboxOpen ? "bg-transparent" : "bg-black/40"
+          )}
+        />
+        <Drawer.Popup
+          className={`fixed inset-x-0 bottom-0 ${Z.overlay} max-h-[85svh] flex flex-col rounded-t-2xl bg-white pb-[var(--safe-inset-bottom)] ring-1 ring-zinc-200 duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:bg-zinc-900 dark:ring-zinc-800`}
+        >
           {/* Handle sits outside the scroll container so swipe-down reaches the drawer */}
           <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
             <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
           </div>
-          <div className="overflow-y-auto pb-8">
-            {panelContent}
-          </div>
+          <div className="overflow-y-auto pb-8">{panelContent}</div>
         </Drawer.Popup>
       </Drawer.Portal>
     </Drawer.Root>
@@ -600,7 +666,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   const copiedToast =
     mounted && copied && !isDesktop
       ? createPortal(
-          <div className={`pointer-events-none fixed top-4 left-1/2 ${Z.overlay} flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-green-600 px-4 py-2 text-sm font-medium text-white shadow-lg animate-in fade-in slide-in-from-top-2 duration-150`}>
+          <div
+            className={`pointer-events-none fixed top-4 left-1/2 ${Z.overlay} flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-green-600 px-4 py-2 text-sm font-medium text-white shadow-lg animate-in fade-in slide-in-from-top-2 duration-150`}
+          >
             <Check className="size-4" />
             {t("copied")}
           </div>,

--- a/src/components/Tagline.tsx
+++ b/src/components/Tagline.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 
 export default function Tagline() {
   const t = useTranslations("Footer");
-  const [tagline, setTagline] = useState<string | null>(null);
-
-  useEffect(() => {
-    const taglines = [t("tagline1"), t("tagline2"), t("tagline3"), t("tagline4")];
-    setTagline(taglines[Math.floor(Math.random() * taglines.length)]);
-  }, [t]);
-
-  if (!tagline) return null;
+  const [tagline] = useState(() => {
+    const taglines = [
+      t("tagline1"),
+      t("tagline2"),
+      t("tagline3"),
+      t("tagline4"),
+    ];
+    return taglines[Math.floor(Math.random() * taglines.length)];
+  });
 
   return (
     <span className="text-[11px] text-zinc-400 dark:text-zinc-600 tracking-wide select-none">

--- a/src/components/TestHookPanel.tsx
+++ b/src/components/TestHookPanel.tsx
@@ -14,13 +14,13 @@ import { TESTHOOK_OPTION_DEFINITIONS } from "@/lib/testhook";
 
 export default function TestHookPanel() {
   const context = useContext(TestHookContext);
+  const [copied, setCopied] = useState(false);
 
   if (!context || !context.state.testHook) {
     return null;
   }
 
   const { state, setOption, setTestHook, reset, buildShareableLink } = context;
-  const [copied, setCopied] = useState(false);
 
   return (
     <aside className="fixed bottom-4 right-4 z-50 w-[min(24rem,calc(100vw-2rem))] rounded-2xl border border-zinc-200/80 bg-white/95 p-4 shadow-xl backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/90">

--- a/src/components/poster/PosterWeightBar.tsx
+++ b/src/components/poster/PosterWeightBar.tsx
@@ -15,7 +15,9 @@ export function PosterWeightBar({
   maxWeightG,
   lensIndex,
 }: PosterWeightBarProps) {
-  if (!weightG || maxWeightG <= 0) return null;
+  if (!weightG || maxWeightG <= 0) {
+    return null;
+  }
 
   const primary = Array.isArray(weightG) ? weightG[0] : weightG;
   const fraction = Math.min(1, primary / maxWeightG);

--- a/src/context/TestHookProvider.tsx
+++ b/src/context/TestHookProvider.tsx
@@ -39,7 +39,9 @@ export function TestHookProvider({ children }: { children: ReactNode }) {
 
   // Strip testhook params from URL after cold-start init
   useEffect(() => {
-    if (!state.testHook) return;
+    if (!state.testHook) {
+      return;
+    }
     const clean = new URLSearchParams(searchParams.toString());
     clean.delete(TESTHOOK_QUERY_KEYS.testHook);
     for (const option of TESTHOOK_OPTION_DEFINITIONS) {
@@ -47,11 +49,13 @@ export function TestHookProvider({ children }: { children: ReactNode }) {
     }
     const query = clean.toString();
     router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
-  }, []);
+  }, [pathname, router, searchParams, state.testHook]);
 
   // Sync state → CSS injection
   useEffect(() => {
-    let styleElement = document.getElementById("testhook-css") as HTMLStyleElement | null;
+    let styleElement = document.getElementById(
+      "testhook-css"
+    ) as HTMLStyleElement | null;
     if (!styleElement) {
       styleElement = document.createElement("style");
       styleElement.id = "testhook-css";

--- a/src/hooks/useCompareUrl.ts
+++ b/src/hooks/useCompareUrl.ts
@@ -31,13 +31,21 @@ export function useCompareUrl() {
 
   function buildQuery(ids: string[], extra?: { preset?: string }): string {
     const parts: string[] = [];
-    if (ids.length > 0) parts.push(`ids=${ids.join(",")}`);
-    if (extra?.preset) parts.push(`preset=${encodeURIComponent(extra.preset)}`);
+    if (ids.length > 0) {
+      parts.push(`ids=${ids.join(",")}`);
+    }
+    if (extra?.preset) {
+      parts.push(`preset=${encodeURIComponent(extra.preset)}`);
+    }
 
     const from = searchParams.get("from");
     const lensId = searchParams.get("lensId");
-    if (from) parts.push(`from=${encodeURIComponent(from)}`);
-    if (lensId) parts.push(`lensId=${encodeURIComponent(lensId)}`);
+    if (from) {
+      parts.push(`from=${encodeURIComponent(from)}`);
+    }
+    if (lensId) {
+      parts.push(`lensId=${encodeURIComponent(lensId)}`);
+    }
 
     return parts.join("&");
   }
@@ -48,7 +56,10 @@ export function useCompareUrl() {
     return qs ? `/lenses/${seg}/compare?${qs}` : `/lenses/${seg}/compare`;
   }
 
-  function buildLocalizedCompareUrl(ids: string[], extra?: { preset?: string }) {
+  function buildLocalizedCompareUrl(
+    ids: string[],
+    extra?: { preset?: string }
+  ) {
     const seg = mountToUrlSegment(mount);
     const qs = buildQuery(ids, extra);
     const path = `/${locale}/lenses/${seg}/compare`;

--- a/src/lib/filter-params.ts
+++ b/src/lib/filter-params.ts
@@ -24,19 +24,39 @@ const SORT_KEYS: SortKey[] = ["focalLength", "maxAperture", "weightG"];
 // feat=features, fc=focalCategories, sort=sortKey, dir=sortDir
 export function serializeFilters(filters: FilterState): URLSearchParams {
   const p = new URLSearchParams();
-  if (filters.brands.length > 0) p.set("b", filters.brands.join(","));
-  if (filters.typeFilter) p.set("t", filters.typeFilter);
-  if (filters.focusFilter) p.set("f", filters.focusFilter);
-  if (filters.specialtyTag) p.set("st", filters.specialtyTag);
-  if (filters.focusMotorClass) p.set("m", filters.focusMotorClass);
-  if (filters.features.length > 0) p.set("feat", filters.features.join(","));
-  if (filters.focalCategories.length > 0) p.set("fc", filters.focalCategories.join(","));
-  if (filters.sort !== defaultFilters.sort) p.set("sort", filters.sort);
-  if (filters.sortDir !== defaultFilters.sortDir) p.set("dir", filters.sortDir);
+  if (filters.brands.length > 0) {
+    p.set("b", filters.brands.join(","));
+  }
+  if (filters.typeFilter) {
+    p.set("t", filters.typeFilter);
+  }
+  if (filters.focusFilter) {
+    p.set("f", filters.focusFilter);
+  }
+  if (filters.specialtyTag) {
+    p.set("st", filters.specialtyTag);
+  }
+  if (filters.focusMotorClass) {
+    p.set("m", filters.focusMotorClass);
+  }
+  if (filters.features.length > 0) {
+    p.set("feat", filters.features.join(","));
+  }
+  if (filters.focalCategories.length > 0) {
+    p.set("fc", filters.focalCategories.join(","));
+  }
+  if (filters.sort !== defaultFilters.sort) {
+    p.set("sort", filters.sort);
+  }
+  if (filters.sortDir !== defaultFilters.sortDir) {
+    p.set("dir", filters.sortDir);
+  }
   return p;
 }
 
-export function parseFilters(params: URLSearchParams | { get: (key: string) => string | null }): FilterState {
+export function parseFilters(
+  params: URLSearchParams | { get: (key: string) => string | null }
+): FilterState {
   const raw = {
     b: params.get("b"),
     t: params.get("t"),
@@ -51,17 +71,40 @@ export function parseFilters(params: URLSearchParams | { get: (key: string) => s
 
   return {
     brands: raw.b ? raw.b.split(",").filter(Boolean) : [],
-    typeFilter: raw.t && LENS_TYPES.includes(raw.t as LensType) ? (raw.t as LensType) : null,
-    focusFilter: raw.f && FOCUS_FILTERS.includes(raw.f as FocusFilter) ? (raw.f as FocusFilter) : null,
-    specialtyTag: raw.st && (SPECIALTY_TAGS as readonly string[]).includes(raw.st) ? (raw.st as SpecialtyTag) : null,
-    focusMotorClass: raw.m && MOTOR_CLASSES.includes(raw.m as FocusMotorClass) ? (raw.m as FocusMotorClass) : null,
+    typeFilter:
+      raw.t && LENS_TYPES.includes(raw.t as LensType)
+        ? (raw.t as LensType)
+        : null,
+    focusFilter:
+      raw.f && FOCUS_FILTERS.includes(raw.f as FocusFilter)
+        ? (raw.f as FocusFilter)
+        : null,
+    specialtyTag:
+      raw.st && (SPECIALTY_TAGS as readonly string[]).includes(raw.st)
+        ? (raw.st as SpecialtyTag)
+        : null,
+    focusMotorClass:
+      raw.m && MOTOR_CLASSES.includes(raw.m as FocusMotorClass)
+        ? (raw.m as FocusMotorClass)
+        : null,
     features: raw.feat
-      ? (raw.feat.split(",").filter((k) => (FILTER_FEATURE_KEYS as readonly string[]).includes(k)) as FilterFeatureKey[])
+      ? (raw.feat
+          .split(",")
+          .filter((k) =>
+            (FILTER_FEATURE_KEYS as readonly string[]).includes(k)
+          ) as FilterFeatureKey[])
       : [],
     focalCategories: raw.fc
-      ? (raw.fc.split(",").filter((k) => (FOCAL_KEYS as readonly string[]).includes(k)) as FocalCategory[])
+      ? (raw.fc
+          .split(",")
+          .filter((k) =>
+            (FOCAL_KEYS as readonly string[]).includes(k)
+          ) as FocalCategory[])
       : [],
-    sort: raw.sort && SORT_KEYS.includes(raw.sort as SortKey) ? (raw.sort as SortKey) : defaultFilters.sort,
+    sort:
+      raw.sort && SORT_KEYS.includes(raw.sort as SortKey)
+        ? (raw.sort as SortKey)
+        : defaultFilters.sort,
     sortDir: raw.dir === "desc" ? "desc" : "asc",
   };
 }

--- a/src/lib/iris-kinematics.ts
+++ b/src/lib/iris-kinematics.ts
@@ -92,7 +92,9 @@ function solveGuidePinRadius(
   const { pivotRadius: Rp, pinDistance: d, slotOffset: delta } = config;
   const angle = delta + theta; // β - φ_i  (same for all blades)
   const discriminant = d * d - Rp * Rp * Math.sin(angle) * Math.sin(angle);
-  if (discriminant < 0) return null;
+  if (discriminant < 0) {
+    return null;
+  }
   return Rp * Math.cos(angle) + Math.sqrt(discriminant);
 }
 
@@ -106,7 +108,9 @@ export function solveAllBlades(
 ): BladeState[] {
   const { N, pivotRadius: Rp, slotOffset: delta } = config;
   const r = solveGuidePinRadius(theta, config);
-  if (r === null || r <= 0) return [];
+  if (r === null || r <= 0) {
+    return [];
+  }
 
   const step = (2 * Math.PI) / N;
   const slotDir = delta + theta; // β_0 = φ_0 + δ + θ = 0 + δ + θ (blade 0)
@@ -229,21 +233,25 @@ export function bladeShapePath(config: IrisMechanismConfig): string {
     ].join(" ");
   }
 
-  const cx = L / 2;                                        // half-chord = arc center x
-  const s  = C * hw * 1.2;                                 // sagitta
-  const R  = (cx * cx + s * s) / (2 * s);                 // arc radius
-  const cy = R - s;                                        // arc center y (below chord)
-  const f  = hw / R;                                       // radial fraction
-  const Ro = R + hw;                                       // outer arc radius
-  const Ri = R - hw;                                       // inner arc radius
+  const cx = L / 2; // half-chord = arc center x
+  const s = C * hw * 1.2; // sagitta
+  const R = (cx * cx + s * s) / (2 * s); // arc radius
+  const cy = R - s; // arc center y (below chord)
+  const f = hw / R; // radial fraction
+  const Ro = R + hw; // outer arc radius
+  const Ri = R - hw; // inner arc radius
 
   // Outer arc endpoints (above chord: negative y)
-  const OTailX = -cx * f,        OTailY = -cy * f;
-  const OTipX  =  cx * (2 + f),  OTipY  = OTailY;
+  const OTailX = -cx * f,
+    OTailY = -cy * f;
+  const OTipX = cx * (2 + f),
+    OTipY = OTailY;
 
   // Inner arc endpoints (below chord: positive y)
-  const ITailX =  cx * f,        ITailY =  cy * f;
-  const ITipX  =  cx * (2 - f),  ITipY  = ITailY;
+  const ITailX = cx * f,
+    ITailY = cy * f;
+  const ITipX = cx * (2 - f),
+    ITipY = ITailY;
 
   return [
     `M ${fmt(OTailX)} ${fmt(OTailY)}`,
@@ -312,7 +320,9 @@ export function computeBladeCurvature(
   const cx = L / 2;
   const Rt = housingRadius - hw;
   const disc = Rt * Rt - cx * cx;
-  if (disc < 0) return 0;
+  if (disc < 0) {
+    return 0;
+  }
   return (Rt - Math.sqrt(disc)) / (hw * 1.2);
 }
 
@@ -341,9 +351,12 @@ export function computeThetaOpen(
 
   function apexRadius(theta: number): number {
     const blades = solveAllBlades(theta, config);
-    if (!blades.length) return 0;
+    if (!blades.length) {
+      return 0;
+    }
     const b = blades[0];
-    const ca = Math.cos(b.bladeAngle), sa = Math.sin(b.bladeAngle);
+    const ca = Math.cos(b.bladeAngle),
+      sa = Math.sin(b.bladeAngle);
     const wx = b.pivotPos.x + ca * OMidX - sa * OMidY;
     const wy = b.pivotPos.y + sa * OMidX + ca * OMidY;
     return Math.sqrt(wx * wx + wy * wy);
@@ -353,13 +366,22 @@ export function computeThetaOpen(
   const lo = -config.slotOffset;
   const hi = kinRange.max;
 
-  if (apexRadius(lo) < housingRadius) return lo;
-  if (apexRadius(hi) >= housingRadius) return hi;
+  if (apexRadius(lo) < housingRadius) {
+    return lo;
+  }
+  if (apexRadius(hi) >= housingRadius) {
+    return hi;
+  }
 
-  let a = lo, b = hi;
+  let a = lo,
+    b = hi;
   for (let i = 0; i < 60; i++) {
     const m = (a + b) / 2;
-    if (apexRadius(m) >= housingRadius) a = m; else b = m;
+    if (apexRadius(m) >= housingRadius) {
+      a = m;
+    } else {
+      b = m;
+    }
   }
   return a;
 }
@@ -373,7 +395,10 @@ export function computeThetaOpen(
  * also has pivotRadius/bladeCurvature). The `t` and derived fields are ignored.
  */
 export function buildDerivedConfig(
-  stored: Pick<StoredIrisParams, "N" | "pinDistance" | "slotOffset" | "bladeLength" | "bladeWidth">,
+  stored: Pick<
+    StoredIrisParams,
+    "N" | "pinDistance" | "slotOffset" | "bladeLength" | "bladeWidth"
+  >,
   housingRadius: number
 ): IrisMechanismConfig {
   const bladeCurvature = computeBladeCurvature(
@@ -413,25 +438,35 @@ export function tNormToTheta(
  * intersection point to the iris centre is the aperture vertex; its distance
  * equals the inradius.
  */
-export function apertureInradius(theta: number, dc: IrisMechanismConfig): number {
+export function apertureInradius(
+  theta: number,
+  dc: IrisMechanismConfig
+): number {
   const blades = solveAllBlades(theta, dc);
-  if (blades.length < 2) return 0;
+  if (blades.length < 2) {
+    return 0;
+  }
 
   const { bladeLength: L, bladeWidth: W, bladeCurvature: C } = dc;
   const hw = W / 2;
   const cx = L / 2;
 
-  if (C < 0.005) return 0;
+  if (C < 0.005) {
+    return 0;
+  }
 
-  const s   = C * hw * 1.2;
-  const Ro  = (cx * cx + s * s) / (2 * s);
+  const s = C * hw * 1.2;
+  const Ro = (cx * cx + s * s) / (2 * s);
   const cyL = Ro - s;
-  const Ri  = Ro - hw;
+  const Ri = Ro - hw;
 
-  if (Ri <= 0) return 0;
+  if (Ri <= 0) {
+    return 0;
+  }
 
   function arcCenter(b: (typeof blades)[0]) {
-    const ca = Math.cos(b.bladeAngle), sa = Math.sin(b.bladeAngle);
+    const ca = Math.cos(b.bladeAngle),
+      sa = Math.sin(b.bladeAngle);
     return {
       x: b.pivotPos.x + cx * ca - cyL * sa,
       y: b.pivotPos.y + cx * sa + cyL * ca,
@@ -440,18 +475,22 @@ export function apertureInradius(theta: number, dc: IrisMechanismConfig): number
 
   const c0 = arcCenter(blades[0]);
   const c1 = arcCenter(blades[1]);
-  const dx  = c1.x - c0.x;
-  const dy  = c1.y - c0.y;
-  const d   = Math.sqrt(dx * dx + dy * dy);
+  const dx = c1.x - c0.x;
+  const dy = c1.y - c0.y;
+  const d = Math.sqrt(dx * dx + dy * dy);
 
-  if (d < 0.001) return Ri;
-  if (d >= 2 * Ri) return 0;
+  if (d < 0.001) {
+    return Ri;
+  }
+  if (d >= 2 * Ri) {
+    return 0;
+  }
 
   const mx = (c0.x + c1.x) / 2;
   const my = (c0.y + c1.y) / 2;
-  const h  = Math.sqrt(Math.max(0, Ri * Ri - (d / 2) * (d / 2)));
+  const h = Math.sqrt(Math.max(0, Ri * Ri - (d / 2) * (d / 2)));
   const px = (-dy / d) * h;
-  const py = ( dx / d) * h;
+  const py = (dx / d) * h;
 
   return Math.min(Math.hypot(mx + px, my + py), Math.hypot(mx - px, my - py));
 }
@@ -463,14 +502,17 @@ export function apertureInradius(theta: number, dc: IrisMechanismConfig): number
 export function findThetaForInradius(
   targetR: number,
   dc: IrisMechanismConfig,
-  range: { min: number; max: number },
+  range: { min: number; max: number }
 ): number {
   let lo = range.min;
   let hi = range.max;
   for (let i = 0; i < 48; i++) {
     const mid = (lo + hi) / 2;
-    if (apertureInradius(mid, dc) > targetR) lo = mid;
-    else hi = mid;
+    if (apertureInradius(mid, dc) > targetR) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
   }
   return (lo + hi) / 2;
 }
@@ -486,17 +528,22 @@ export function findThetaForFStop(
   targetFStop: number,
   dc: IrisMechanismConfig,
   range: { min: number; max: number },
-  openFStop = 1.4,
+  openFStop = 1.4
 ): number {
   const rOpen = apertureInradius(range.min, dc);
-  if (rOpen <= 0) return range.min;
+  if (rOpen <= 0) {
+    return range.min;
+  }
   const targetR = (openFStop * rOpen) / targetFStop;
   let lo = range.min;
   let hi = range.max;
   for (let i = 0; i < 48; i++) {
     const mid = (lo + hi) / 2;
-    if (apertureInradius(mid, dc) > targetR) lo = mid;
-    else hi = mid;
+    if (apertureInradius(mid, dc) > targetR) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
   }
   return (lo + hi) / 2;
 }

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -6,15 +6,16 @@ import type { ApertureValue, Lens } from "./types.ts";
 const positiveNumberSchema = z.number().positive();
 const nonEmptyStringSchema = z.string().trim().min(1);
 const optionalNonEmptyStringSchema = nonEmptyStringSchema.optional();
-function createApertureSchema(fieldName: "maxAperture" | "minAperture" | "maxTStop" | "minTStop") {
+function createApertureSchema(
+  fieldName: "maxAperture" | "minAperture" | "maxTStop" | "minTStop"
+) {
   return z.union([
     positiveNumberSchema,
-    z.tuple([positiveNumberSchema, positiveNumberSchema]).refine(
-      (arr) => arr[0] < arr[1],
-      {
+    z
+      .tuple([positiveNumberSchema, positiveNumberSchema])
+      .refine((arr) => arr[0] < arr[1], {
         message: `When ${fieldName} is an array, the first value (wide) must be less than the second (tele)`,
-      }
-    ),
+      }),
   ]);
 }
 
@@ -46,7 +47,10 @@ export const magnificationVariantsSchema = z.strictObject({
 });
 
 const lensBaseShape = {
-  id: z.string().min(1).regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  id: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
   brand: nonEmptyStringSchema,
   mount: z.enum(["X", "G"]),
   series: optionalNonEmptyStringSchema,
@@ -67,52 +71,76 @@ const lensBaseShape = {
   powerZoom: z.boolean().optional(),
   focusMotor: optionalNonEmptyStringSchema,
   internalFocusing: z.boolean().optional(),
-  weightG: z.union([
-    positiveNumberSchema,
-    z.tuple([positiveNumberSchema, positiveNumberSchema]).refine(
-      (arr) => arr[0] < arr[1],
-      { message: "weightG range: first value (min) must be less than second (max)" }
-    ),
-  ]).optional(),
+  weightG: z
+    .union([
+      positiveNumberSchema,
+      z
+        .tuple([positiveNumberSchema, positiveNumberSchema])
+        .refine((arr) => arr[0] < arr[1], {
+          message:
+            "weightG range: first value (min) must be less than second (max)",
+        }),
+    ])
+    .optional(),
   diameterMm: positiveNumberSchema.optional(),
-  length: z.strictObject({
-    mm: positiveNumberSchema,
-    variants: z.strictObject({
-      retracted: positiveNumberSchema.optional(),
-      wide: positiveNumberSchema.optional(),
-      tele: positiveNumberSchema.optional(),
-    }).optional(),
-  }).optional(),
-  minFocusDistance: z.strictObject({
-    cm: positiveNumberSchema,
-    macroCm: positiveNumberSchema.optional(),
-    variants: focusDistanceVariantsSchema.optional(),
-    macroVariants: focusDistanceVariantsSchema.optional(),
-  }).optional(),
-  maxMagnification: z.strictObject({
-    value: positiveNumberSchema,
-    variants: magnificationVariantsSchema.optional(),
-  }).optional(),
-  angleOfView: z.union([
-    positiveNumberSchema,
-    z.tuple([positiveNumberSchema, positiveNumberSchema]).refine(
-      (arr) => arr[0] > arr[1],
-      { message: "angleOfView tuple must be [wideEnd, teleEnd] with wide > tele" }
-    ),
-  ]).optional(),
-  angleOfViewCalc: z.union([
-    positiveNumberSchema,
-    z.tuple([positiveNumberSchema, positiveNumberSchema]).refine(
-      (arr) => arr[0] > arr[1],
-      { message: "angleOfViewCalc tuple must be [wideEnd, teleEnd] with wide > tele" }
-    ),
-  ]).optional(),
-  apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
+  length: z
+    .strictObject({
+      mm: positiveNumberSchema,
+      variants: z
+        .strictObject({
+          retracted: positiveNumberSchema.optional(),
+          wide: positiveNumberSchema.optional(),
+          tele: positiveNumberSchema.optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  minFocusDistance: z
+    .strictObject({
+      cm: positiveNumberSchema,
+      macroCm: positiveNumberSchema.optional(),
+      variants: focusDistanceVariantsSchema.optional(),
+      macroVariants: focusDistanceVariantsSchema.optional(),
+    })
+    .optional(),
+  maxMagnification: z
+    .strictObject({
+      value: positiveNumberSchema,
+      variants: magnificationVariantsSchema.optional(),
+    })
+    .optional(),
+  angleOfView: z
+    .union([
+      positiveNumberSchema,
+      z
+        .tuple([positiveNumberSchema, positiveNumberSchema])
+        .refine((arr) => arr[0] > arr[1], {
+          message:
+            "angleOfView tuple must be [wideEnd, teleEnd] with wide > tele",
+        }),
+    ])
+    .optional(),
+  angleOfViewCalc: z
+    .union([
+      positiveNumberSchema,
+      z
+        .tuple([positiveNumberSchema, positiveNumberSchema])
+        .refine((arr) => arr[0] > arr[1], {
+          message:
+            "angleOfViewCalc tuple must be [wideEnd, teleEnd] with wide > tele",
+        }),
+    ])
+    .optional(),
+  apertureBladeCount: z
+    .union([z.number().int().positive(), specNaSchema])
+    .optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
-  pricing: z.strictObject({
-    cn: pricingMarketSchema.optional(),
-    global: pricingMarketSchema.optional(),
-  }).optional(),
+  pricing: z
+    .strictObject({
+      cn: pricingMarketSchema.optional(),
+      global: pricingMarketSchema.optional(),
+    })
+    .optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),
   lensMaterial: optionalNonEmptyStringSchema,
@@ -149,7 +177,8 @@ export const lensConfigurationSchema = z
     if (value.groups > value.elements) {
       ctx.addIssue({
         code: "custom",
-        message: "lensConfiguration.groups cannot exceed lensConfiguration.elements",
+        message:
+          "lensConfiguration.groups cannot exceed lensConfiguration.elements",
         path: ["groups"],
       });
     }
@@ -196,7 +225,7 @@ function validateAperturePair(
   labels: {
     maxField: "maxAperture" | "maxTStop";
     minField: "minAperture" | "minTStop";
-  },
+  }
 ): void {
   if (maxValue === undefined || minValue === undefined) {
     return;
@@ -204,8 +233,12 @@ function validateAperturePair(
 
   const maxEndpoints = getApertureEndpoints(maxValue);
   const minEndpoints = getApertureEndpoints(minValue);
-  const maxWidePath = Array.isArray(maxValue) ? [labels.maxField, 0] : [labels.maxField];
-  const maxTelePath = Array.isArray(maxValue) ? [labels.maxField, 1] : [labels.maxField];
+  const maxWidePath = Array.isArray(maxValue)
+    ? [labels.maxField, 0]
+    : [labels.maxField];
+  const maxTelePath = Array.isArray(maxValue)
+    ? [labels.maxField, 1]
+    : [labels.maxField];
 
   if (maxEndpoints.wide > minEndpoints.wide) {
     ctx.addIssue({
@@ -232,9 +265,10 @@ function validateAperturePair(
   ) {
     ctx.addIssue({
       code: "custom",
-      message: minEndpoints.tele !== undefined
-        ? `${labels.maxField} tele-end cannot be greater than ${labels.minField} tele-end`
-        : `${labels.maxField} tele-end cannot be greater than ${labels.minField}`,
+      message:
+        minEndpoints.tele !== undefined
+          ? `${labels.maxField} tele-end cannot be greater than ${labels.minField} tele-end`
+          : `${labels.maxField} tele-end cannot be greater than ${labels.minField}`,
       path: maxTelePath,
     });
   }
@@ -296,9 +330,11 @@ export const lensSchema = lensObjectSchema.superRefine((value, ctx) => {
   applyLensBusinessRules(value, ctx);
 });
 
-export const lensPatchSchema = lensObjectSchema.partial().superRefine((value, ctx) => {
-  applyLensBusinessRules(value, ctx);
-});
+export const lensPatchSchema = lensObjectSchema
+  .partial()
+  .superRefine((value, ctx) => {
+    applyLensBusinessRules(value, ctx);
+  });
 
 // Pairs of lens IDs confirmed to be distinct despite scoring above the spec
 // similarity threshold. Also used by the pipeline image dedupe gate.
@@ -313,24 +349,29 @@ export const KNOWN_DISTINCT_PAIRS = new Set([
   // specialtyTags differ even though optical formula is the same.
   makeAllowlistKey(
     "ttartisan-100mm-f28-2x-macro-x",
-    "ttartisan-tilt-shift-100mm-f28-2x-macro-x"),
+    "ttartisan-tilt-shift-100mm-f28-2x-macro-x"
+  ),
   // APD version adds apodization filter: same optical formula but different bokeh
   // rendering, ~1-stop light loss (T~1.7), and slower AF vs non-APD.
-  makeAllowlistKey(
-    "fujifilm-xf-56mmf12-r-apd-x",
-    "fujifilm-xf-56mmf12-r-x"),
+  makeAllowlistKey("fujifilm-xf-56mmf12-r-apd-x", "fujifilm-xf-56mmf12-r-x"),
   // XC 50-230mm OIS II is visually identical to the original; shared raw image
   // is intentional, not a collect-stage error.
   makeAllowlistKey(
     "fujifilm-xc-50-230mmf45-67-ois-ii-x",
-    "fujifilm-xc-50-230mmf45-67-ois-x"),
+    "fujifilm-xc-50-230mmf45-67-ois-x"
+  ),
 ]);
 
 // Fields excluded from the spec similarity comparison.
 // Identifiers, human-readable labels, links, and freeform notes are excluded;
 // all measurable optical/physical fields are included automatically.
 const SIMILARITY_EXCLUDE = new Set([
-  "id", "brand", "model", "series", "officialLinks", "fieldNotes",
+  "id",
+  "brand",
+  "model",
+  "series",
+  "officialLinks",
+  "fieldNotes",
 ]);
 
 // Threshold above which two same-brand lenses are flagged as suspiciously similar.
@@ -338,7 +379,13 @@ const SIMILARITY_EXCLUDE = new Set([
 // at 0.895 and 0.870; the next-highest unrelated pair is 0.762.
 const SPEC_SIMILARITY_THRESHOLD = 0.85;
 
-type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [k: string]: JsonValue };
 
 function normalizeForComparison(v: unknown): JsonValue {
   if (Array.isArray(v)) {
@@ -358,14 +405,15 @@ function normalizeForComparison(v: unknown): JsonValue {
 
 function specSimilarity(
   a: Lens,
-  b: Lens,
+  b: Lens
 ): { score: number; equalFields: string[]; diffFields: string[] } {
   const ra = a as unknown as Record<string, unknown>;
   const rb = b as unknown as Record<string, unknown>;
-  const keys = new Set([
-    ...Object.keys(ra),
-    ...Object.keys(rb),
-  ].filter(k => !SIMILARITY_EXCLUDE.has(k)));
+  const keys = new Set(
+    [...Object.keys(ra), ...Object.keys(rb)].filter(
+      (k) => !SIMILARITY_EXCLUDE.has(k)
+    )
+  );
 
   const equalFields: string[] = [];
   const diffFields: string[] = [];
@@ -374,9 +422,14 @@ function specSimilarity(
   for (const k of keys) {
     const av = ra[k];
     const bv = rb[k];
-    if (av === undefined || bv === undefined) continue;
+    if (av === undefined || bv === undefined) {
+      continue;
+    }
     compared++;
-    if (JSON.stringify(normalizeForComparison(av)) === JSON.stringify(normalizeForComparison(bv))) {
+    if (
+      JSON.stringify(normalizeForComparison(av)) ===
+      JSON.stringify(normalizeForComparison(bv))
+    ) {
       equalFields.push(k);
     } else {
       diffFields.push(k);
@@ -390,108 +443,115 @@ function specSimilarity(
   };
 }
 
-export const lensCatalogSchema = z.array(lensSchema).superRefine((lenses, ctx) => {
-  const seenIds = new Map<string, number>();
-  const seenCnLinks = new Map<string, number>();
-  const seenGlobalLinks = new Map<string, number>();
-  const seenBrandModels = new Map<string, number>();
+export const lensCatalogSchema = z
+  .array(lensSchema)
+  .superRefine((lenses, ctx) => {
+    const seenIds = new Map<string, number>();
+    const seenCnLinks = new Map<string, number>();
+    const seenGlobalLinks = new Map<string, number>();
+    const seenBrandModels = new Map<string, number>();
 
-  // Group by brand for pairwise similarity comparison (within-brand only,
-  // matching the scope of the previous tuple-based check).
-  const byBrand = new Map<string, { lens: Lens; index: number }[]>();
+    // Group by brand for pairwise similarity comparison (within-brand only,
+    // matching the scope of the previous tuple-based check).
+    const byBrand = new Map<string, { lens: Lens; index: number }[]>();
 
-  lenses.forEach((lens, index) => {
-    const previousIndex = seenIds.get(lens.id);
-    if (previousIndex !== undefined) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Duplicate lens id "${lens.id}" also appears at index ${previousIndex}`,
-        path: [index, "id"],
-      });
-      return;
-    }
-
-    seenIds.set(lens.id, index);
-
-    if (lens.officialLinks.cn) {
-      const previousCnIndex = seenCnLinks.get(lens.officialLinks.cn);
-      if (previousCnIndex !== undefined) {
+    lenses.forEach((lens, index) => {
+      const previousIndex = seenIds.get(lens.id);
+      if (previousIndex !== undefined) {
         ctx.addIssue({
           code: "custom",
-          message: `Duplicate officialLinks.cn also appears at index ${previousCnIndex}`,
-          path: [index, "officialLinks", "cn"],
+          message: `Duplicate lens id "${lens.id}" also appears at index ${previousIndex}`,
+          path: [index, "id"],
         });
-      } else {
-        seenCnLinks.set(lens.officialLinks.cn, index);
+        return;
       }
-    }
 
-    if (lens.officialLinks.global) {
-      const previousGlobalIndex = seenGlobalLinks.get(lens.officialLinks.global);
-      if (previousGlobalIndex !== undefined) {
+      seenIds.set(lens.id, index);
+
+      if (lens.officialLinks.cn) {
+        const previousCnIndex = seenCnLinks.get(lens.officialLinks.cn);
+        if (previousCnIndex !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Duplicate officialLinks.cn also appears at index ${previousCnIndex}`,
+            path: [index, "officialLinks", "cn"],
+          });
+        } else {
+          seenCnLinks.set(lens.officialLinks.cn, index);
+        }
+      }
+
+      if (lens.officialLinks.global) {
+        const previousGlobalIndex = seenGlobalLinks.get(
+          lens.officialLinks.global
+        );
+        if (previousGlobalIndex !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Duplicate officialLinks.global also appears at index ${previousGlobalIndex}`,
+            path: [index, "officialLinks", "global"],
+          });
+        } else {
+          seenGlobalLinks.set(lens.officialLinks.global, index);
+        }
+      }
+
+      const brandModelKey = [
+        lens.brand,
+        lens.model,
+        lens.generation ?? "<none>",
+      ].join("|");
+      const previousBrandModelIndex = seenBrandModels.get(brandModelKey);
+      if (previousBrandModelIndex !== undefined) {
         ctx.addIssue({
           code: "custom",
-          message: `Duplicate officialLinks.global also appears at index ${previousGlobalIndex}`,
-          path: [index, "officialLinks", "global"],
+          message: `Duplicate brand/model/generation combination also appears at index ${previousBrandModelIndex}`,
+          path: [index, "model"],
         });
       } else {
-        seenGlobalLinks.set(lens.officialLinks.global, index);
+        seenBrandModels.set(brandModelKey, index);
+      }
+
+      const group = byBrand.get(lens.brand) ?? [];
+      group.push({ lens, index });
+      byBrand.set(lens.brand, group);
+    });
+
+    // Pairwise spec similarity check within each brand.
+    for (const group of byBrand.values()) {
+      for (let i = 0; i < group.length; i++) {
+        for (let j = i + 1; j < group.length; j++) {
+          const { lens: a, index: ai } = group[i];
+          const { lens: b, index: bj } = group[j];
+          const { score, equalFields, diffFields } = specSimilarity(a, b);
+          if (score < SPEC_SIMILARITY_THRESHOLD) {
+            continue;
+          }
+          const pairKey = makeAllowlistKey(a.id, b.id);
+          if (KNOWN_DISTINCT_PAIRS.has(pairKey)) {
+            continue;
+          }
+          ctx.addIssue({
+            code: "custom",
+            message: [
+              `Suspiciously similar specs (score=${score.toFixed(2)}) — also at index ${ai}.`,
+              `  equal=[${equalFields.join(", ")}]`,
+              `  diff=[${diffFields.length > 0 ? diffFields.join(", ") : "(none)"}]`,
+              `  If confirmed distinct, add makeAllowlistKey("${a.id}", "${b.id}") to KNOWN_DISTINCT_PAIRS.`,
+            ].join("\n"),
+            path: [bj, "focalLengthMin"],
+          });
+        }
       }
     }
-
-    const brandModelKey = [
-      lens.brand,
-      lens.model,
-      lens.generation ?? "<none>",
-    ].join("|");
-    const previousBrandModelIndex = seenBrandModels.get(brandModelKey);
-    if (previousBrandModelIndex !== undefined) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Duplicate brand/model/generation combination also appears at index ${previousBrandModelIndex}`,
-        path: [index, "model"],
-      });
-    } else {
-      seenBrandModels.set(brandModelKey, index);
-    }
-
-    const group = byBrand.get(lens.brand) ?? [];
-    group.push({ lens, index });
-    byBrand.set(lens.brand, group);
   });
-
-  // Pairwise spec similarity check within each brand.
-  for (const group of byBrand.values()) {
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        const { lens: a, index: ai } = group[i];
-        const { lens: b, index: bj } = group[j];
-        const { score, equalFields, diffFields } = specSimilarity(a, b);
-        if (score < SPEC_SIMILARITY_THRESHOLD) continue;
-        const pairKey = makeAllowlistKey(a.id, b.id);
-        if (KNOWN_DISTINCT_PAIRS.has(pairKey)) continue;
-        ctx.addIssue({
-          code: "custom",
-          message: [
-            `Suspiciously similar specs (score=${score.toFixed(2)}) — also at index ${ai}.`,
-            `  equal=[${equalFields.join(", ")}]`,
-            `  diff=[${diffFields.length > 0 ? diffFields.join(", ") : "(none)"}]`,
-            `  If confirmed distinct, add makeAllowlistKey("${a.id}", "${b.id}") to KNOWN_DISTINCT_PAIRS.`,
-          ].join("\n"),
-          path: [bj, "focalLengthMin"],
-        });
-      }
-    }
-  }
-});
 
 // Compile-time assertion: Lens interface and lensSchema's inferred type must stay
 // bidirectionally compatible. A type error here means the two have drifted —
 // update whichever definition is stale.
-type _AssertExtends<T, U extends T> = true;
-type _LensSchemaCheck = [
-  _AssertExtends<Lens, z.infer<typeof lensSchema>>,
-  _AssertExtends<z.infer<typeof lensSchema>, Lens>,
+export type LensSchemaCheck = [
+  z.infer<typeof lensSchema> extends Lens ? true : never,
+  Lens extends z.infer<typeof lensSchema> ? true : never,
 ];
 
 export function formatZodIssues(error: z.ZodError): string[] {

--- a/src/lib/lens-search.ts
+++ b/src/lib/lens-search.ts
@@ -29,7 +29,10 @@ const DOT_SENTINEL = "\u0001";
  * treated as delimiters. Note: real dots are still delimiters; only the
  * sentinel (which has temporarily replaced digit-dot-digit sequences) is kept.
  */
-const DELIMITER_PATTERN = new RegExp(`[^a-z0-9${DOT_SENTINEL}${CJK_RANGE}]+`, "gu");
+const DELIMITER_PATTERN = new RegExp(
+  `[^a-z0-9${DOT_SENTINEL}${CJK_RANGE}]+`,
+  "gu"
+);
 
 /**
  * Normalise a single string into a clean, lowercase searchable form.
@@ -59,15 +62,21 @@ export function normalizeLensSearchText(value: string): string {
  * concept in CJK), while ASCII alphanumeric runs are split on spaces.
  */
 export function tokenize(normalised: string): string[] {
-  if (!normalised) return [];
+  if (!normalised) {
+    return [];
+  }
   const tokens: string[] = [];
   for (const part of normalised.split(" ")) {
-    if (!part) continue;
+    if (!part) {
+      continue;
+    }
     if (/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff]/.test(part)) {
       for (const ch of part) {
         tokens.push(ch);
       }
-      if (part.length > 1) tokens.push(part);
+      if (part.length > 1) {
+        tokens.push(part);
+      }
     } else {
       tokens.push(part);
     }
@@ -117,7 +126,9 @@ function formatApertureNum(n: number): string {
 
 function apertureTokens(lens: Lens): string[] {
   const tokens: string[] = [];
-  if (lens.maxAperture === undefined) return tokens;
+  if (lens.maxAperture === undefined) {
+    return tokens;
+  }
   for (const n of apertureNums(lens.maxAperture)) {
     const s = formatApertureNum(n);
     const noDot = s.replace(".", "");
@@ -200,19 +211,57 @@ function isBoundaryPrefix(token: string, query: string): boolean {
 }
 
 function matchStrength(tokens: string[], query: string): MatchStrength {
-  if (tokens.includes(query)) return "exact";
-  if (tokens.some((t) => isBoundaryPrefix(t, query))) return "boundaryPrefix";
-  if (tokens.some((t) => t.startsWith(query))) return "wordPrefix";
-  if (tokens.some((t) => t.includes(query))) return "includes";
+  if (tokens.includes(query)) {
+    return "exact";
+  }
+  if (tokens.some((t) => isBoundaryPrefix(t, query))) {
+    return "boundaryPrefix";
+  }
+  if (tokens.some((t) => t.startsWith(query))) {
+    return "wordPrefix";
+  }
+  if (tokens.some((t) => t.includes(query))) {
+    return "includes";
+  }
   return "none";
 }
 
 const WEIGHTS: Record<keyof TokenBucket, Record<MatchStrength, number>> = {
-  model:    { exact: 600, boundaryPrefix: 520, wordPrefix: 450, includes: 280, none: 0 },
-  brand:    { exact: 260, boundaryPrefix: 220, wordPrefix: 200, includes: 120, none: 0 },
-  alias:    { exact: 240, boundaryPrefix: 200, wordPrefix: 180, includes: 110, none: 0 },
-  series:   { exact: 210, boundaryPrefix: 180, wordPrefix: 160, includes: 110, none: 0 },
-  aperture: { exact: 190, boundaryPrefix: 180, wordPrefix: 170, includes: 140, none: 0 },
+  model: {
+    exact: 600,
+    boundaryPrefix: 520,
+    wordPrefix: 450,
+    includes: 280,
+    none: 0,
+  },
+  brand: {
+    exact: 260,
+    boundaryPrefix: 220,
+    wordPrefix: 200,
+    includes: 120,
+    none: 0,
+  },
+  alias: {
+    exact: 240,
+    boundaryPrefix: 200,
+    wordPrefix: 180,
+    includes: 110,
+    none: 0,
+  },
+  series: {
+    exact: 210,
+    boundaryPrefix: 180,
+    wordPrefix: 160,
+    includes: 110,
+    none: 0,
+  },
+  aperture: {
+    exact: 190,
+    boundaryPrefix: 180,
+    wordPrefix: 170,
+    includes: 140,
+    none: 0,
+  },
 };
 
 /**
@@ -262,7 +311,9 @@ function scoreLens(entry: SearchableLensEntry, queryTokens: string[]): number {
   let total = 0;
   for (const qt of queryTokens) {
     const s = scoreToken(entry.buckets, qt);
-    if (s === 0) return 0;
+    if (s === 0) {
+      return 0;
+    }
     total += s;
   }
   if (entry.lens.brand === FIRST_PARTY_BRAND) {
@@ -303,20 +354,20 @@ export function searchLensIndex(
   return scored
     .filter((item) => item.score >= relativeFloor)
     .sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
       const aLen = a.entry.buckets.model.join("").length;
       const bLen = b.entry.buckets.model.join("").length;
-      if (aLen !== bLen) return aLen - bLen;
+      if (aLen !== bLen) {
+        return aLen - bLen;
+      }
       return a.entry.lens.model.localeCompare(b.entry.lens.model);
     })
     .slice(0, limit)
     .map((item) => item.entry.lens);
 }
 
-export function searchLenses(
-  lenses: Lens[],
-  query: string,
-  limit = 8
-): Lens[] {
+export function searchLenses(lenses: Lens[], query: string, limit = 8): Lens[] {
   return searchLensIndex(buildLensSearchIndex(lenses), query, limit);
 }

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -1,4 +1,9 @@
-import { SPEC_NA, type Lens, type FieldNoteKey, type SpecialtyTag } from "./types";
+import {
+  SPEC_NA,
+  type Lens,
+  type FieldNoteKey,
+  type SpecialtyTag,
+} from "./types";
 import type { LensConfigurationLabels } from "./lens.format";
 import { classifyFocusMotor, type FocusMotorClass } from "./lens";
 import * as fmt from "./lens.format";
@@ -150,7 +155,10 @@ export interface ResolvedBoolRow {
   plainText: string;
 }
 
-export type ResolvedSpecRow = ResolvedTextRow | ResolvedNumericRow | ResolvedBoolRow;
+export type ResolvedSpecRow =
+  | ResolvedTextRow
+  | ResolvedNumericRow
+  | ResolvedBoolRow;
 
 export interface ResolvedSpecGroup {
   label: string;
@@ -235,7 +243,9 @@ export function resolveSpecRow(
   lens: Lens,
   labels: SpecValueTextLabels
 ): ResolvedSpecRow | null {
-  if (!row.hasData(lens)) return null;
+  if (!row.hasData(lens)) {
+    return null;
+  }
 
   const note =
     (row.fieldNoteKey ? lens.fieldNotes?.[row.fieldNoteKey] : undefined) ??
@@ -304,7 +314,11 @@ export function resolveSpecRow(
     note,
     displayValue,
     subValue,
-    plainText: joinParts(displayValue ?? labels.missing, subValue, note && `(${note})`),
+    plainText: joinParts(
+      displayValue ?? labels.missing,
+      subValue,
+      note && `(${note})`
+    ),
   };
 }
 
@@ -341,9 +355,6 @@ export function resolveSpecGroups(
  */
 export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
   const {
-    yes,
-    no,
-    partial,
     retracted,
     wide,
     tele,
@@ -384,7 +395,9 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
           fieldNoteKey: "maxAperture" as FieldNoteKey,
           hasData: (l) => l.maxAperture !== undefined,
           getDisplayValue: (l) =>
-            l.maxAperture !== undefined ? fmt.apertureDisplay(l.maxAperture) : "",
+            l.maxAperture !== undefined
+              ? fmt.apertureDisplay(l.maxAperture)
+              : "",
           toComparable: (l) =>
             l.maxAperture === undefined
               ? undefined
@@ -398,7 +411,9 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
           label: labels.minAperture,
           hasData: (l) => l.minAperture !== undefined,
           getDisplayValue: (l) =>
-            l.minAperture !== undefined ? fmt.apertureDisplay(l.minAperture) : "",
+            l.minAperture !== undefined
+              ? fmt.apertureDisplay(l.minAperture)
+              : "",
         },
         {
           kind: "text",
@@ -471,8 +486,7 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
         {
           kind: "text",
           label: labels.dimensions,
-          hasData: (l) =>
-            l.diameterMm !== undefined || l.length !== undefined,
+          hasData: (l) => l.diameterMm !== undefined || l.length !== undefined,
           getDisplayValue: (l) =>
             fmt.dimensionsPrimaryDisplay(l.diameterMm, l.length),
           getSubValue: (l) =>
@@ -530,12 +544,16 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
             }),
           getStructuredLines: (l) => {
             const mfd = l.minFocusDistance;
-            if (!mfd?.variants) return undefined;
+            if (!mfd?.variants) {
+              return undefined;
+            }
             const lines: StructuredLine[] = [];
-            if (mfd.variants.wide !== undefined)
+            if (mfd.variants.wide !== undefined) {
               lines.push({ value: `${mfd.variants.wide}cm`, label: wide });
-            if (mfd.variants.tele !== undefined)
+            }
+            if (mfd.variants.tele !== undefined) {
               lines.push({ value: `${mfd.variants.tele}cm`, label: tele });
+            }
             return lines.length > 0 ? lines : undefined;
           },
           getSubValue: (l) =>
@@ -561,12 +579,16 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
             }),
           getStructuredLines: (l) => {
             const mag = l.maxMagnification;
-            if (!mag?.variants) return undefined;
+            if (!mag?.variants) {
+              return undefined;
+            }
             const lines: StructuredLine[] = [];
-            if (mag.variants.wide !== undefined)
+            if (mag.variants.wide !== undefined) {
               lines.push({ value: `${mag.variants.wide}x`, label: wide });
-            if (mag.variants.tele !== undefined)
+            }
+            if (mag.variants.tele !== undefined) {
               lines.push({ value: `${mag.variants.tele}x`, label: tele });
+            }
             return lines.length > 0 ? lines : undefined;
           },
           toComparable: (l) => l.maxMagnification?.value,
@@ -627,7 +649,8 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
           label: labels.specialtyTags,
           hasData: (l) =>
             l.specialtyTags !== undefined && l.specialtyTags.length > 0,
-          getDisplayValue: (l) => fmt.specialtyTagsDisplay(l.specialtyTags, tags),
+          getDisplayValue: (l) =>
+            fmt.specialtyTagsDisplay(l.specialtyTags, tags),
         },
       ] satisfies SpecRow[],
     },

--- a/src/lib/lens.format.ts
+++ b/src/lib/lens.format.ts
@@ -15,8 +15,12 @@ export function oisDisplay(
   oisStops: number | undefined,
   labels: { yes: string; no: string }
 ): string {
-  if (!ois) return labels.no;
-  return oisStops !== undefined ? `${labels.yes} (${oisStops}-stop)` : labels.yes;
+  if (!ois) {
+    return labels.no;
+  }
+  return oisStops !== undefined
+    ? `${labels.yes} (${oisStops}-stop)`
+    : labels.yes;
 }
 
 export function focalEquiv(n: number, mount: Mount = "X"): number {
@@ -27,7 +31,9 @@ export function focalRangeDisplay(min: number, max: number): string {
   return min === max ? `${min}mm` : `${min}–${max}mm`;
 }
 
-export function apertureDisplay(aperture: NonNullable<Lens["maxAperture"]>): string {
+export function apertureDisplay(
+  aperture: NonNullable<Lens["maxAperture"]>
+): string {
   return Array.isArray(aperture)
     ? `f/${aperture[0]}–${aperture[1]}`
     : `f/${aperture}`;
@@ -36,7 +42,9 @@ export function apertureDisplay(aperture: NonNullable<Lens["maxAperture"]>): str
 export function tStopDisplay(
   tStop: Lens["maxTStop"] | undefined
 ): string | undefined {
-  if (tStop === undefined) return undefined;
+  if (tStop === undefined) {
+    return undefined;
+  }
   return Array.isArray(tStop) ? `T${tStop[0]}–${tStop[1]}` : `T${tStop}`;
 }
 
@@ -46,7 +54,9 @@ export function tStopDisplay(
  * Returns undefined when neither value is available.
  */
 export function primaryApertureDisplay(lens: Lens): string | undefined {
-  if (lens.maxAperture !== undefined) return apertureDisplay(lens.maxAperture);
+  if (lens.maxAperture !== undefined) {
+    return apertureDisplay(lens.maxAperture);
+  }
   return tStopDisplay(lens.maxTStop);
 }
 
@@ -56,7 +66,9 @@ export function primaryApertureDisplay(lens: Lens): string | undefined {
  * neither) is available, so callers can suppress the secondary line.
  */
 export function secondaryApertureDisplay(lens: Lens): string | undefined {
-  if (lens.maxAperture === undefined) return undefined;
+  if (lens.maxAperture === undefined) {
+    return undefined;
+  }
   return tStopDisplay(lens.maxTStop);
 }
 
@@ -71,8 +83,12 @@ export function weightDisplay(
   weightG: number | [number, number] | undefined,
   unit: string
 ): string | undefined {
-  if (weightG === undefined) return undefined;
-  if (Array.isArray(weightG)) return `${weightG[0]}–${weightG[1]}${unit}`;
+  if (weightG === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(weightG)) {
+    return `${weightG[0]}–${weightG[1]}${unit}`;
+  }
   return `${weightG}${unit}`;
 }
 
@@ -80,8 +96,12 @@ export function wrDisplay(
   wr: boolean | "partial",
   labels: { yes: string; no: string; partial: string }
 ): string {
-  if (wr === true) return labels.yes;
-  if (wr === "partial") return labels.partial;
+  if (wr === true) {
+    return labels.yes;
+  }
+  if (wr === "partial") {
+    return labels.partial;
+  }
   return labels.no;
 }
 
@@ -98,17 +118,23 @@ export function filterSizeDisplay(
 }
 
 export function angleOfViewDisplay(
-  angleOfView: number | [number, number] | undefined,
+  angleOfView: number | [number, number] | undefined
 ): string | undefined {
-  if (angleOfView === undefined) return undefined;
-  if (Array.isArray(angleOfView)) return `${angleOfView[0]}°–${angleOfView[1]}°`;
+  if (angleOfView === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(angleOfView)) {
+    return `${angleOfView[0]}°–${angleOfView[1]}°`;
+  }
   return `${angleOfView}°`;
 }
 
 export function magnificationDisplay(
-  maxMagnification: MaxMagnification | undefined,
+  maxMagnification: MaxMagnification | undefined
 ): string | undefined {
-  if (maxMagnification === undefined) return undefined;
+  if (maxMagnification === undefined) {
+    return undefined;
+  }
   return `${maxMagnification.value}x`;
 }
 
@@ -125,7 +151,9 @@ export function dimensionsRichDisplay(
 ): string | undefined {
   const hasDiameter = diameterMm !== undefined;
   const hasLength = length?.mm !== undefined;
-  if (!hasDiameter && !hasLength) return undefined;
+  if (!hasDiameter && !hasLength) {
+    return undefined;
+  }
 
   const parts: string[] = [];
 
@@ -165,7 +193,9 @@ export function minFocusDistanceRichDisplay(
   mfd: MinFocusDistance | undefined,
   labels: { wide: string; tele: string; macro: string }
 ): string | undefined {
-  if (!mfd) return undefined;
+  if (!mfd) {
+    return undefined;
+  }
 
   const lines: string[] = [];
 
@@ -213,9 +243,14 @@ export function maxMagnificationRichDisplay(
   maxMag: MaxMagnification | undefined,
   labels: { wide: string; tele: string }
 ): string | undefined {
-  if (!maxMag) return undefined;
+  if (!maxMag) {
+    return undefined;
+  }
 
-  if (maxMag.variants?.wide !== undefined || maxMag.variants?.tele !== undefined) {
+  if (
+    maxMag.variants?.wide !== undefined ||
+    maxMag.variants?.tele !== undefined
+  ) {
     const parts = [
       maxMag.variants.wide !== undefined
         ? `${labels.wide} ${maxMag.variants.wide}x`
@@ -237,7 +272,9 @@ export function specialtyTagsDisplay(
   tags: SpecialtyTag[] | undefined,
   labels: Record<SpecialtyTag, string>
 ): string | undefined {
-  if (!tags || tags.length === 0) return undefined;
+  if (!tags || tags.length === 0) {
+    return undefined;
+  }
   return tags.map((tag) => labels[tag]).join(", ");
 }
 
@@ -250,9 +287,15 @@ export function dimensionsPrimaryDisplay(
 ): string | undefined {
   const hasDiameter = diameterMm !== undefined;
   const hasLength = length?.mm !== undefined;
-  if (!hasDiameter && !hasLength) return undefined;
-  if (hasDiameter && hasLength) return `⌀${diameterMm} × ${length!.mm}mm`;
-  if (hasDiameter) return `⌀${diameterMm}mm`;
+  if (!hasDiameter && !hasLength) {
+    return undefined;
+  }
+  if (hasDiameter && hasLength) {
+    return `⌀${diameterMm} × ${length!.mm}mm`;
+  }
+  if (hasDiameter) {
+    return `⌀${diameterMm}mm`;
+  }
   return `${length!.mm}mm`;
 }
 
@@ -262,7 +305,9 @@ export function dimensionsVariantsDisplay(
   labels: { retracted: string; wide: string; tele: string }
 ): string | undefined {
   const variants = length?.variants;
-  if (!variants) return undefined;
+  if (!variants) {
+    return undefined;
+  }
   const parts = [
     variants.retracted !== undefined
       ? `${labels.retracted} ${variants.retracted}mm`
@@ -283,7 +328,9 @@ export function minFocusDistancePrimaryDisplay(
   mfd: MinFocusDistance | undefined,
   labels: { wide: string; tele: string }
 ): string | undefined {
-  if (!mfd) return undefined;
+  if (!mfd) {
+    return undefined;
+  }
   if (mfd.variants?.wide !== undefined || mfd.variants?.tele !== undefined) {
     const parts = [
       mfd.variants.wide !== undefined
@@ -306,7 +353,9 @@ export function minFocusDistanceSecondaryDisplay(
   mfd: MinFocusDistance | undefined,
   labels: { wide: string; tele: string; macro: string }
 ): string | undefined {
-  if (!mfd) return undefined;
+  if (!mfd) {
+    return undefined;
+  }
 
   if (
     mfd.macroVariants?.wide !== undefined ||
@@ -338,8 +387,13 @@ export function maxMagnificationPrimaryDisplay(
   maxMag: MaxMagnification | undefined,
   labels: { wide: string; tele: string }
 ): string | undefined {
-  if (!maxMag) return undefined;
-  if (maxMag.variants?.wide !== undefined || maxMag.variants?.tele !== undefined) {
+  if (!maxMag) {
+    return undefined;
+  }
+  if (
+    maxMag.variants?.wide !== undefined ||
+    maxMag.variants?.tele !== undefined
+  ) {
     const parts = [
       maxMag.variants.wide !== undefined
         ? `${labels.wide} ${maxMag.variants.wide}x`
@@ -358,7 +412,9 @@ export function maxMagnificationSecondaryDisplay(
   maxMag: MaxMagnification | undefined,
   labels: { wide: string; tele: string }
 ): string | undefined {
-  if (!maxMag?.variants) return undefined;
+  if (!maxMag?.variants) {
+    return undefined;
+  }
   const parts = [
     maxMag.variants.wide !== undefined
       ? `${labels.wide} ${maxMag.variants.wide}x`
@@ -395,13 +451,21 @@ function mergedElementLine(
   vendorLabel: string,
   inclLabel: string
 ): string | null {
-  if (base === undefined && vendor === undefined) return null;
+  if (base === undefined && vendor === undefined) {
+    return null;
+  }
   const baseCount = base ?? 0;
   const vendorCount = vendor ?? 0;
   const total = baseCount + vendorCount;
-  if (total === 0) return null;
-  if (vendorCount === 0) return `${total} ${baseLabel}`;
-  if (baseCount === 0) return `${total} ${baseLabel} (${vendorCount} ${vendorLabel})`;
+  if (total === 0) {
+    return null;
+  }
+  if (vendorCount === 0) {
+    return `${total} ${baseLabel}`;
+  }
+  if (baseCount === 0) {
+    return `${total} ${baseLabel} (${vendorCount} ${vendorLabel})`;
+  }
   return `${total} ${baseLabel} (${inclLabel} ${vendorCount} ${vendorLabel})`;
 }
 
@@ -410,7 +474,9 @@ export function lensConfigurationPrimaryDisplay(
   configuration: LensConfiguration | undefined,
   labels: LensConfigurationLabels
 ): string | undefined {
-  if (!configuration) return undefined;
+  if (!configuration) {
+    return undefined;
+  }
   return `${configuration.groups} ${labels.groups} / ${configuration.elements} ${labels.elements}`;
 }
 
@@ -422,7 +488,9 @@ export function lensConfigurationSecondaryDisplay(
   configuration: LensConfiguration | undefined,
   labels: LensConfigurationLabels
 ): string | undefined {
-  if (!configuration) return undefined;
+  if (!configuration) {
+    return undefined;
+  }
   const parts = [
     configuration.aspherical !== undefined
       ? `${configuration.aspherical} ${labels.aspherical}`
@@ -452,9 +520,10 @@ export function lensConfigurationDisplay(
   configuration: LensConfiguration | undefined,
   labels: LensConfigurationLabels
 ): string | undefined {
-  if (!configuration) return undefined;
+  if (!configuration) {
+    return undefined;
+  }
   const primary = lensConfigurationPrimaryDisplay(configuration, labels);
   const secondary = lensConfigurationSecondaryDisplay(configuration, labels);
   return [primary, secondary].filter(Boolean).join("\n");
 }
-

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -6,8 +6,12 @@ import type { Lens, LensCatalog, Mount, SpecialtyTag } from "./types";
 import { CNY_THRESHOLDS, USD_THRESHOLDS } from "./lens-pricing";
 export type { SpecialtyTag };
 
-export const xLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
-export const gfxLenses: Lens[] = lensCatalogSchema.parse(gfxLensesData) as LensCatalog;
+export const xLenses: Lens[] = lensCatalogSchema.parse(
+  lensesData
+) as LensCatalog;
+export const gfxLenses: Lens[] = lensCatalogSchema.parse(
+  gfxLensesData
+) as LensCatalog;
 // allLenses combines both mounts — use only for aggregate contexts (About, sitemap, search index).
 // Within a mount-specific route, use getLensesByMount() or xLenses / gfxLenses directly.
 export const allLenses: Lens[] = [...xLenses, ...gfxLenses];
@@ -25,7 +29,10 @@ export function getLensesByMount(mount: Mount): Lens[] {
 }
 
 export type LensType = "prime" | "zoom";
-export const LENS_TYPES = ["prime", "zoom"] as const satisfies readonly LensType[];
+export const LENS_TYPES = [
+  "prime",
+  "zoom",
+] as const satisfies readonly LensType[];
 
 export function isZoom(lens: Lens): boolean {
   return lens.focalLengthMin !== lens.focalLengthMax;
@@ -97,8 +104,10 @@ export function getFocalCategoriesOf(lens: {
   const lensEquivMax = lens.focalLengthMax * cropFactor;
 
   return FOCAL_CATEGORIES.filter((cat) => {
-    const catMin = "equivMinInclusive" in cat ? cat.equivMinInclusive : -Infinity;
-    const catMax = "equivMaxExclusive" in cat ? cat.equivMaxExclusive : Infinity;
+    const catMin =
+      "equivMinInclusive" in cat ? cat.equivMinInclusive : -Infinity;
+    const catMax =
+      "equivMaxExclusive" in cat ? cat.equivMaxExclusive : Infinity;
     // overlap: lens range intersects [catMin, catMax)
     return lensEquivMin < catMax && lensEquivMax >= catMin;
   }).map((cat) => cat.key);
@@ -112,17 +121,27 @@ export type FocusMotorClass = "linear" | "stepping" | "other";
  * AF lenses with an undocumented motor type return "other".
  */
 export function classifyFocusMotor(lens: Lens): FocusMotorClass | undefined {
-  if (!lens.af) return undefined;
+  if (!lens.af) {
+    return undefined;
+  }
   const m = lens.focusMotor;
-  if (!m) return "other"; // AF but motor type not documented → treated as Other
+  if (!m) {
+    return "other";
+  } // AF but motor type not documented → treated as Other
 
   const s = m.toLowerCase();
   // Linear family: LM, HLA, VXD, VCM, Triple/Quad Linear, Dual HyperVCM
-  if (/\b(lm|hla|vxd|vcm)\b/.test(s) || s.includes("linear") || s.includes("hypervcm"))
+  if (
+    /\b(lm|hla|vxd|vcm)\b/.test(s) ||
+    s.includes("linear") ||
+    s.includes("hypervcm")
+  ) {
     return "linear";
+  }
   // Stepping family: STM, RXD, "Stepping Motor", "STM+Lead screw"
-  if (/\b(stm|rxd)\b/.test(s) || s.includes("stepping"))
+  if (/\b(stm|rxd)\b/.test(s) || s.includes("stepping")) {
     return "stepping";
+  }
   return "other";
 }
 
@@ -156,18 +175,31 @@ export function filterLenses(lenses: Lens[], filters: FilterState): Lens[] {
       return false;
     }
 
-    if (filters.typeFilter && filters.typeFilter !== (isZoom(lens) ? "zoom" : "prime")) {
+    if (
+      filters.typeFilter &&
+      filters.typeFilter !== (isZoom(lens) ? "zoom" : "prime")
+    ) {
       return false;
     }
 
-    if (filters.focusFilter === "auto" && !lens.af) return false;
-    if (filters.focusFilter === "manual" && lens.af) return false;
-
-    if (filters.specialtyTag && !lens.specialtyTags?.includes(filters.specialtyTag)) {
+    if (filters.focusFilter === "auto" && !lens.af) {
+      return false;
+    }
+    if (filters.focusFilter === "manual" && lens.af) {
       return false;
     }
 
-    if (filters.focusMotorClass && classifyFocusMotor(lens) !== filters.focusMotorClass) {
+    if (
+      filters.specialtyTag &&
+      !lens.specialtyTags?.includes(filters.specialtyTag)
+    ) {
+      return false;
+    }
+
+    if (
+      filters.focusMotorClass &&
+      classifyFocusMotor(lens) !== filters.focusMotorClass
+    ) {
       return false;
     }
 
@@ -208,7 +240,9 @@ export function getUniqueBrands(lenses: Lens[]): string[] {
 export function getOrderedUniqueBrands(lenses: Lens[]): string[] {
   const present = new Set(lenses.map((l) => l.brand));
   const ordered = BRAND_DISPLAY_ORDER.filter((b) => present.has(b));
-  const rest = [...present].filter((b) => !BRAND_DISPLAY_ORDER.includes(b)).sort();
+  const rest = [...present]
+    .filter((b) => !BRAND_DISPLAY_ORDER.includes(b))
+    .sort();
   return [...ordered, ...rest];
 }
 
@@ -238,7 +272,9 @@ function getSortableMaxAperture(lens: Lens): number {
   // T-stop is numerically slightly larger than f-stop but ordering is preserved
   // for sort purposes within the cine cohort.
   const value = lens.maxAperture ?? lens.maxTStop;
-  if (value === undefined) return Number.POSITIVE_INFINITY;
+  if (value === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
   return Array.isArray(value) ? value[0] : value;
 }
 
@@ -264,10 +300,15 @@ export function sortLenses(
   });
 }
 
-export function priceTier(price: number, currency: "CNY" | "USD"): 1 | 2 | 3 | 4 | 5 | undefined {
+export function priceTier(
+  price: number,
+  currency: "CNY" | "USD"
+): 1 | 2 | 3 | 4 | 5 | undefined {
   const thresholds = currency === "CNY" ? CNY_THRESHOLDS : USD_THRESHOLDS;
   for (let i = thresholds.length - 1; i >= 0; i--) {
-    if (price >= thresholds[i]) return (i + 1) as 1 | 2 | 3 | 4 | 5;
+    if (price >= thresholds[i]) {
+      return (i + 1) as 1 | 2 | 3 | 4 | 5;
+    }
   }
   return undefined;
 }
@@ -275,4 +316,3 @@ export function priceTier(price: number, currency: "CNY" | "USD"): 1 | 2 | 3 | 4
 export function defaultMarketForLocale(locale: string): "cn" | "global" {
   return locale === "zh" ? "cn" : "global";
 }
-

--- a/src/lib/mount.ts
+++ b/src/lib/mount.ts
@@ -3,8 +3,12 @@ import type { Mount } from "@/lib/types";
 export type MountSegment = "x" | "gfx";
 
 export function urlSegmentToMount(seg: string | undefined): Mount | null {
-  if (seg === "x") return "X";
-  if (seg === "gfx") return "G";
+  if (seg === "x") {
+    return "X";
+  }
+  if (seg === "gfx") {
+    return "G";
+  }
   return null;
 }
 

--- a/src/lib/usePwa.ts
+++ b/src/lib/usePwa.ts
@@ -1,11 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+function subscribeToDisplayModeChange(onChange: () => void) {
+  const query = window.matchMedia("(display-mode: standalone)");
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getPwaSnapshot() {
+  return window.matchMedia("(display-mode: standalone)").matches;
+}
 
 export function usePwa(): boolean {
-  const [isPwa, setIsPwa] = useState(false);
-  useEffect(() => {
-    setIsPwa(window.matchMedia("(display-mode: standalone)").matches);
-  }, []);
-  return isPwa;
+  return useSyncExternalStore(
+    subscribeToDisplayModeChange,
+    getPwaSnapshot,
+    () => false
+  );
 }


### PR DESCRIPTION
## Summary

- Apply the repository-wide ESLint auto-fixes, mostly adding required braces for `curly`.
- Resolve the remaining lint findings by removing unused code, correcting hook ordering/dependencies, and replacing a few mount-time state sync patterns with safer alternatives.
- Keep deliberate exceptions narrow where DOM/image behavior requires them.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/app/api/feedback/__tests__/route.test.ts src/lib/__tests__/lens-search.test.ts src/lib/__tests__/lens-spec-groups.test.ts src/lib/__tests__/lenses.test.ts src/lib/__tests__/testhook.test.ts`
- `git diff --check HEAD~1..HEAD`

## Notes

- `npm test` still collects Playwright `e2e/*.spec.ts` under Vitest and fails before running those files as Playwright tests. The actual Vitest unit test files above pass.
