### PR TITLE
feat(toast): show top-center on desktop, bottom-center on mobile

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -16,7 +16,7 @@ import { TestHookProvider } from "@/context/TestHookProvider";
 import { TESTHOOK_ALLOWED } from "@/lib/testhook";
 import { SITE } from "@/config/site";
 import { SPLASH_DEVICES, splashUrl, splashMedia } from "@/config/splash";
-import { Toaster } from "sonner";
+import AppToaster from "@/components/AppToaster";
 import { fontClassName } from "../fonts";
 import "../globals.css";
 
@@ -152,12 +152,7 @@ export default async function LocaleLayout({
             </ScrollContainerProvider>
           </CompareProvider>
           </MountPreferenceProvider>
-          <Toaster
-            position="bottom-center"
-            offset="calc(var(--compare-bar-height, 0px) + 16px)"
-            mobileOffset="calc(var(--compare-bar-height, 0px) + 16px)"
-            toastOptions={{ className: "whitespace-nowrap" }}
-          />
+          <AppToaster />
         </NextIntlClientProvider>
         <RegisterSW />
         <Analytics />

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Toaster } from "sonner";
+
+export default function AppToaster() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 639px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return (
+    <Toaster
+      position={isMobile ? "bottom-center" : "top-center"}
+      offset="calc(var(--compare-bar-height, 0px) + 16px)"
+      mobileOffset="calc(var(--compare-bar-height, 0px) + 16px)"
+      toastOptions={{ className: "whitespace-nowrap" }}
+    />
+  );
+}

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
+import { SCREEN } from "@/config/ui";
 
 export default function AppToaster() {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const mq = window.matchMedia("(max-width: 639px)");
+    const mq = window.matchMedia(`(max-width: ${SCREEN.sm - 1}px)`);
     setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener("change", handler);

--- a/src/components/CuratedPresetsButton.tsx
+++ b/src/components/CuratedPresetsButton.tsx
@@ -5,7 +5,7 @@ import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
 import { LayoutGrid } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Z } from "@/config/ui";
+import { Z, SCREEN } from "@/config/ui";
 import { curatedPresets } from "@/lib/curated-presets";
 import { PresetCard } from "@/components/CuratedComparisons";
 import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
@@ -18,7 +18,7 @@ export default function CuratedPresetsButton() {
 
   useEffect(() => {
     setMounted(true);
-    const mq = window.matchMedia("(min-width: 640px)");
+    const mq = window.matchMedia(`(min-width: ${SCREEN.sm}px)`);
     setIsDesktop(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -46,6 +46,19 @@ export const Z = {
   dialog:  "z-[60]",
 } as const;
 
+// ── Breakpoints ───────────────────────────────────────────────────────────────
+//
+// Mirror of Tailwind's default screen breakpoints, used for JS matchMedia calls.
+// If you change Tailwind's screens config, update these values to match.
+
+export const SCREEN = {
+  sm:  640,
+  md:  768,
+  lg:  1024,
+  xl:  1280,
+  "2xl": 1536,
+} as const;
+
 // ── Layout ────────────────────────────────────────────────────────────────────
 //
 // The layout's scroll container (ScrollContainerContext) owns the vertical

--- a/src/hooks/useShareCapabilities.ts
+++ b/src/hooks/useShareCapabilities.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { SCREEN } from "@/config/ui";
 
 export interface ShareCapabilities {
   mounted: boolean;
@@ -28,7 +29,7 @@ export function useShareCapabilities(): ShareCapabilities {
       );
     }
 
-    const mq = window.matchMedia("(min-width: 640px)");
+    const mq = window.matchMedia(`(min-width: ${SCREEN.sm}px)`);
     setIsDesktop(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);


### PR DESCRIPTION
## Summary

- Desktop (≥640px): toast now appears at `top-center`, animating downward — consistent with how Linear, Vercel, and other modern web apps position notifications, and avoids competing with the compare bar at the bottom.
- Mobile (<640px): toast remains at `bottom-center`, which is the platform convention for thumb-reachable feedback.

## What changed

Extracted the inline `<Toaster>` from `[locale]/layout.tsx` into a new `AppToaster` client component (`src/components/AppToaster.tsx`). On mount it listens to `matchMedia("(max-width: 639px)")` and passes either `"bottom-center"` or `"top-center"` to sonner's `position` prop. The compare-bar height offset logic (`--compare-bar-height`) is preserved unchanged.

Sonner v2 does not support a `mobilePosition` prop, so the client-side media query wrapper is the correct approach.

## Reviewer notes

- Breakpoint is `639px` (Tailwind `sm` — 640px), consistent with the rest of the codebase.
- No behavior change on mobile.
- The `offset` / `mobileOffset` props are kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)