### PR TITLE
refactor(about,nav): polish coverage table and mobile nav

### DIFF
--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -35,15 +35,15 @@ function MountCoverageTable({
   const total = brands.reduce((s, b) => s + (counts[b] ?? 0), 0);
   return (
     <div className="flex flex-col gap-2">
-      <p className="text-xs font-medium text-zinc-400 dark:text-zinc-500">{title}</p>
+      <p className="text-sm font-medium text-zinc-600 dark:text-zinc-400">{title}</p>
       <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden self-start">
         <table className="text-sm">
           <thead>
             <tr className="border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
               <th className="px-3 py-2 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 w-28">{col.brand}</th>
-              <th className="px-3 py-2 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.count}</th>
               <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.active}</th>
-              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-20">{col.discontinued}</th>
+              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.discontinued}</th>
+              <th className="px-3 py-2 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 whitespace-nowrap">{col.count}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/60">
@@ -52,9 +52,9 @@ function MountCoverageTable({
               return (
                 <tr key={b}>
                   <td className="px-3 py-2 font-medium text-zinc-800 dark:text-zinc-200 whitespace-nowrap">{brandNames[b] ?? b}</td>
-                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">{counts[b] ?? 0}</td>
                   <td className="px-3 py-2 text-center">{m.active ? <Check /> : <Dash />}</td>
                   <td className="px-3 py-2 text-center">{m.discontinued ? <Check /> : <Dash />}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">{counts[b] ?? 0}</td>
                 </tr>
               );
             })}
@@ -62,8 +62,8 @@ function MountCoverageTable({
           <tfoot>
             <tr className="border-t border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
               <td className="px-3 py-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">{rowTotal}</td>
-              <td className="px-3 py-2 text-right tabular-nums text-xs font-semibold text-zinc-700 dark:text-zinc-300">{total}</td>
               <td colSpan={2} />
+              <td className="px-3 py-2 text-right tabular-nums text-xs font-semibold text-zinc-700 dark:text-zinc-300">{total}</td>
             </tr>
           </tfoot>
         </table>
@@ -193,10 +193,7 @@ export default async function AboutContent() {
 
       {/* Coverage */}
       <Section id="coverage" title={t("coverageTitle")}>
-        <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
-          {t("coverageBody")}
-        </p>
-        <div className="flex flex-col gap-4 mt-1">
+        <div className="flex flex-col gap-4">
           {([
             { key: "coverageBrandsX", brands: X_BRANDS, counts: xCounts, meta: coverageMeta.x },
             { key: "coverageBrandsG", brands: G_BRANDS, counts: gCounts, meta: coverageMeta.g },
@@ -272,7 +269,7 @@ export default async function AboutContent() {
 
         {/* GitHub link */}
         <ExternalLink
-          href="https://github.com/sentacraft/x-glass"
+          href="https://github.com/sentacraft/x-glass#data-pipeline"
           className="inline-flex items-center gap-0.5 self-start text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
         >
           {t("dataGitHubCta")}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -163,6 +163,17 @@ export default function Nav() {
           <Link href={compareHref} className={linkCls(isCompareActive)}>
             {t("compare")}
           </Link>
+          <a
+            href="https://github.com/sentacraft/x-glass"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors px-1.5"
+            aria-label="GitHub"
+          >
+            <svg viewBox="0 0 24 24" width="17" height="17" fill="currentColor" aria-hidden="true">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+          </a>
           <div ref={menuRef} className="relative">
             <button
               onClick={() => setMobileMenuOpen((v) => !v)}
@@ -183,14 +194,6 @@ export default function Nav() {
                     {t("getApp")}
                   </Link>
                 )}
-                <a
-                  href="https://github.com/sentacraft/x-glass"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={mobileLinkCls(false)}
-                >
-                  GitHub
-                </a>
               </div>
             )}
           </div>

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -293,7 +293,7 @@
     "coverageBrandsX": "X 卡口",
     "coverageBrandsG": "G 卡口",
     "coverageColBrand": "品牌",
-    "coverageColCount": "镜头数",
+    "coverageColCount": "镜头总数",
     "coverageColActive": "在产",
     "coverageColDiscontinued": "停产",
     "coverageRowTotal": "合计",


### PR DESCRIPTION
## Summary

- Remove redundant intro paragraph from the Coverage section on the About page
- Reorder coverage table columns so Active/Discontinued appear before the total count; fixes the column-order UX mismatch shown in the screenshot
- Add `whitespace-nowrap` to the "镜头总数" header to stop it wrapping onto two lines
- Elevate X/G mount subtitle visibility (`text-xs text-zinc-400` → `text-sm text-zinc-600`)
- Rename column label "镜头数" → "镜头总数" in `zh.json`
- Update the data-pipeline GitHub CTA link to anchor directly at `#data-pipeline`
- Promote GitHub icon from the mobile overflow menu to the inline primary nav bar (icon only, no text label)

## Test plan

- [ ] Visit `/zh/about` — coverage tables show Active | Discontinued | 镜头总数 column order with no header wrap
- [ ] X 卡口 / G 卡口 subtitles are visibly darker/larger than before
- [ ] "在 GitHub 查看完整的 Pipeline 架构" link opens `github.com/sentacraft/x-glass#data-pipeline`
- [ ] Mobile viewport: GitHub icon is visible inline next to 浏览 / 对比; overflow menu no longer contains a GitHub entry
- [ ] Desktop nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)