### PR TITLE
feat(i18n): add translations container and locale-aware spec resolution

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getLensesByMount, getLensUrl } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens-spec-groups";
+import { resolveTranslations } from "@/lib/types";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens-spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
 import { Link } from "@/i18n/navigation";
@@ -115,6 +116,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     notFound();
   }
 
+  const displayLens = resolveTranslations(lens, locale);
   const t = await getTranslations("LensDetail");
   const tBrand = await getTranslations("Brands");
   const tPricing = await getTranslations("Pricing");
@@ -200,7 +202,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   // Resolve all row values once. This is the single source of truth for both
   // the rendered spec table and the Report Dialog's field list.
-  const resolvedGroups = resolveSpecGroups(specGroups, lens, valueCellLabels);
+  const resolvedGroups = resolveSpecGroups(specGroups, displayLens, valueCellLabels);
 
   // Field options for the Report Dialog — taken directly from resolved values,
   // identical to what is rendered in the spec table below.

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -7,7 +7,6 @@ import { getLensesByMount, getLensUrl } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens-spec-groups";
-import { resolveTranslations } from "@/lib/types";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens-spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
 import { Link } from "@/i18n/navigation";
@@ -31,7 +30,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale, mount, id } = await params;
   const t = await getTranslations("LensDetail");
