### PR TITLE
feat(data): publish lens data 2026.05.10 build 3

### DIFF
--- a/src/data/lenses-g.json
+++ b/src/data/lenses-g.json
@@ -21,7 +21,9 @@
       "mm": 112.5
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "maxMagnification": {
       "value": 0.14
@@ -111,7 +113,9 @@
       "mm": 103
     },
     "minFocusDistance": {
-      "cm": 38
+      "normal": {
+        "cm": 38
+      }
     },
     "maxMagnification": {
       "value": 0.09
@@ -190,7 +194,9 @@
       "mm": 99.4
     },
     "minFocusDistance": {
-      "cm": 32
+      "normal": {
+        "cm": 32
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -256,7 +262,9 @@
       "mm": 138.5
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.21
@@ -351,10 +359,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 50,
-      "variants": {
-        "wide": 50,
-        "tele": 60
+      "normal": {
+        "cm": 50,
+        "teleCm": 60
       }
     },
     "maxMagnification": {
@@ -448,7 +455,9 @@
       "mm": 222.5
     },
     "minFocusDistance": {
-      "cm": 80
+      "normal": {
+        "cm": 80
+      }
     },
     "maxMagnification": {
       "value": 0.06
@@ -529,7 +538,9 @@
       "mm": 73.9
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "maxMagnification": {
       "value": 0.28
@@ -619,10 +630,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 65,
-      "variants": {
-        "wide": 65,
-        "tele": 82
+      "normal": {
+        "cm": 65,
+        "teleCm": 82
       }
     },
     "maxMagnification": {
@@ -708,7 +718,9 @@
       "mm": 88
     },
     "minFocusDistance": {
-      "cm": 45
+      "normal": {
+        "cm": 45
+      }
     },
     "maxMagnification": {
       "value": 0.14
@@ -788,7 +800,9 @@
       "mm": 48
     },
     "minFocusDistance": {
-      "cm": 55
+      "normal": {
+        "cm": 55
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -868,7 +882,9 @@
       "mm": 99.3
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "maxMagnification": {
       "value": 0.17
@@ -946,7 +962,9 @@
       "mm": 71
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "maxMagnification": {
       "value": 0.17
@@ -1024,7 +1042,9 @@
       "mm": 99.2
     },
     "minFocusDistance": {
-      "cm": 70
+      "normal": {
+        "cm": 70
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -1104,10 +1124,9 @@
       "mm": 183
     },
     "minFocusDistance": {
-      "cm": 60,
-      "variants": {
-        "wide": 60,
-        "tele": 160
+      "normal": {
+        "cm": 60,
+        "teleCm": 160
       }
     },
     "maxMagnification": {
@@ -1195,7 +1214,9 @@
       "mm": 125.5
     },
     "minFocusDistance": {
-      "cm": 90
+      "normal": {
+        "cm": 90
+      }
     },
     "maxMagnification": {
       "value": 0.16
@@ -1277,7 +1298,9 @@
       "mm": 149
     },
     "minFocusDistance": {
-      "cm": 43
+      "normal": {
+        "cm": 43
+      }
     },
     "maxMagnification": {
       "value": 0.5
@@ -1358,7 +1381,9 @@
       "mm": 152.5
     },
     "minFocusDistance": {
-      "cm": 45
+      "normal": {
+        "cm": 45
+      }
     },
     "maxMagnification": {
       "value": 0.5
@@ -1436,7 +1461,9 @@
       "mm": 203.5
     },
     "minFocusDistance": {
-      "cm": 140
+      "normal": {
+        "cm": 140
+      }
     },
     "maxMagnification": {
       "value": 0.22
@@ -1515,7 +1542,9 @@
       "mm": 246.5
     },
     "minFocusDistance": {
-      "cm": 275
+      "normal": {
+        "cm": 275
+      }
     },
     "maxMagnification": {
       "value": 0.2

--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -23,7 +23,9 @@
       "mm": 70
     },
     "minFocusDistance": {
-      "cm": 14
+      "normal": {
+        "cm": 14
+      }
     },
     "angleOfView": 100,
     "angleOfViewCalc": 99.4,
@@ -93,7 +95,9 @@
       "mm": 99.7
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 58.6,
     "angleOfViewCalc": 59,
@@ -179,7 +183,9 @@
       "mm": 72
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 105,
     "angleOfViewCalc": 109.5,
@@ -254,7 +260,9 @@
       "mm": 51
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 58.3,
     "angleOfViewCalc": 59,
@@ -320,7 +328,9 @@
       "mm": 42
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 55,
     "angleOfViewCalc": 55.3,
@@ -381,7 +391,9 @@
       "mm": 49
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 43.5,
     "angleOfViewCalc": 44,
@@ -443,7 +455,9 @@
       "mm": 51
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 44,
     "angleOfViewCalc": 44,
@@ -509,7 +523,9 @@
       "mm": 51
     },
     "minFocusDistance": {
-      "cm": 55
+      "normal": {
+        "cm": 55
+      }
     },
     "angleOfView": 31.4,
     "angleOfViewCalc": 31.6,
@@ -578,7 +594,9 @@
       "mm": 91
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfViewCalc": 109.5,
     "apertureBladeCount": 10,
@@ -648,7 +666,9 @@
       "mm": 88
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfViewCalc": 83,
     "apertureBladeCount": 11,
@@ -717,7 +737,9 @@
       "mm": 104
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfViewCalc": 59,
     "pricing": {
@@ -786,7 +808,9 @@
       "mm": 104
     },
     "minFocusDistance": {
-      "cm": 51
+      "normal": {
+        "cm": 51
+      }
     },
     "angleOfViewCalc": 44,
     "pricing": {
@@ -855,7 +879,9 @@
       "mm": 104
     },
     "minFocusDistance": {
-      "cm": 60
+      "normal": {
+        "cm": 60
+      }
     },
     "angleOfViewCalc": 31.6,
     "pricing": {
@@ -924,7 +950,9 @@
       "mm": 104
     },
     "minFocusDistance": {
-      "cm": 90
+      "normal": {
+        "cm": 90
+      }
     },
     "angleOfViewCalc": 18.9,
     "pricing": {
@@ -1134,7 +1162,9 @@
       "mm": 50.6
     },
     "minFocusDistance": {
-      "cm": 15
+      "normal": {
+        "cm": 15
+      }
     },
     "angleOfView": 190,
     "angleOfViewCalc": 124.1,
@@ -1208,7 +1238,9 @@
       "mm": 34
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 108,
     "angleOfViewCalc": 109.5,
@@ -1276,7 +1308,9 @@
       "mm": 66
     },
     "minFocusDistance": {
-      "cm": 15
+      "normal": {
+        "cm": 15
+      }
     },
     "angleOfView": 100,
     "angleOfViewCalc": 99.4,
@@ -1345,7 +1379,9 @@
       "mm": 15
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 74,
     "angleOfViewCalc": 76.3,
@@ -1420,7 +1456,9 @@
       "mm": 37.8
     },
     "minFocusDistance": {
-      "cm": 18
+      "normal": {
+        "cm": 18
+      }
     },
     "angleOfView": 68,
     "angleOfViewCalc": 59,
@@ -1488,7 +1526,9 @@
       "mm": 44
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "angleOfView": 43.9,
     "angleOfViewCalc": 44,
@@ -1556,7 +1596,9 @@
       "mm": 42.2
     },
     "minFocusDistance": {
-      "cm": 37
+      "normal": {
+        "cm": 37
+      }
     },
     "angleOfView": 43,
     "angleOfViewCalc": 44,
@@ -1628,7 +1670,9 @@
       "mm": 73
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 46,
     "angleOfViewCalc": 31.6,
@@ -1694,7 +1738,9 @@
       "mm": 40
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -1821,7 +1867,9 @@
       "mm": 81
     },
     "minFocusDistance": {
-      "cm": 26
+      "normal": {
+        "cm": 26
+      }
     },
     "maxMagnification": {
       "value": 1
@@ -1891,7 +1939,9 @@
       "mm": 42
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 63.2,
     "angleOfViewCalc": 44,
@@ -1960,7 +2010,9 @@
       "mm": 112
     },
     "minFocusDistance": {
-      "cm": 18.2
+      "normal": {
+        "cm": 18.2
+      }
     },
     "maxMagnification": {
       "value": 2
@@ -2033,7 +2085,9 @@
       "mm": 118
     },
     "minFocusDistance": {
-      "cm": 18.2
+      "normal": {
+        "cm": 18.2
+      }
     },
     "maxMagnification": {
       "value": 2
@@ -2112,7 +2166,9 @@
       "mm": 79
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -2177,7 +2233,9 @@
       "mm": 58
     },
     "minFocusDistance": {
-      "cm": 15
+      "normal": {
+        "cm": 15
+      }
     },
     "angleOfView": 190,
     "angleOfViewCalc": 124.1,
@@ -2254,7 +2312,9 @@
       "mm": 37
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 172,
     "angleOfViewCalc": 109.5,
@@ -2331,7 +2391,9 @@
       "mm": 20
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 175,
     "angleOfViewCalc": 109.5,
@@ -2405,7 +2467,9 @@
       "mm": 70.6
     },
     "minFocusDistance": {
-      "cm": 18
+      "normal": {
+        "cm": 18
+      }
     },
     "angleOfView": 97,
     "angleOfViewCalc": 99.4,
@@ -2462,7 +2526,9 @@
       "mm": 33
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 57.4,
     "angleOfViewCalc": 59,
@@ -2522,7 +2588,9 @@
       "mm": 62
     },
     "minFocusDistance": {
-      "cm": 37
+      "normal": {
+        "cm": 37
+      }
     },
     "angleOfView": 44,
     "angleOfViewCalc": 44,
@@ -2586,7 +2654,9 @@
       "mm": 38
     },
     "minFocusDistance": {
-      "cm": 32
+      "normal": {
+        "cm": 32
+      }
     },
     "angleOfView": 43,
     "angleOfViewCalc": 44,
@@ -2638,7 +2708,9 @@
       "mm": 40
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "angleOfView": 42,
     "angleOfViewCalc": 44,
@@ -2699,7 +2771,9 @@
       "mm": 67
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -2765,7 +2839,9 @@
       "mm": 64
     },
     "minFocusDistance": {
-      "cm": 42
+      "normal": {
+        "cm": 42
+      }
     },
     "angleOfView": 29.5,
     "angleOfViewCalc": 31.6,
