### PR TITLE
test: add unit tests for lens.format and iris-kinematics; remove dead code

### DIFF
--- a/src/lib/__tests__/iris-kinematics.test.ts
+++ b/src/lib/__tests__/iris-kinematics.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from "vitest";
+import type { IrisMechanismConfig } from "../iris-kinematics";
+import {
+  solveAllBlades,
+  thetaRange,
+  bladeShapePath,
+  computeBladeCurvature,
+  computeThetaOpen,
+  buildDerivedConfig,
+  tNormToTheta,
+  apertureInradius,
+  findThetaForInradius,
+  findThetaForFStop,
+  DEFAULT_IRIS_CONFIG,
+} from "../iris-kinematics";
+
+// Representative 7-blade config derived from DEFAULT_IRIS_CONFIG at housingRadius=100.
+const cfg7: IrisMechanismConfig = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+
+// ---------------------------------------------------------------------------
+// thetaRange
+// ---------------------------------------------------------------------------
+describe("thetaRange", () => {
+  it("returns finite range for typical config", () => {
+    const r = thetaRange(cfg7);
+    expect(r.min).toBeLessThan(r.max);
+    expect(isFinite(r.min)).toBe(true);
+    expect(isFinite(r.max)).toBe(true);
+  });
+
+  it("returns half-period range when d >= Rp", () => {
+    // DEFAULT_IRIS_CONFIG has d=88, Rp=85 at h=100 → d > Rp
+    const r = thetaRange(cfg7);
+    const delta = cfg7.slotOffset;
+    expect(r.min).toBeCloseTo(-delta, 6);
+    expect(r.max).toBeCloseTo(-delta + Math.PI, 6);
+  });
+
+  it("constrains range when d < Rp", () => {
+    const tight: IrisMechanismConfig = {
+      ...cfg7,
+      pinDistance: 50,   // d=50 < Rp≈85
+      pivotRadius: 85,
+    };
+    const r = thetaRange(tight);
+    expect(r.max - r.min).toBeLessThan(Math.PI);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// solveAllBlades
+// ---------------------------------------------------------------------------
+describe("solveAllBlades", () => {
+  it("returns N blades at a valid theta", () => {
+    const r = thetaRange(cfg7);
+    const theta = (r.min + r.max) / 2;
+    const blades = solveAllBlades(theta, cfg7);
+    expect(blades).toHaveLength(cfg7.N);
+  });
+
+  it("returns empty array when theta is outside valid range", () => {
+    // cfg7 uses d >= Rp so discriminant is always non-negative. Use a tight
+    // config (d < Rp) which has a constrained thetaRange, then probe outside it.
+    const tight: IrisMechanismConfig = { ...cfg7, pinDistance: 50 };
+    const r = thetaRange(tight);
+    const blades = solveAllBlades(r.max + 1, tight);
+    expect(blades).toHaveLength(0);
+  });
+
+  it("each blade has correct index and finite positions", () => {
+    const r = thetaRange(cfg7);
+    const blades = solveAllBlades(r.min, cfg7);
+    blades.forEach((b, i) => {
+      expect(b.index).toBe(i);
+      expect(isFinite(b.pivotPos.x)).toBe(true);
+      expect(isFinite(b.pivotPos.y)).toBe(true);
+      expect(isFinite(b.guidePinPos.x)).toBe(true);
+      expect(isFinite(b.guidePinPos.y)).toBe(true);
+      expect(isFinite(b.bladeAngle)).toBe(true);
+    });
+  });
+
+  it("pivot pins lie on the pivot circle", () => {
+    const r = thetaRange(cfg7);
+    const blades = solveAllBlades(r.min, cfg7);
+    for (const b of blades) {
+      const dist = Math.hypot(b.pivotPos.x, b.pivotPos.y);
+      expect(dist).toBeCloseTo(cfg7.pivotRadius, 4);
+    }
+  });
+
+  it("guide pins maintain rigid distance from pivot", () => {
+    const r = thetaRange(cfg7);
+    const theta = (r.min + r.max) / 2;
+    const blades = solveAllBlades(theta, cfg7);
+    for (const b of blades) {
+      const dist = Math.hypot(
+        b.guidePinPos.x - b.pivotPos.x,
+        b.guidePinPos.y - b.pivotPos.y
+      );
+      expect(dist).toBeCloseTo(cfg7.pinDistance, 4);
+    }
+  });
+
+  it("blades are evenly distributed angularly", () => {
+    const r = thetaRange(cfg7);
+    const blades = solveAllBlades(r.min, cfg7);
+    const step = (2 * Math.PI) / cfg7.N;
+    blades.forEach((b, i) => {
+      const expectedAngle = i * step;
+      const pivotAngle = Math.atan2(b.pivotPos.y, b.pivotPos.x);
+      // Normalize to [0, 2π)
+      const normalised = ((pivotAngle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
+      expect(normalised).toBeCloseTo(expectedAngle, 4);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeBladeCurvature
+// ---------------------------------------------------------------------------
+describe("computeBladeCurvature", () => {
+  it("returns a positive curvature for valid inputs", () => {
+    const C = computeBladeCurvature(115, 30, 100);
+    expect(C).toBeGreaterThan(0);
+    expect(C).toBeLessThan(10);
+  });
+
+  it("returns 0 when housingRadius is too small (disc < 0)", () => {
+    // L=200, W=10 → cx=100, hw=5, Rt=housingRadius-5; need Rt² < cx²=10000
+    // housingRadius=50 → Rt=45, Rt²=2025 < 10000? No, disc=2025-10000<0 → return 0
+    const C = computeBladeCurvature(200, 10, 50);
+    expect(C).toBe(0);
+  });
+
+  it("produces curvature consistent with buildDerivedConfig", () => {
+    const derived = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+    const expected = computeBladeCurvature(
+      DEFAULT_IRIS_CONFIG.bladeLength,
+      DEFAULT_IRIS_CONFIG.bladeWidth,
+      100
+    );
+    expect(derived.bladeCurvature).toBeCloseTo(expected, 8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDerivedConfig
+// ---------------------------------------------------------------------------
+describe("buildDerivedConfig", () => {
+  it("copies stored fields verbatim", () => {
+    const dc = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+    expect(dc.N).toBe(DEFAULT_IRIS_CONFIG.N);
+    expect(dc.pinDistance).toBe(DEFAULT_IRIS_CONFIG.pinDistance);
+    expect(dc.slotOffset).toBe(DEFAULT_IRIS_CONFIG.slotOffset);
+    expect(dc.bladeLength).toBe(DEFAULT_IRIS_CONFIG.bladeLength);
+    expect(dc.bladeWidth).toBe(DEFAULT_IRIS_CONFIG.bladeWidth);
+  });
+
+  it("derives pivotRadius as housingRadius - bladeWidth/2", () => {
+    const dc = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+    expect(dc.pivotRadius).toBeCloseTo(100 - DEFAULT_IRIS_CONFIG.bladeWidth / 2, 8);
+  });
+
+  it("derives bladeCurvature from geometry", () => {
+    const dc = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+    expect(dc.bladeCurvature).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tNormToTheta
+// ---------------------------------------------------------------------------
+describe("tNormToTheta", () => {
+  it("t=0 returns thetaOpen", () => {
+    expect(tNormToTheta(0, 0.5, 1.5)).toBeCloseTo(0.5, 8);
+  });
+
+  it("t=1 returns thetaMax", () => {
+    expect(tNormToTheta(1, 0.5, 1.5)).toBeCloseTo(1.5, 8);
+  });
+
+  it("t=0.5 returns midpoint", () => {
+    expect(tNormToTheta(0.5, 0.0, 2.0)).toBeCloseTo(1.0, 8);
+  });
+
+  it("is linear between open and max", () => {
+    const open = 0.3, max = 1.8;
+    const t1 = tNormToTheta(0.25, open, max);
+    const t2 = tNormToTheta(0.50, open, max);
+    const t3 = tNormToTheta(0.75, open, max);
+    expect(t2 - t1).toBeCloseTo(t3 - t2, 8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apertureInradius
+// ---------------------------------------------------------------------------
+describe("apertureInradius", () => {
+  it("returns a positive inradius at a mid-range theta", () => {
+    const r = thetaRange(cfg7);
+    const thetaMid = (r.min + r.max) * 0.6;
+    const inr = apertureInradius(thetaMid, cfg7);
+    expect(inr).toBeGreaterThan(0);
+  });
+
+  it("inradius decreases monotonically from thetaOpen to thetaMax", () => {
+    // apertureInradius is 0 at the fully-open position (blades don't yet
+    // overlap the aperture polygon), then peaks once blades start intersecting,
+    // then decreases monotonically as the iris closes further. The monotone
+    // region starts at thetaOpen (computeThetaOpen), not at thetaRange.min.
+    const r = thetaRange(cfg7);
+    const thetaOpen = computeThetaOpen(cfg7, 100);
+    const samples = 8;
+    const thetas = Array.from({ length: samples }, (_, i) =>
+      thetaOpen + (i / (samples - 1)) * (r.max - thetaOpen) * 0.95
+    );
+    const radii = thetas.map((th) => apertureInradius(th, cfg7));
+    for (let i = 1; i < radii.length; i++) {
+      expect(radii[i]).toBeLessThanOrEqual(radii[i - 1] + 1e-6);
+    }
+  });
+
+  it("returns 0 when blades have no valid solution (tight config, out-of-range theta)", () => {
+    // cfg7 has d >= Rp so it has no invalid theta. Use a tight config instead.
+    const tight: IrisMechanismConfig = { ...cfg7, pinDistance: 50 };
+    const r = thetaRange(tight);
+    expect(apertureInradius(r.max + 1, tight)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findThetaForInradius
+// ---------------------------------------------------------------------------
+describe("findThetaForInradius", () => {
+  it("returned theta produces inradius close to the target", () => {
+    const r = thetaRange(cfg7);
+    const range = { min: r.min, max: r.max * 0.9 };
+    const openR = apertureInradius(range.min, cfg7);
+    const targetR = openR * 0.5;
+    const theta = findThetaForInradius(targetR, cfg7, range);
+    expect(apertureInradius(theta, cfg7)).toBeCloseTo(targetR, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findThetaForFStop
+// ---------------------------------------------------------------------------
+describe("findThetaForFStop", () => {
+  it("f-stop at open position equals openFStop", () => {
+    const r = thetaRange(cfg7);
+    const range = { min: r.min, max: r.max };
+    // At thetaOpen the iris is fully open; f-stop should be ≈ openFStop
+    const openFStop = 1.4;
+    const theta = findThetaForFStop(openFStop, cfg7, range, openFStop);
+    // theta should be very close to range.min
+    expect(theta).toBeCloseTo(range.min, 1);
+  });
+
+  it("closing f-stop produces a smaller inradius", () => {
+    const r = thetaRange(cfg7);
+    const range = { min: r.min, max: r.max };
+    const thetaOpen = findThetaForFStop(1.4, cfg7, range, 1.4);
+    const thetaClosed = findThetaForFStop(5.6, cfg7, range, 1.4);
+    expect(apertureInradius(thetaClosed, cfg7)).toBeLessThan(
+      apertureInradius(thetaOpen, cfg7)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeThetaOpen
+// ---------------------------------------------------------------------------
+describe("computeThetaOpen", () => {
+  it("returns a theta within the valid range", () => {
+    const r = thetaRange(cfg7);
+    const thetaOpen = computeThetaOpen(cfg7, 100);
+    expect(thetaOpen).toBeGreaterThanOrEqual(r.min - 1e-6);
+    expect(thetaOpen).toBeLessThanOrEqual(r.max + 1e-6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bladeShapePath
+// ---------------------------------------------------------------------------
+describe("bladeShapePath", () => {
+  it("returns a non-empty SVG path string", () => {
+    const path = bladeShapePath(cfg7);
+    expect(typeof path).toBe("string");
+    expect(path.length).toBeGreaterThan(0);
+    expect(path.startsWith("M")).toBe(true);
+    expect(path.endsWith("Z")).toBe(true);
+  });
+
+  it("degenerate path (C≈0) is a straight rectangle with semicircle caps", () => {
+    const straight: IrisMechanismConfig = { ...cfg7, bladeCurvature: 0 };
+    const path = bladeShapePath(straight);
+    // Degenerate branch uses L (lineto) commands, not A arcs for the long edges
+    expect(path).toContain("L");
+  });
+
+  it("curved path uses arc commands for long edges", () => {
+    const path = bladeShapePath(cfg7);
+    // Should contain multiple A commands for arcs
+    const arcCount = (path.match(/\bA\b/g) || []).length;
+    expect(arcCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it("path coordinates are finite numbers", () => {
+    const path = bladeShapePath(cfg7);
+    const numbers = path.replace(/[A-Z]/g, " ").trim().split(/\s+/).map(Number);
+    for (const n of numbers) {
+      expect(isFinite(n)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_IRIS_CONFIG sanity
+// ---------------------------------------------------------------------------
+describe("DEFAULT_IRIS_CONFIG", () => {
+  it("has a positive blade count", () => {
+    expect(DEFAULT_IRIS_CONFIG.N).toBeGreaterThan(0);
+  });
+
+  it("can be used to derive a valid config", () => {
+    const dc = buildDerivedConfig(DEFAULT_IRIS_CONFIG, 100);
+    expect(dc.pivotRadius).toBeGreaterThan(0);
+    expect(dc.bladeCurvature).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/lib/__tests__/lens.format.test.ts
+++ b/src/lib/__tests__/lens.format.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect } from "vitest";
+import type { LensConfiguration, LensLength, MaxMagnification, MinFocusDistance } from "../types";
+import { SPEC_NA } from "../types";
+import {
+  oisDisplay,
+  tStopDisplay,
+  optionalNumber,
+  weightDisplay,
+  wrDisplay,
+  filterSizeDisplay,
+  angleOfViewDisplay,
+  magnificationDisplay,
+  dimensionsRichDisplay,
+  minFocusDistanceRichDisplay,
+  maxMagnificationRichDisplay,
+  specialtyTagsDisplay,
+  dimensionsPrimaryDisplay,
+  dimensionsVariantsDisplay,
+  minFocusDistancePrimaryDisplay,
+  minFocusDistanceSecondaryDisplay,
+  maxMagnificationPrimaryDisplay,
+  maxMagnificationSecondaryDisplay,
+  lensConfigurationPrimaryDisplay,
+  lensConfigurationSecondaryDisplay,
+  lensConfigurationDisplay,
+} from "../lens.format";
+
+const oisLabels = { yes: "Yes", no: "No" };
+const wrLabels = { yes: "Yes", no: "No", partial: "Partial" };
+const wideTeLabels = { wide: "Wide", tele: "Tele" };
+const wideTelemacroLabels = { wide: "Wide", tele: "Tele", macro: "Macro" };
+const variantLabels = { retracted: "Retracted", wide: "Wide", tele: "Tele" };
+
+const configLabels = {
+  groups: "groups",
+  elements: "elements",
+  aspherical: "Asph.",
+  ed: "ED",
+  superEd: "Super ED",
+  sld: "SLD",
+  fld: "FLD",
+  highRefractive: "HR",
+  incl: "incl.",
+};
+
+// ---------------------------------------------------------------------------
+// oisDisplay
+// ---------------------------------------------------------------------------
+describe("oisDisplay", () => {
+  it("returns no-label when ois is false", () => {
+    expect(oisDisplay(false, undefined, oisLabels)).toBe("No");
+  });
+
+  it("returns yes-label without stops when oisStops is undefined", () => {
+    expect(oisDisplay(true, undefined, oisLabels)).toBe("Yes");
+  });
+
+  it("appends stop count when oisStops is provided", () => {
+    expect(oisDisplay(true, 5, oisLabels)).toBe("Yes (5-stop)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tStopDisplay
+// ---------------------------------------------------------------------------
+describe("tStopDisplay", () => {
+  it("returns undefined when tStop is undefined", () => {
+    expect(tStopDisplay(undefined)).toBeUndefined();
+  });
+
+  it("formats a single T-stop", () => {
+    expect(tStopDisplay(2.1)).toBe("T2.1");
+  });
+
+  it("formats a T-stop range", () => {
+    expect(tStopDisplay([2.1, 16])).toBe("T2.1–16");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// optionalNumber
+// ---------------------------------------------------------------------------
+describe("optionalNumber", () => {
+  it("returns undefined when value is undefined", () => {
+    expect(optionalNumber(undefined, "mm")).toBeUndefined();
+  });
+
+  it("appends unit to the number", () => {
+    expect(optionalNumber(52, "mm")).toBe("52mm");
+    expect(optionalNumber(0.5, "×")).toBe("0.5×");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// weightDisplay
+// ---------------------------------------------------------------------------
+describe("weightDisplay", () => {
+  it("returns undefined when weightG is undefined", () => {
+    expect(weightDisplay(undefined, "g")).toBeUndefined();
+  });
+
+  it("formats a single weight", () => {
+    expect(weightDisplay(187, "g")).toBe("187g");
+  });
+
+  it("formats a weight range", () => {
+    expect(weightDisplay([300, 350], "g")).toBe("300–350g");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrDisplay
+// ---------------------------------------------------------------------------
+describe("wrDisplay", () => {
+  it("returns yes-label for true", () => {
+    expect(wrDisplay(true, wrLabels)).toBe("Yes");
+  });
+
+  it("returns partial-label for 'partial'", () => {
+    expect(wrDisplay("partial", wrLabels)).toBe("Partial");
+  });
+
+  it("returns no-label for false", () => {
+    expect(wrDisplay(false, wrLabels)).toBe("No");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterSizeDisplay
+// ---------------------------------------------------------------------------
+describe("filterSizeDisplay", () => {
+  it("returns undefined when filterMm is undefined", () => {
+    expect(filterSizeDisplay(undefined)).toBeUndefined();
+  });
+
+  it("returns SPEC_NA when filterMm is SPEC_NA", () => {
+    expect(filterSizeDisplay(SPEC_NA)).toBe(SPEC_NA);
+  });
+
+  it("appends mm to a numeric value", () => {
+    expect(filterSizeDisplay(52)).toBe("52mm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// angleOfViewDisplay
+// ---------------------------------------------------------------------------
+describe("angleOfViewDisplay", () => {
+  it("returns undefined when value is undefined", () => {
+    expect(angleOfViewDisplay(undefined)).toBeUndefined();
+  });
+
+  it("formats a single angle", () => {
+    expect(angleOfViewDisplay(44)).toBe("44°");
+  });
+
+  it("formats an angle range", () => {
+    expect(angleOfViewDisplay([76, 44])).toBe("76°–44°");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// magnificationDisplay
+// ---------------------------------------------------------------------------
+describe("magnificationDisplay", () => {
+  it("returns undefined when maxMagnification is undefined", () => {
+    expect(magnificationDisplay(undefined)).toBeUndefined();
+  });
+
+  it("formats the value with x suffix", () => {
+    expect(magnificationDisplay({ value: 0.5 })).toBe("0.5x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dimensionsPrimaryDisplay
+// ---------------------------------------------------------------------------
+describe("dimensionsPrimaryDisplay", () => {
+  it("returns undefined when both are undefined", () => {
+    expect(dimensionsPrimaryDisplay(undefined, undefined)).toBeUndefined();
+  });
+
+  it("shows only diameter when length is undefined", () => {
+    expect(dimensionsPrimaryDisplay(65, undefined)).toBe("⌀65mm");
+  });
+
+  it("shows only length when diameter is undefined", () => {
+    const length: LensLength = { mm: 45 };
+    expect(dimensionsPrimaryDisplay(undefined, length)).toBe("45mm");
+  });
+
+  it("shows diameter × length when both are present", () => {
+    const length: LensLength = { mm: 45 };
+    expect(dimensionsPrimaryDisplay(65, length)).toBe("⌀65 × 45mm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dimensionsVariantsDisplay
+// ---------------------------------------------------------------------------
+describe("dimensionsVariantsDisplay", () => {
+  it("returns undefined when length is undefined", () => {
+    expect(dimensionsVariantsDisplay(undefined, variantLabels)).toBeUndefined();
+  });
+
+  it("returns undefined when length has no variants", () => {
+    const length: LensLength = { mm: 45 };
+    expect(dimensionsVariantsDisplay(length, variantLabels)).toBeUndefined();
+  });
+
+  it("shows retracted/wide/tele variants, each on its own line", () => {
+    const length: LensLength = {
+      mm: 85,
+      variants: { retracted: 70, wide: 80, tele: 95 },
+    };
+    expect(dimensionsVariantsDisplay(length, variantLabels)).toBe(
+      "Retracted 70mm\nWide 80mm\nTele 95mm"
+    );
+  });
+
+  it("omits variant lines that are undefined", () => {
+    const length: LensLength = { mm: 85, variants: { tele: 95 } };
+    expect(dimensionsVariantsDisplay(length, variantLabels)).toBe("Tele 95mm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dimensionsRichDisplay
+// ---------------------------------------------------------------------------
+describe("dimensionsRichDisplay", () => {
+  it("returns undefined when both are undefined", () => {
+    expect(dimensionsRichDisplay(undefined, undefined, variantLabels)).toBeUndefined();
+  });
+
+  it("returns single line when no variants", () => {
+    const length: LensLength = { mm: 45 };
+    expect(dimensionsRichDisplay(65, length, variantLabels)).toBe("⌀65 × 45mm");
+  });
+
+  it("appends variant line when variants are present", () => {
+    const length: LensLength = { mm: 85, variants: { wide: 80, tele: 95 } };
+    expect(dimensionsRichDisplay(65, length, variantLabels)).toBe(
+      "⌀65 × 85mm\nWide 80mm · Tele 95mm"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// minFocusDistancePrimaryDisplay
+// ---------------------------------------------------------------------------
+describe("minFocusDistancePrimaryDisplay", () => {
+  it("returns undefined when mfd is undefined", () => {
+    expect(minFocusDistancePrimaryDisplay(undefined, wideTeLabels)).toBeUndefined();
+  });
+
+  it("shows single cm value for primes", () => {
+    const mfd: MinFocusDistance = { cm: 28 };
+    expect(minFocusDistancePrimaryDisplay(mfd, wideTeLabels)).toBe("28cm");
+  });
+
+  it("shows wide · tele inline for zoom lenses with variants", () => {
+    const mfd: MinFocusDistance = { cm: 30, variants: { wide: 25, tele: 38 } };
+    expect(minFocusDistancePrimaryDisplay(mfd, wideTeLabels)).toBe("Wide 25cm · Tele 38cm");
+  });
+
+  it("shows only wide when tele variant is absent", () => {
+    const mfd: MinFocusDistance = { cm: 25, variants: { wide: 25 } };
+    expect(minFocusDistancePrimaryDisplay(mfd, wideTeLabels)).toBe("Wide 25cm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// minFocusDistanceSecondaryDisplay
+// ---------------------------------------------------------------------------
+describe("minFocusDistanceSecondaryDisplay", () => {
+  it("returns undefined when mfd is undefined", () => {
+    expect(minFocusDistanceSecondaryDisplay(undefined, wideTelemacroLabels)).toBeUndefined();
+  });
+
+  it("returns undefined when no macro info", () => {
+    const mfd: MinFocusDistance = { cm: 28 };
+    expect(minFocusDistanceSecondaryDisplay(mfd, wideTelemacroLabels)).toBeUndefined();
+  });
+
+  it("shows single macro cm", () => {
+    const mfd: MinFocusDistance = { cm: 28, macroCm: 12 };
+    expect(minFocusDistanceSecondaryDisplay(mfd, wideTelemacroLabels)).toBe("Macro: 12cm");
+  });
+
+  it("shows macro wide · tele when macroVariants present", () => {
+    const mfd: MinFocusDistance = {
+      cm: 30,
+      macroVariants: { wide: 10, tele: 15 },
+    };
+    expect(minFocusDistanceSecondaryDisplay(mfd, wideTelemacroLabels)).toBe(
+      "Macro: Wide 10cm · Tele 15cm"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// minFocusDistanceRichDisplay
+// ---------------------------------------------------------------------------
+describe("minFocusDistanceRichDisplay", () => {
+  it("returns undefined when mfd is undefined", () => {
+    expect(minFocusDistanceRichDisplay(undefined, wideTelemacroLabels)).toBeUndefined();
+  });
+
+  it("shows primary only when no macro", () => {
+    const mfd: MinFocusDistance = { cm: 28 };
+    expect(minFocusDistanceRichDisplay(mfd, wideTelemacroLabels)).toBe("28cm");
+  });
+
+  it("combines primary and macro on separate lines", () => {
+    const mfd: MinFocusDistance = { cm: 28, macroCm: 12 };
+    expect(minFocusDistanceRichDisplay(mfd, wideTelemacroLabels)).toBe(
+      "28cm\nMacro: 12cm"
+    );
+  });
+
+  it("shows zoom variants + macro variants", () => {
+    const mfd: MinFocusDistance = {
+      cm: 30,
+      variants: { wide: 25, tele: 38 },
+      macroVariants: { wide: 10, tele: 15 },
+    };
+    expect(minFocusDistanceRichDisplay(mfd, wideTelemacroLabels)).toBe(
+      "Wide 25cm · Tele 38cm\nMacro: Wide 10cm · Tele 15cm"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxMagnificationPrimaryDisplay
+// ---------------------------------------------------------------------------
+describe("maxMagnificationPrimaryDisplay", () => {
+  it("returns undefined when maxMag is undefined", () => {
+    expect(maxMagnificationPrimaryDisplay(undefined, wideTeLabels)).toBeUndefined();
+  });
+
+  it("shows single value for prime", () => {
+    const mag: MaxMagnification = { value: 0.5 };
+    expect(maxMagnificationPrimaryDisplay(mag, wideTeLabels)).toBe("0.5x");
+  });
+
+  it("shows wide · tele inline for zoom with variants", () => {
+    const mag: MaxMagnification = { value: 0.3, variants: { wide: 0.2, tele: 0.3 } };
+    expect(maxMagnificationPrimaryDisplay(mag, wideTeLabels)).toBe("Wide 0.2x · Tele 0.3x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxMagnificationSecondaryDisplay
+// ---------------------------------------------------------------------------
+describe("maxMagnificationSecondaryDisplay", () => {
+  it("returns undefined when maxMag is undefined", () => {
+    expect(maxMagnificationSecondaryDisplay(undefined, wideTeLabels)).toBeUndefined();
+  });
+
+  it("returns undefined when no variants", () => {
+    const mag: MaxMagnification = { value: 0.5 };
+    expect(maxMagnificationSecondaryDisplay(mag, wideTeLabels)).toBeUndefined();
+  });
+
+  it("shows wide · tele when variants present", () => {
+    const mag: MaxMagnification = { value: 0.3, variants: { wide: 0.2, tele: 0.3 } };
+    expect(maxMagnificationSecondaryDisplay(mag, wideTeLabels)).toBe("Wide 0.2x · Tele 0.3x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxMagnificationRichDisplay
+// ---------------------------------------------------------------------------
+describe("maxMagnificationRichDisplay", () => {
+  it("returns undefined when maxMag is undefined", () => {
+    expect(maxMagnificationRichDisplay(undefined, wideTeLabels)).toBeUndefined();
+  });
+
+  it("shows single value when no variants", () => {
+    const mag: MaxMagnification = { value: 0.5 };
+    expect(maxMagnificationRichDisplay(mag, wideTeLabels)).toBe("0.5x");
+  });
+
+  it("shows wide · tele when variants present", () => {
+    const mag: MaxMagnification = { value: 0.3, variants: { wide: 0.2, tele: 0.3 } };
+    expect(maxMagnificationRichDisplay(mag, wideTeLabels)).toBe("Wide 0.2x · Tele 0.3x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// specialtyTagsDisplay
+// ---------------------------------------------------------------------------
+describe("specialtyTagsDisplay", () => {
+  const labels = { cine: "Cinema", macro: "Macro" } as Record<string, string>;
+
+  it("returns undefined when tags is undefined", () => {
+    expect(specialtyTagsDisplay(undefined, labels)).toBeUndefined();
+  });
+
+  it("returns undefined when tags is empty", () => {
+    expect(specialtyTagsDisplay([], labels)).toBeUndefined();
+  });
+
+  it("formats a single tag", () => {
+    expect(specialtyTagsDisplay(["cine"], labels)).toBe("Cinema");
+  });
+
+  it("joins multiple tags with a comma", () => {
+    expect(specialtyTagsDisplay(["cine", "macro"], labels)).toBe("Cinema, Macro");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lensConfigurationPrimaryDisplay
+// ---------------------------------------------------------------------------
+describe("lensConfigurationPrimaryDisplay", () => {
+  it("returns undefined when configuration is undefined", () => {
+    expect(lensConfigurationPrimaryDisplay(undefined, configLabels)).toBeUndefined();
+  });
+
+  it("formats groups / elements", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11 };
+    expect(lensConfigurationPrimaryDisplay(cfg, configLabels)).toBe("9 groups / 11 elements");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lensConfigurationSecondaryDisplay
+// ---------------------------------------------------------------------------
+describe("lensConfigurationSecondaryDisplay", () => {
+  it("returns undefined when configuration is undefined", () => {
+    expect(lensConfigurationSecondaryDisplay(undefined, configLabels)).toBeUndefined();
+  });
+
+  it("returns undefined when no element types are present", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBeUndefined();
+  });
+
+  it("formats aspherical elements", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, aspherical: 3 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe("3 Asph.");
+  });
+
+  it("merges ED + SLD into one line with incl. clause", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, ed: 3, sld: 2 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe(
+      "5 ED (incl. 2 SLD)"
+    );
+  });
+
+  it("shows only ED when no SLD", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, ed: 3 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe("3 ED");
+  });
+
+  it("shows only SLD labelled as ED when base ED is absent", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, sld: 2 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe("2 ED (2 SLD)");
+  });
+
+  it("merges Super ED + FLD", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, superEd: 1, fld: 2 };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe(
+      "3 Super ED (incl. 2 FLD)"
+    );
+  });
+
+  it("joins multiple element types with · separator", () => {
+    const cfg: LensConfiguration = {
+      groups: 10,
+      elements: 14,
+      aspherical: 2,
+      ed: 3,
+      highRefractive: 1,
+    };
+    expect(lensConfigurationSecondaryDisplay(cfg, configLabels)).toBe(
+      "2 Asph. · 3 ED · 1 HR"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lensConfigurationDisplay (combined)
+// ---------------------------------------------------------------------------
+describe("lensConfigurationDisplay", () => {
+  it("returns undefined when configuration is undefined", () => {
+    expect(lensConfigurationDisplay(undefined, configLabels)).toBeUndefined();
+  });
+
+  it("returns primary line only when no element types", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11 };
+    expect(lensConfigurationDisplay(cfg, configLabels)).toBe("9 groups / 11 elements");
+  });
+
+  it("returns primary + secondary separated by newline", () => {
+    const cfg: LensConfiguration = { groups: 9, elements: 11, aspherical: 3, ed: 2 };
+    expect(lensConfigurationDisplay(cfg, configLabels)).toBe(
+      "9 groups / 11 elements\n3 Asph. · 2 ED"
+    );
+  });
+});

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -296,19 +296,15 @@ export const lensSchema = lensObjectSchema.superRefine((value, ctx) => {
   applyLensBusinessRules(value, ctx);
 });
 
-export const lensPatchSchema = lensObjectSchema.partial().superRefine((value, ctx) => {
-  applyLensBusinessRules(value, ctx);
-});
-
 // Pairs of lens IDs confirmed to be distinct despite scoring above the spec
 // similarity threshold. Also used by the pipeline image dedupe gate.
 // Format: "idA|idB" with IDs sorted alphabetically. Add a comment explaining
 // what actually distinguishes the pair — the gate error output shows you the
 // equalFields / diffFields diff to inform that decision.
-export function makeAllowlistKey(a: string, b: string): string {
+function makeAllowlistKey(a: string, b: string): string {
   return a < b ? `${a}|${b}` : `${b}|${a}`;
 }
-export const KNOWN_DISTINCT_PAIRS = new Set([
+const KNOWN_DISTINCT_PAIRS = new Set([
   // Tilt-shift mechanism adds tilt/shift axes; lensConfiguration and
   // specialtyTags differ even though optical formula is the same.
   makeAllowlistKey(


### PR DESCRIPTION
## Summary

- **lens.format.test.ts**: covers all 21 previously-untested display formatters — `oisDisplay`, `tStopDisplay`, `weightDisplay`, `wrDisplay`, `filterSizeDisplay`, `angleOfViewDisplay`, `magnificationDisplay`, dimensions (primary/variants/rich), MFD (primary/secondary/rich), magnification (primary/secondary/rich), `specialtyTagsDisplay`, and full lens configuration display
- **iris-kinematics.test.ts**: covers every exported function of the kinematic engine — `thetaRange`, `solveAllBlades` (pivot circle, rigid distance, angular distribution invariants), `bladeShapePath`, `computeBladeCurvature`, `buildDerivedConfig`, `tNormToTheta`, `apertureInradius` (monotone in the valid region from `thetaOpen`), `findThetaForInradius`, `findThetaForFStop`, `computeThetaOpen`
- **lens-schema.ts**: remove unused `lensPatchSchema` export; demote `makeAllowlistKey` and `KNOWN_DISTINCT_PAIRS` from `export` to module-private

## Test plan

- [x] `npx vitest run src/lib/__tests__/lens.format.test.ts src/lib/__tests__/iris-kinematics.test.ts` — all pass
- [x] Full unit test suite passes (2312 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)