### PR TITLE
feat(lens-schema): export KNOWN_DISTINCT_PAIRS for pipeline dedupe gate

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -304,7 +304,7 @@ export const lensSchema = lensObjectSchema.superRefine((value, ctx) => {
 function makeAllowlistKey(a: string, b: string): string {
   return a < b ? `${a}|${b}` : `${b}|${a}`;
 }
-const KNOWN_DISTINCT_PAIRS = new Set([
+export const KNOWN_DISTINCT_PAIRS = new Set([
   // Tilt-shift mechanism adds tilt/shift axes; lensConfiguration and
   // specialtyTags differ even though optical formula is the same.
   makeAllowlistKey(


### PR DESCRIPTION
## Summary

- `KNOWN_DISTINCT_PAIRS` was declared as `const` (no `export`), so the pipeline's dynamic `import()` resolved it to `undefined`
- This caused `TypeError: Cannot read properties of undefined (reading 'has')` at publish time in the image dedupe gate
- One-character fix: add `export`

## Test plan

- [ ] `tsx scripts/cli.ts publish` no longer throws on the dedupe gate