-  const lenses = getLensesByMount(urlSegmentToMount(mount) ?? "X");
+  const lenses = getLensesByMount(urlSegmentToMount(mount) ?? "X", locale);
   const lens = lenses.find((l) => l.id === id);
   if (!lens) {
     return { title: t("notFoundTitle") };
@@ -109,14 +108,13 @@ function renderRowValue(
 
 export default async function LensDetailPage({ params }: { params: Params }) {
   const { id, locale, mount } = await params;
-  const lenses = getLensesByMount(urlSegmentToMount(mount) ?? "X");
+  const lenses = getLensesByMount(urlSegmentToMount(mount) ?? "X", locale);
   const lens = lenses.find((l) => l.id === id);
 
   if (!lens) {
     notFound();
   }
 
-  const displayLens = resolveTranslations(lens, locale);
   const t = await getTranslations("LensDetail");
   const tBrand = await getTranslations("Brands");
   const tPricing = await getTranslations("Pricing");
@@ -202,7 +200,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   // Resolve all row values once. This is the single source of truth for both
   // the rendered spec table and the Report Dialog's field list.
-  const resolvedGroups = resolveSpecGroups(specGroups, displayLens, valueCellLabels);
+  const resolvedGroups = resolveSpecGroups(specGroups, lens, valueCellLabels);
 
   // Field options for the Report Dialog — taken directly from resolved values,
   // identical to what is rendered in the spec table below.

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -24,12 +24,12 @@ export async function generateMetadata({
 }
 
 export default async function LensesPage({ params }: { params: Params }) {
-  const { mount } = await params;
+  const { locale, mount } = await params;
   const resolvedMount = urlSegmentToMount(mount);
   if (!resolvedMount) {
     notFound();
   }
-  const lenses = getLensesByMount(resolvedMount);
+  const lenses = getLensesByMount(resolvedMount, locale);
 
   return (
     <Suspense fallback={<LensesLoading />}>

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
     return { title: t("title") };
   }
 
-  const lenses = parseLensIds(ids, resolvedMount);
+  const lenses = parseLensIds(ids, resolvedMount, locale);
   const alternates = buildAlternates(locale, `lenses/${mount}/compare`);
 
   if (preset) {
@@ -65,7 +65,7 @@ export default async function ComparePage({
     notFound();
   }
 
-  const lenses = parseLensIds(ids, resolvedMount);
+  const lenses = parseLensIds(ids, resolvedMount, locale);
 
   const lang = locale === "zh" ? "zh" : "en";
   const presetTitle = preset ? (getPresetBySlug(preset)?.title[lang] ?? undefined) : undefined;

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -9,7 +9,7 @@ import { ExternalLink } from "@/components/ui/external-link";
 import { Link } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import type { FeedbackType } from "@/components/FeedbackDialog";
-import { xLenses, gfxLenses } from "@/lib/lens";
+import { getLensesByMount } from "@/lib/lens";
 import coverageMeta from "@/data/coverage-meta.json";
 import AckCard from "@/components/AckCard";
 
@@ -99,10 +99,10 @@ export default async function AboutContent() {
     getLocale(),
   ]);
 
-  const xCounts = (xLenses as { brand: string }[]).reduce<Record<string, number>>(
+  const xCounts = getLensesByMount("X", locale).reduce<Record<string, number>>(
     (acc, l) => { acc[l.brand] = (acc[l.brand] ?? 0) + 1; return acc; }, {}
   );
-  const gCounts = (gfxLenses as { brand: string }[]).reduce<Record<string, number>>(
+  const gCounts = getLensesByMount("G", locale).reduce<Record<string, number>>(
     (acc, l) => { acc[l.brand] = (acc[l.brand] ?? 0) + 1; return acc; }, {}
   );
   const X_BRANDS = ["fujifilm","sigma","tamron","viltrox","7artisans","ttartisan","brightinstar","sgimage"];

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useEffect, useRef } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import { getLensesByMount } from "@/lib/lens";
 import { useMountedCompare } from "@/context/CompareProvider";
@@ -20,15 +20,16 @@ export default function CompareBar() {
   const tCompare = useTranslations("Compare");
   const router = useRouter();
   const pathname = usePathname();
+  const locale = useLocale();
   const mount = useEffectiveMount();
   const { compareIds, toggleCompare, clearCompare } = useMountedCompare();
 
   const selectedLenses = useMemo(
     () =>
       compareIds
-        .map((id) => getLensesByMount(mount).find((l) => l.id === id))
+        .map((id) => getLensesByMount(mount, locale).find((l) => l.id === id))
         .filter((lens) => lens !== undefined),
-    [compareIds, mount]
+    [compareIds, mount, locale]
   );
 
   // Track bar height and expose it as a CSS variable so other fixed elements

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -27,7 +27,7 @@ import LensSearchDialog from "@/components/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecRow } from "@/lib/lens-spec-groups";
 import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens-spec-groups";
-import type { Lens } from "@/lib/types";
+import { resolveTranslations, type Lens } from "@/lib/types";
 import { PriceBand } from "@/components/PriceBand";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 
@@ -336,10 +336,11 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const resolvedPerLens = useMemo(() => {
     const map = new Map<string, Map<string, ResolvedSpecRow>>();
     for (const lens of orderedLenses) {
+      const displayLens = resolveTranslations(lens, locale);
       const rowMap = new Map<string, ResolvedSpecRow>();
       for (const group of allGroups) {
         for (const row of group.rows) {
-          const resolved = resolveSpecRow(row, lens, valueCellLabels);
+          const resolved = resolveSpecRow(row, displayLens, valueCellLabels);
           if (resolved) {
             rowMap.set(row.label, resolved);
           }
@@ -348,7 +349,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
       map.set(lens.id, rowMap);
     }
     return map;
-  }, [allGroups, orderedLenses, valueCellLabels]);
+  }, [allGroups, orderedLenses, valueCellLabels, locale]);
 
   // Per-view suppression: hide rows where no compared lens has data.
   const visibleGroups = useMemo(

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -27,7 +27,7 @@ import LensSearchDialog from "@/components/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecRow } from "@/lib/lens-spec-groups";
 import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens-spec-groups";
-import { resolveTranslations, type Lens } from "@/lib/types";
+import type { Lens } from "@/lib/types";
 import { PriceBand } from "@/components/PriceBand";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 
@@ -194,7 +194,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   }, [initialLensIds, replaceCompare]);
 
   const orderedLenses = compareIds
-    .map((id) => getLensesByMount(mount).find((lens) => lens.id === id))
+    .map((id) => getLensesByMount(mount, locale).find((lens) => lens.id === id))
     .filter((lens): lens is Lens => lens !== undefined);
 
   // Number of empty slot columns to render (search triggers filling up to minColumns)
@@ -336,11 +336,10 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const resolvedPerLens = useMemo(() => {
     const map = new Map<string, Map<string, ResolvedSpecRow>>();
     for (const lens of orderedLenses) {
-      const displayLens = resolveTranslations(lens, locale);
       const rowMap = new Map<string, ResolvedSpecRow>();
       for (const group of allGroups) {
         for (const row of group.rows) {
-          const resolved = resolveSpecRow(row, displayLens, valueCellLabels);
+          const resolved = resolveSpecRow(row, lens, valueCellLabels);
           if (resolved) {
             rowMap.set(row.label, resolved);
           }
@@ -349,7 +348,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
       map.set(lens.id, rowMap);
     }
     return map;
-  }, [allGroups, orderedLenses, valueCellLabels, locale]);
+  }, [allGroups, orderedLenses, valueCellLabels]);
 
   // Per-view suppression: hide rows where no compared lens has data.
   const visibleGroups = useMemo(

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -7,7 +7,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { trendingPresets, type TrendingPreset } from "@/lib/trending";
-import { allLenses } from "@/lib/lens";
+import { getAllLenses } from "@/lib/lens";
 import { cn } from "@/lib/utils";
 
 export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSelect?: () => void }) {
@@ -18,7 +18,7 @@ export function PresetCard({ preset, onSelect }: { preset: TrendingPreset; onSel
   const tBrand = useTranslations("Brands");
 
   const lenses = preset.lensIds
-    .map((id) => allLenses.find((l) => l.id === id))
+    .map((id) => getAllLenses(locale).find((l) => l.id === id))
     .filter(Boolean);
 
   function handleClick() {

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -13,7 +13,7 @@ export default function DataInfo() {
   const t = useTranslations("Footer");
   const locale = useLocale();
   const mount = useEffectiveMount();
-  const mountLenses = getLensesByMount(mount);
+  const mountLenses = getLensesByMount(mount, locale);
   const lensCount = mountLenses.length;
   const brandCount = new Set(mountLenses.map((l) => l.brand)).size;
   const [clickState, setClickState] = useState<ClickState>("date");

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from "react";
 import { Search, X } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
 import { getLensesByMount } from "@/lib/lens";
 import { mountToUrlSegment } from "@/lib/mount";
@@ -50,8 +50,9 @@ export default function LensSearchDialog({
   const t = useTranslations("Search");
   const tBrand = useTranslations("Brands");
   const router = useRouter();
+  const locale = useLocale();
   const mount = useEffectiveMount();
-  const lensSearchIndex = useMemo(() => buildLensSearchIndex(getLensesByMount(mount)), [mount]);
+  const lensSearchIndex = useMemo(() => buildLensSearchIndex(getLensesByMount(mount, locale)), [mount, locale]);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -5,7 +5,7 @@ import { QRCodeSVG } from "qrcode.react";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
-import { resolveTranslations, type Lens } from "@/lib/types";
+import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { classifyFocusMotor, priceTier } from "@/lib/lens";
 import { pickPriceEntry, formatTierRange } from "@/lib/lens-pricing";
@@ -235,8 +235,7 @@ interface SharePosterProps {
   ref?: Ref<HTMLDivElement>;
 }
 
-export function SharePoster({ lenses: rawLenses, labels, custom, shareUrl, ref }: SharePosterProps) {
-  const lenses = rawLenses.map((l) => resolveTranslations(l, labels.locale));
+export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePosterProps) {
   const n = lenses.length;
   const titleLines: string[] = custom?.title?.trim()
     ? [custom.title.trim()]

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -5,7 +5,7 @@ import { QRCodeSVG } from "qrcode.react";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
-import type { Lens } from "@/lib/types";
+import { resolveTranslations, type Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { classifyFocusMotor, priceTier } from "@/lib/lens";
 import { pickPriceEntry, formatTierRange } from "@/lib/lens-pricing";
@@ -235,7 +235,8 @@ interface SharePosterProps {
   ref?: Ref<HTMLDivElement>;
 }
 
-export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePosterProps) {
+export function SharePoster({ lenses: rawLenses, labels, custom, shareUrl, ref }: SharePosterProps) {
+  const lenses = rawLenses.map((l) => resolveTranslations(l, labels.locale));
   const n = lenses.length;
   const titleLines: string[] = custom?.title?.trim()
     ? [custom.title.trim()]

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -172,12 +172,21 @@ const fieldNotesSchema = z.strictObject({
   apertureBladeCount: nonEmptyStringSchema.optional(),
 });
 
+const translationsSchema = z.strictObject({
+  zh: z.strictObject({
+    fieldNotes: fieldNotesSchema.optional(),
+    lensMaterial: nonEmptyStringSchema.optional(),
+    accessories: z.array(nonEmptyStringSchema).optional(),
+  }).optional(),
+}).optional();
+
 const lensObjectSchema = z.strictObject({
   ...lensBaseShape,
   filterMm: z.union([positiveNumberSchema, specNaSchema]).optional(),
   lensConfiguration: lensConfigurationSchema.optional(),
   fieldNotes: fieldNotesSchema.optional(),
   officialLinks: officialLinksSchema,
+  translations: translationsSchema,
 });
 
 function getApertureEndpoints(aperture: ApertureValue): {
@@ -326,7 +335,7 @@ const KNOWN_DISTINCT_PAIRS = new Set([
 // Identifiers, human-readable labels, links, and freeform notes are excluded;
 // all measurable optical/physical fields are included automatically.
 const SIMILARITY_EXCLUDE = new Set([
-  "id", "brand", "model", "series", "officialLinks", "fieldNotes",
+  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations",
 ]);
 
 // Threshold above which two same-brand lenses are flagged as suspiciously similar.

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -2,15 +2,13 @@ import lensesData from "../data/lenses.json";
 import gfxLensesData from "../data/lenses-g.json";
 import metaData from "../data/meta.json";
 import { lensCatalogSchema } from "./lens-schema";
-import type { Lens, LensCatalog, Mount, SpecialtyTag } from "./types";
+import { resolveTranslations, type Lens, type LensCatalog, type Mount, type SpecialtyTag } from "./types";
 import { CNY_THRESHOLDS, USD_THRESHOLDS } from "./lens-pricing";
 export type { SpecialtyTag };
 
-export const xLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
-export const gfxLenses: Lens[] = lensCatalogSchema.parse(gfxLensesData) as LensCatalog;
-// allLenses combines both mounts — use only for aggregate contexts (About, sitemap, search index).
-// Within a mount-specific route, use getLensesByMount() or xLenses / gfxLenses directly.
-export const allLenses: Lens[] = [...xLenses, ...gfxLenses];
+const xLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
+const gfxLenses: Lens[] = lensCatalogSchema.parse(gfxLensesData) as LensCatalog;
+
 export const meta = metaData;
 export const brandCount = new Set(xLenses.map((l) => l.brand)).size;
 export const MAX_COMPARE = 4;
@@ -20,8 +18,24 @@ export const CROP_FACTOR: Record<Mount, number> = {
   G: 0.79, // GFX 44×33 mm diagonal ≈54.78 mm vs FF ≈43.3 mm
 };
 
-export function getLensesByMount(mount: Mount): Lens[] {
-  return mount === "G" ? gfxLenses : xLenses;
+const resolvedCache = new Map<string, Lens[]>();
+
+function getResolved(base: Lens[], locale: string): Lens[] {
+  const key = `${base === xLenses ? "X" : "G"}:${locale}`;
+  let result = resolvedCache.get(key);
+  if (!result) {
+    result = base.map((l) => resolveTranslations(l, locale));
+    resolvedCache.set(key, result);
+  }
+  return result;
+}
+
+export function getLensesByMount(mount: Mount, locale: string): Lens[] {
+  return getResolved(mount === "G" ? gfxLenses : xLenses, locale);
+}
+
+export function getAllLenses(locale: string): Lens[] {
+  return [...getLensesByMount("X", locale), ...getLensesByMount("G", locale)];
 }
 
 export type LensType = "prime" | "zoom";
@@ -235,8 +249,8 @@ export function getLensUrl(lens: Lens, locale?: string): string | undefined {
   return lens.officialLinks?.global;
 }
 
-export function parseLensIds(ids: string | undefined, mount: Mount): Lens[] {
-  const pool = getLensesByMount(mount);
+export function parseLensIds(ids: string | undefined, mount: Mount, locale: string): Lens[] {
+  const pool = getLensesByMount(mount, locale);
   return (ids ?? "")
     .split(",")
     .filter(Boolean)

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -1,5 +1,5 @@
 import trendingData from "../data/trending.json";
-import { allLenses } from "./lens";
+import { getAllLenses } from "./lens";
 import type { Lens } from "./types";
 
 export interface TrendingPreset {
@@ -15,8 +15,8 @@ export function getPresetBySlug(slug: string): TrendingPreset | undefined {
   return trendingPresets.find((p) => p.slug === slug);
 }
 
-export function getPresetLenses(preset: TrendingPreset): Lens[] {
+export function getPresetLenses(preset: TrendingPreset, locale: string): Lens[] {
   return preset.lensIds
-    .map((id) => allLenses.find((l) => l.id === id))
+    .map((id) => getAllLenses(locale).find((l) => l.id === id))
     .filter((l): l is Lens => l !== undefined);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -724,6 +724,44 @@ export interface Lens {
    */
   officialLinks: LensOfficialLinks;
 
+  /**
+   * Localized translations of user-visible free-text fields.
+   * Keys are language codes; currently only "zh" is produced.
+   * English values live in the top-level fields (fieldNotes, lensMaterial,
+   * accessories) and serve as the fallback when a translation is absent.
+   */
+  translations?: {
+    zh?: {
+      fieldNotes?: Partial<Record<FieldNoteKey, string>>;
+      lensMaterial?: string;
+      accessories?: string[];
+    };
+  };
+
+}
+
+/**
+ * Returns a shallow copy of the lens with translated free-text fields
+ * promoted to top-level when a matching locale exists in `translations`.
+ * Falls back to the original English values for any field without a
+ * translation. Pass-through when locale is "en" or has no translations.
+ */
+export function resolveTranslations(lens: Lens, locale: string): Lens {
+  if (locale !== "zh") {
+    return lens;
+  }
+  const zh = lens.translations?.zh;
+  if (!zh) {
+    return lens;
+  }
+  return {
+    ...lens,
+    ...(zh.fieldNotes && {
+      fieldNotes: { ...lens.fieldNotes, ...zh.fieldNotes },
+    }),
+    ...(zh.lensMaterial !== undefined && { lensMaterial: zh.lensMaterial }),
+    ...(zh.accessories !== undefined && { accessories: zh.accessories }),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a unified `translations` field to the `Lens` type for localized free-text fields (fieldNotes, lensMaterial, accessories)
- Wire locale through spec group helpers so the detail page, compare table, and poster resolve zh translations when locale is "zh", falling back to the English original
- Simplify detail page by removing redundant translation logic in favor of the new centralized approach

## Test plan
- [ ] Verify lens detail page displays Chinese translations when locale is `zh`
- [ ] Verify lens detail page falls back to English when locale is `en` or translation is missing
- [ ] Verify compare table shows localized specs per locale
- [ ] Verify share poster renders localized text correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)