### PR TITLE
fix(feedback): assign generated issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ GITHUB_TOKEN=your_github_personal_access_token
 
 # The repo where feedback issues are created (format: owner/repo).
 GITHUB_FEEDBACK_REPO=owner/repo-name
+
+# Optional comma-separated GitHub usernames to assign to feedback issues.
+GITHUB_FEEDBACK_ASSIGNEES=your-github-username

--- a/src/app/api/feedback/__tests__/route.test.ts
+++ b/src/app/api/feedback/__tests__/route.test.ts
@@ -175,6 +175,34 @@ describe("POST /api/feedback — replyEmail", () => {
   });
 });
 
+describe("POST /api/feedback — assignees", () => {
+  beforeAll(() => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ number: 1 }), { status: 201 })
+    );
+  });
+
+  it("includes configured feedback assignees in the GitHub issue payload", async () => {
+    process.env.GITHUB_FEEDBACK_ASSIGNEES = "ericzeyuzhang, sentacraft";
+
+    await POST(makeRequest({ type: "general", description: "Great app!" }));
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { assignees: string[] };
+    expect(body.assignees).toEqual(["ericzeyuzhang", "sentacraft"]);
+
+    delete process.env.GITHUB_FEEDBACK_ASSIGNEES;
+  });
+
+  it("omits assignees when no feedback assignee is configured", async () => {
+    delete process.env.GITHUB_FEEDBACK_ASSIGNEES;
+
+    await POST(makeRequest({ type: "general", description: "Great app!" }));
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { assignees?: string[] };
+    expect(body.assignees).toBeUndefined();
+  });
+});
+
 describe("POST /api/feedback — type validation", () => {
   it("rejects an invalid type", async () => {
     const res = await POST(makeRequest({ type: "unknown", description: "Test" }));

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -49,6 +49,7 @@ function buildIssue(payload: FeedbackPayload): {
   title: string;
   body: string;
   labels: string[];
+  assignees?: string[];
 } {
   const { type, description, replyEmail, context } = payload;
   const lines: string[] = [];
@@ -101,8 +102,17 @@ function buildIssue(payload: FeedbackPayload): {
   }
 
   const labels = ["user-feedback", `feedback:${type}`];
+  const assignees = (process.env.GITHUB_FEEDBACK_ASSIGNEES ?? "")
+    .split(",")
+    .map((assignee) => assignee.trim())
+    .filter(Boolean);
 
-  return { title, body: lines.join("\n"), labels };
+  return {
+    title,
+    body: lines.join("\n"),
+    labels,
+    ...(assignees.length > 0 ? { assignees } : {}),
+  };
 }
 
 export async function POST(req: Request) {


### PR DESCRIPTION
## Summary

- Add optional `GITHUB_FEEDBACK_ASSIGNEES` support for feedback-created GitHub issues.
- Include configured assignees in the `/api/feedback` issue payload when present.
- Document the new environment variable and cover configured/unconfigured assignee behavior in route tests.

## Why

Feedback issues were created with title, body, and labels only. If the repo notification setup does not notify on every issue, those bot-created issues may never reach the maintainer unless the issue explicitly assigns or mentions them.

## Validation

- `npm test -- src/app/api/feedback/__tests__/route.test.ts`
- `npx eslint .env.example src/app/api/feedback/route.ts src/app/api/feedback/__tests__/route.test.ts` (passes for code files; `.env.example` is ignored by ESLint config)
- `npm run lint` was attempted, but the current branch has unrelated existing lint errors outside this PR scope.