@@ -2822,7 +2898,9 @@
       "mm": 40
     },
     "minFocusDistance": {
-      "cm": 38
+      "normal": {
+        "cm": 38
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -2890,10 +2968,11 @@
       "mm": 206.6
     },
     "minFocusDistance": {
-      "cm": 85,
-      "macroCm": 38,
-      "macroVariants": {
-        "wide": 38
+      "normal": {
+        "cm": 85
+      },
+      "macro": {
+        "cm": 38
       }
     },
     "angleOfView": [
@@ -2984,10 +3063,11 @@
       "mm": 206.6
     },
     "minFocusDistance": {
-      "cm": 120,
-      "macroCm": 85,
-      "macroVariants": {
-        "wide": 85
+      "normal": {
+        "cm": 120
+      },
+      "macro": {
+        "cm": 85
       }
     },
     "angleOfView": [
@@ -3080,7 +3160,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "maxMagnification": {
       "value": 0.25,
@@ -3173,10 +3255,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 13,
-      "variants": {
-        "wide": 13,
-        "tele": 35
+      "normal": {
+        "cm": 13,
+        "teleCm": 35
       }
     },
     "maxMagnification": {
@@ -3268,10 +3349,12 @@
       }
     },
     "minFocusDistance": {
-      "cm": 30,
-      "macroVariants": {
-        "wide": 30,
-        "tele": 40
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 30,
+        "teleCm": 40
       }
     },
     "maxMagnification": {
@@ -3345,7 +3428,9 @@
       "mm": 46.5
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "maxMagnification": {
       "value": 0.14
@@ -3424,8 +3509,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 110,
-      "macroCm": 110
+      "normal": {
+        "cm": 110
+      }
     },
     "maxMagnification": {
       "value": 0.2
@@ -3499,10 +3585,8 @@
       }
     },
     "minFocusDistance": {
-      "cm": 110,
-      "macroCm": 110,
-      "variants": {
-        "wide": 110
+      "normal": {
+        "cm": 110
       }
     },
     "maxMagnification": {
@@ -3587,7 +3671,9 @@
       "mm": 121.5
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 0.1,
@@ -3678,7 +3764,9 @@
       "mm": 52.8
     },
     "minFocusDistance": {
-      "cm": 18
+      "normal": {
+        "cm": 18
+      }
     },
     "maxMagnification": {
       "value": 0.07
@@ -3757,8 +3845,12 @@
       "mm": 87
     },
     "minFocusDistance": {
-      "cm": 24,
-      "macroCm": 24
+      "normal": {
+        "cm": 50
+      },
+      "macro": {
+        "cm": 24
+      }
     },
     "maxMagnification": {
       "value": 0.16
@@ -3831,7 +3923,9 @@
       "mm": 87
     },
     "minFocusDistance": {
-      "cm": 24
+      "normal": {
+        "cm": 24
+      }
     },
     "maxMagnification": {
       "value": 0.16,
@@ -3902,8 +3996,12 @@
       "mm": 58.4
     },
     "minFocusDistance": {
-      "cm": 18,
-      "macroCm": 18
+      "normal": {
+        "cm": 30
+      },
+      "macro": {
+        "cm": 18
+      }
     },
     "maxMagnification": {
       "value": 0.12
@@ -3970,7 +4068,9 @@
       "mm": 71.4
     },
     "minFocusDistance": {
-      "cm": 24
+      "normal": {
+        "cm": 24
+      }
     },
     "maxMagnification": {
       "value": 0.3
@@ -4059,10 +4159,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 60,
-      "variants": {
-        "wide": 60,
-        "tele": 40
+      "normal": {
+        "cm": 60,
+        "teleCm": 40
       }
     },
     "maxMagnification": {
@@ -4141,7 +4240,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.21
@@ -4233,7 +4334,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "maxMagnification": {
       "value": 0.25,
@@ -4322,7 +4425,9 @@
       "mm": 73
     },
     "minFocusDistance": {
-      "cm": 15
+      "normal": {
+        "cm": 15
+      }
     },
     "maxMagnification": {
       "value": 0.21
@@ -4396,7 +4501,9 @@
       "mm": 45.4
     },
     "minFocusDistance": {
-      "cm": 17
+      "normal": {
+        "cm": 17
+      }
     },
     "maxMagnification": {
       "value": 0.13
@@ -4484,11 +4591,12 @@
       }
     },
     "minFocusDistance": {
-      "cm": 60,
-      "macroCm": 30,
-      "macroVariants": {
-        "wide": 30,
-        "tele": 40
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 30,
+        "teleCm": 40
       }
     },
     "maxMagnification": {
@@ -4562,7 +4670,9 @@
       "mm": 123.5
     },
     "minFocusDistance": {
-      "cm": 60
+      "normal": {
+        "cm": 60
+      }
     },
     "maxMagnification": {
       "value": 0.2,
@@ -4642,8 +4752,12 @@
       }
     },
     "minFocusDistance": {
-      "cm": 60,
-      "macroCm": 45
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 45
+      }
     },
     "maxMagnification": {
       "value": 0.27,
@@ -4716,7 +4830,9 @@
       "mm": 75.6
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -4788,8 +4904,12 @@
       "mm": 33.7
     },
     "minFocusDistance": {
-      "cm": 18,
-      "macroCm": 18
+      "normal": {
+        "cm": 80
+      },
+      "macro": {
+        "cm": 18
+      }
     },
     "maxMagnification": {
       "value": 0.14
@@ -4843,8 +4963,12 @@
       "mm": 63
     },
     "minFocusDistance": {
-      "cm": 28,
-      "macroCm": 28
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 28
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -4902,7 +5026,9 @@
       "mm": 77.8
     },
     "minFocusDistance": {
-      "cm": 19
+      "normal": {
+        "cm": 19
+      }
     },
     "maxMagnification": {
       "value": 0.2
@@ -4966,7 +5092,9 @@
       "mm": 51.9
     },
     "minFocusDistance": {
-      "cm": 22
+      "normal": {
+        "cm": 22
+      }
     },
     "maxMagnification": {
       "value": 0.13
@@ -5043,7 +5171,9 @@
       "mm": 23
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -5123,8 +5253,12 @@
       "mm": 23
     },
     "minFocusDistance": {
-      "cm": 34,
-      "macroCm": 34
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 34
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -5188,7 +5322,9 @@
       "mm": 23
     },
     "minFocusDistance": {
-      "cm": 34
+      "normal": {
+        "cm": 34
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -5254,7 +5390,9 @@
       "mm": 69.5
     },
     "minFocusDistance": {
-      "cm": 10
+      "normal": {
+        "cm": 10
+      }
     },
     "maxMagnification": {
       "value": 1
@@ -5318,7 +5456,9 @@
       "mm": 73.5
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -5380,8 +5520,12 @@
       "mm": 50.4
     },
     "minFocusDistance": {
-      "cm": 80,
-      "macroCm": 28
+      "normal": {
+        "cm": 80
+      },
+      "macro": {
+        "cm": 28
+      }
     },
     "maxMagnification": {
       "value": 0.17
@@ -5465,7 +5609,9 @@
       "mm": 45.9
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "maxMagnification": {
       "value": 0.135
@@ -5544,8 +5690,9 @@
       "mm": 175.9
     },
     "minFocusDistance": {
-      "cm": 100,
-      "macroCm": 100
+      "normal": {
+        "cm": 100
+      }
     },
     "maxMagnification": {
       "value": 0.12,
@@ -5641,7 +5788,9 @@
       "mm": 103.5
     },
     "minFocusDistance": {
-      "cm": 70
+      "normal": {
+        "cm": 70
+      }
     },
     "maxMagnification": {
       "value": 0.08
@@ -5705,7 +5854,9 @@
       "mm": 59.4
     },
     "minFocusDistance": {
-      "cm": 39
+      "normal": {
+        "cm": 39
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -5792,8 +5943,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 110,
-      "macroCm": 110
+      "normal": {
+        "cm": 110
+      }
     },
     "maxMagnification": {
       "value": 0.18,
@@ -5875,8 +6027,9 @@
       "mm": 69.7
     },
     "minFocusDistance": {
-      "cm": 70,
-      "macroCm": 70
+      "normal": {
+        "cm": 70
+      }
     },
     "maxMagnification": {
       "value": 0.09
@@ -5942,8 +6095,9 @@
       "mm": 69.7
     },
     "minFocusDistance": {
-      "cm": 70,
-      "macroCm": 70
+      "normal": {
+        "cm": 70
+      }
     },
     "maxMagnification": {
       "value": 0.09
@@ -6019,7 +6173,9 @@
       "mm": 76
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "maxMagnification": {
       "value": 0.14
@@ -6100,8 +6256,12 @@
       "mm": 63.6
     },
     "minFocusDistance": {
-      "cm": 60,
-      "macroCm": 26.7
+      "normal": {
+        "cm": 60
+      },
+      "macro": {
+        "cm": 26.7
+      }
     },
     "maxMagnification": {
       "value": 0.5
@@ -6181,7 +6341,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 83
+      "normal": {
+        "cm": 83
+      }
     },
     "maxMagnification": {
       "value": 0.33,
@@ -6258,7 +6420,9 @@
       "mm": 130
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 1
@@ -6340,7 +6504,9 @@
       "mm": 105
     },
     "minFocusDistance": {
-      "cm": 60
+      "normal": {
+        "cm": 60
+      }
     },
     "maxMagnification": {
       "value": 0.2
@@ -6410,7 +6576,9 @@
       }
     },
     "minFocusDistance": {
-      "cm": 175
+      "normal": {
+        "cm": 175
+      }
     },
     "maxMagnification": {
       "value": 0.19,
@@ -6487,7 +6655,9 @@
       "mm": 314.5
     },
     "minFocusDistance": {
-      "cm": 240
+      "normal": {
+        "cm": 240
+      }
     },
     "maxMagnification": {
       "value": 0.24,
@@ -6581,7 +6751,9 @@
       "mm": 205.5
     },
     "minFocusDistance": {
-      "cm": 180
+      "normal": {
+        "cm": 180
+      }
     },
     "maxMagnification": {
       "value": 0.12
@@ -6663,7 +6835,9 @@
       "mm": 255.5
     },
     "minFocusDistance": {
-      "cm": 275
+      "normal": {
+        "cm": 275
+      }
     },
     "maxMagnification": {
       "value": 0.2
@@ -6745,7 +6919,9 @@
       "mm": 60
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 98,
     "angleOfViewCalc": 99.4,
@@ -6812,7 +6988,9 @@
       "mm": 16.7
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 76.2,
     "angleOfViewCalc": 61,
@@ -6888,7 +7066,9 @@
       "mm": 32
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 58,
     "angleOfViewCalc": 59,
@@ -6958,7 +7138,9 @@
       "mm": 78
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 42,
     "angleOfViewCalc": 28.9,
@@ -7023,7 +7205,9 @@
       "mm": 54
     },
     "minFocusDistance": {
-      "cm": 12
+      "normal": {
+        "cm": 12
+      }
     },
     "angleOfView": 168,
     "angleOfViewCalc": 124.1,
@@ -7099,7 +7283,9 @@
       "mm": 14
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 76,
     "angleOfViewCalc": 76.3,
@@ -7174,7 +7360,9 @@
       "mm": 36.5
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 58,
     "angleOfViewCalc": 59,
@@ -7245,7 +7433,9 @@
       "mm": 63
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 44,
     "angleOfViewCalc": 44,
@@ -7315,7 +7505,9 @@
       "mm": 33.1
     },
     "minFocusDistance": {
-      "cm": 40
+      "normal": {
+        "cm": 40
+      }
     },
     "angleOfView": 44,
     "angleOfViewCalc": 44,
@@ -7386,7 +7578,9 @@
       "mm": 42.5
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -7456,7 +7650,9 @@
       "mm": 48
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 44,
     "angleOfViewCalc": 31.6,
@@ -7533,10 +7729,9 @@
       "mm": 64.3
     },
     "minFocusDistance": {
-      "cm": 11.6,
-      "variants": {
-        "wide": 11.6,
-        "tele": 19.1
+      "normal": {
+        "cm": 11.6,
+        "teleCm": 19.1
       }
     },
     "maxMagnification": {
@@ -7631,7 +7826,9 @@
       "mm": 69.7
     },
     "minFocusDistance": {
-      "cm": 17.2
+      "normal": {
+        "cm": 17.2
+      }
     },
     "maxMagnification": {
       "value": 0.119
@@ -7720,7 +7917,9 @@
       "mm": 65.1
     },
     "minFocusDistance": {
-      "cm": 17.7
+      "normal": {
+        "cm": 17.7
+      }
     },
     "maxMagnification": {
       "value": 0.127
@@ -7818,10 +8017,9 @@
       "mm": 123.7
     },
     "minFocusDistance": {
-      "cm": 17,
-      "variants": {
-        "wide": 17,
-        "tele": 105
+      "normal": {
+        "cm": 17,
+        "teleCm": 105
       }
     },
     "maxMagnification": {
@@ -7923,7 +8121,9 @@
       "mm": 92.6
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 0.101
@@ -8012,7 +8212,9 @@
       "mm": 118.2
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "maxMagnification": {
       "value": 0.21
@@ -8108,10 +8310,9 @@
       "mm": 76.8
     },
     "minFocusDistance": {
-      "cm": 12.1,
-      "variants": {
-        "wide": 12.1,
-        "tele": 30
+      "normal": {
+        "cm": 12.1,
+        "teleCm": 30
       }
     },
     "maxMagnification": {
@@ -8204,7 +8405,9 @@
       "mm": 79.2
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 0.137
@@ -8286,7 +8489,9 @@
       "mm": 73.6
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.143
@@ -8369,7 +8574,9 @@
       "mm": 59.8
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "maxMagnification": {
       "value": 0.135
@@ -8458,10 +8665,9 @@
       "mm": 199.5
     },
     "minFocusDistance": {
-      "cm": 112,
-      "variants": {
-        "wide": 112,
-        "tele": 160
+      "normal": {
+        "cm": 112,
+        "teleCm": 160
       }
     },
     "maxMagnification": {
@@ -8555,10 +8761,9 @@
       "mm": 86.5
     },
     "minFocusDistance": {
-      "cm": 15,
-      "variants": {
-        "wide": 15,
-        "tele": 24
+      "normal": {
+        "cm": 15,
+        "teleCm": 24
       }
     },
     "maxMagnification": {
@@ -8653,10 +8858,9 @@
       "mm": 119.6
     },
     "minFocusDistance": {
-      "cm": 19,
-      "variants": {
-        "wide": 19,
-        "tele": 39
+      "normal": {
+        "cm": 19,
+        "teleCm": 39
       }
     },
     "maxMagnification": {
@@ -8756,10 +8960,9 @@
       "mm": 125.8
     },
     "minFocusDistance": {
-      "cm": 15,
-      "variants": {
-        "wide": 15,
-        "tele": 99
+      "normal": {
+        "cm": 15,
+        "teleCm": 99
       }
     },
     "maxMagnification": {
@@ -8861,10 +9064,9 @@
       "mm": 209.9
     },
     "minFocusDistance": {
-      "cm": 60,
-      "variants": {
-        "wide": 60,
-        "tele": 180
+      "normal": {
+        "cm": 60,
+        "teleCm": 180
       }
     },
     "maxMagnification": {
@@ -8958,7 +9160,9 @@
       "mm": 58
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "angleOfView": 63,
     "angleOfViewCalc": 44,
@@ -9034,7 +9238,9 @@
       "mm": 150
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 2
@@ -9114,7 +9320,9 @@
       "mm": 31
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 92,
     "angleOfViewCalc": 90.6,
@@ -9189,7 +9397,9 @@
       "mm": 47
     },
     "minFocusDistance": {
-      "cm": 18
+      "normal": {
+        "cm": 18
+      }
     },
     "angleOfView": 81,
     "angleOfViewCalc": 79.5,
@@ -9261,7 +9471,9 @@
       "mm": 60
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "angleOfView": 62,
     "angleOfViewCalc": 63.2,
@@ -9340,7 +9552,9 @@
       "mm": 29
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 56,
     "angleOfViewCalc": 55.3,
@@ -9415,7 +9629,9 @@
       "mm": 49
     },
     "minFocusDistance": {
-      "cm": 40
+      "normal": {
+        "cm": 40
+      }
     },
     "angleOfView": 45,
     "angleOfViewCalc": 44,
@@ -9501,7 +9717,9 @@
       "mm": 62
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 28,
     "angleOfViewCalc": 28.4,
@@ -9587,7 +9805,9 @@
       "mm": 74
     },
     "minFocusDistance": {
-      "cm": 75
+      "normal": {
+        "cm": 75
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 21.4,
@@ -9667,7 +9887,9 @@
       "mm": 57
     },
     "minFocusDistance": {
-      "cm": 12.5
+      "normal": {
+        "cm": 12.5
+      }
     },
     "angleOfView": 180,
     "angleOfViewCalc": 124.1,
@@ -9746,7 +9968,9 @@
       "mm": 63
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 105,
     "angleOfViewCalc": 109.5,
@@ -9825,7 +10049,9 @@
       "mm": 40.5
     },
     "minFocusDistance": {
-      "cm": 20
+      "normal": {
+        "cm": 20
+      }
     },
     "angleOfView": 62,
     "angleOfViewCalc": 63.2,
@@ -9905,7 +10131,9 @@
       "mm": 31
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "angleOfView": 61,
     "angleOfViewCalc": 59,
@@ -9982,7 +10210,9 @@
       "mm": 41
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 45,
     "angleOfViewCalc": 44,
@@ -10055,7 +10285,9 @@
       "mm": 44
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "angleOfView": 45,
     "angleOfViewCalc": 44,
@@ -10131,7 +10363,9 @@
       "mm": 76
     },
     "minFocusDistance": {
-      "cm": 17
+      "normal": {
+        "cm": 17
+      }
     },
     "maxMagnification": {
       "value": 1
@@ -10208,7 +10442,9 @@
       "mm": 63
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -10277,7 +10513,9 @@
       "mm": 60
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 32,
     "angleOfViewCalc": 31.6,
@@ -10350,7 +10588,9 @@
       "mm": 68
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfView": 45,
     "angleOfViewCalc": 31.6,
@@ -10425,7 +10665,9 @@
       "mm": 63
     },
     "minFocusDistance": {
-      "cm": 35
+      "normal": {
+        "cm": 35
+      }
     },
     "angleOfView": 45,
     "angleOfViewCalc": 44,
@@ -10507,7 +10749,9 @@
       "mm": 150
     },
     "minFocusDistance": {
-      "cm": 25
+      "normal": {
+        "cm": 25
+      }
     },
     "maxMagnification": {
       "value": 2
@@ -10596,7 +10840,9 @@
       "mm": 56.7
     },
     "minFocusDistance": {
-      "cm": 13
+      "normal": {
+        "cm": 13
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -10663,7 +10909,9 @@
       "mm": 90
     },
     "minFocusDistance": {
-      "cm": 22
+      "normal": {
+        "cm": 22
+      }
     },
     "angleOfViewCalc": 94.9,
     "apertureBladeCount": 9,
@@ -10747,7 +10995,9 @@
       "mm": 56.7
     },
     "minFocusDistance": {
-      "cm": 23
+      "normal": {
+        "cm": 23
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -10814,7 +11064,9 @@
       "mm": 72
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -10898,7 +11150,9 @@
       "mm": 54.7
     },
     "minFocusDistance": {
-      "cm": 30
+      "normal": {
+        "cm": 30
+      }
     },
     "maxMagnification": {
       "value": 0.11
@@ -10963,7 +11217,9 @@
       "mm": 92
     },
     "minFocusDistance": {
-      "cm": 28
+      "normal": {
+        "cm": 28
+      }
     },
     "maxMagnification": {
       "value": 0.15
@@ -11036,7 +11292,9 @@
       "mm": 15.3
     },
     "minFocusDistance": {
-      "cm": 34
+      "normal": {
+        "cm": 34
+      }
     },
     "angleOfView": 52.07,
     "angleOfViewCalc": 53.6,
@@ -11107,7 +11365,9 @@
       "mm": 72
     },
     "minFocusDistance": {
-      "cm": 40
+      "normal": {
+        "cm": 40
+      }
     },
     "maxMagnification": {
       "value": 0.1
@@ -11175,7 +11435,9 @@
       "mm": 54.7
     },
     "minFocusDistance": {
-      "cm": 33
+      "normal": {
+        "cm": 33
+      }
     },
     "maxMagnification": {
       "value": 0.13
@@ -11242,7 +11504,9 @@
       "mm": 92
     },
     "minFocusDistance": {
-      "cm": 50
+      "normal": {
+        "cm": 50
+      }
     },
     "angleOfViewCalc": 28.4,
     "pricing": {
@@ -11314,7 +11578,9 @@
       "mm": 72
     },
     "minFocusDistance": {
-      "cm": 60
+      "normal": {
+        "cm": 60
+      }
     },
     "angleOfViewCalc": 28.4,
     "pricing": {
@@ -11378,7 +11644,9 @@
       "mm": 54.7
     },
     "minFocusDistance": {
-      "cm": 55
+      "normal": {
+        "cm": 55
+      }
     },
     "maxMagnification": {
       "value": 0.11
@@ -11444,7 +11712,9 @@
       "mm": 101
     },
     "minFocusDistance": {
-      "cm": 88
+      "normal": {
+        "cm": 88
+      }
     },
     "angleOfViewCalc": 21.4,
     "apertureBladeCount": 11,

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.10",
-  "lastUpdated": "2026-05-10T04:58:49.515Z",
+  "lastUpdated": "2026-05-10T11:00:50.136Z",
   "lensCount": 171,
-  "buildNumber": 2
+  "buildNumber": 3
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.10` build 3
- **X-mount lenses** (`lenses.json`): 152
- **G-mount lenses** (`lenses-g.json`): 19
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`