### PR TITLE
feat(toast): top-center on desktop; css-only breakpoints via tailwind v4 vars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,6 +169,16 @@ details[open] > div {
 .wco-drag   { -webkit-app-region: drag;    app-region: drag;    }
 .wco-no-drag { -webkit-app-region: no-drag; app-region: no-drag; }
 
+/* On mobile, move the sonner toaster from top to bottom and respect the
+   compare bar height. The position prop stays "top-center" so we only need
+   to override the y-axis placement here. */
+@media (max-width: calc(theme(--breakpoint-sm) - 1px)) {
+  [data-sonner-toaster][data-y-position='top'] {
+    top: auto !important;
+    bottom: calc(var(--compare-bar-height, 0px) + 16px) !important;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -1,25 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Toaster } from "sonner";
-import { SCREEN } from "@/config/ui";
 
 export default function AppToaster() {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${SCREEN.sm - 1}px)`);
-    setIsMobile(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-
   return (
     <Toaster
-      position={isMobile ? "bottom-center" : "top-center"}
-      offset="calc(var(--compare-bar-height, 0px) + 16px)"
-      mobileOffset="calc(var(--compare-bar-height, 0px) + 16px)"
+      position="top-center"
+      offset={16}
       toastOptions={{ className: "whitespace-nowrap" }}
     />
   );

--- a/src/components/CuratedPresetsButton.tsx
+++ b/src/components/CuratedPresetsButton.tsx
@@ -8,22 +8,17 @@ import { useTranslations } from "next-intl";
 import { Z } from "@/config/ui";
 import { curatedPresets } from "@/lib/curated-presets";
 import { PresetCard } from "@/components/CuratedComparisons";
+import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
 
 export default function CuratedPresetsButton() {
   const t = useTranslations("Compare");
   const [open, setOpen] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(true);
   const [mounted, setMounted] = useState(false);
+  const isDesktop = useBreakpoint("sm");
 
   useEffect(() => {
     setMounted(true);
-    const bp = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-sm").trim();
-    const mq = window.matchMedia(`(min-width: ${bp})`);
-    setIsDesktop(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
   }, []);
 
   const trigger = (

--- a/src/components/CuratedPresetsButton.tsx
+++ b/src/components/CuratedPresetsButton.tsx
@@ -5,7 +5,7 @@ import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
 import { LayoutGrid } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Z, SCREEN } from "@/config/ui";
+import { Z } from "@/config/ui";
 import { curatedPresets } from "@/lib/curated-presets";
 import { PresetCard } from "@/components/CuratedComparisons";
 import { ICON_NAV_BTN_CLS } from "@/lib/ui-tokens";
@@ -18,7 +18,8 @@ export default function CuratedPresetsButton() {
 
   useEffect(() => {
     setMounted(true);
-    const mq = window.matchMedia(`(min-width: ${SCREEN.sm}px)`);
+    const bp = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-sm").trim();
+    const mq = window.matchMedia(`(min-width: ${bp})`);
     setIsDesktop(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -214,7 +214,7 @@ export default function LensListClient({ lenses }: Props) {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.18, ease: "easeOut" }}
-              className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+              className="grid grid-cols-1 gap-4 min-[500px]:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
             >
               {displayed.map((lens, i) => (
                 <LensCard

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -1,4 +1,4 @@
-// UI constants — z-index layers and layout breakpoints.
+// UI constants — z-index layers.
 // Animation params that belong to a specific component live in that
 // component's config (e.g. Iris animation params are in IrisConfig in brand.ts).
 
@@ -44,19 +44,6 @@ export const Z = {
   fixed:   "z-40",
   overlay: "z-50",
   dialog:  "z-[60]",
-} as const;
-
-// ── Breakpoints ───────────────────────────────────────────────────────────────
-//
-// Mirror of Tailwind's default screen breakpoints, used for JS matchMedia calls.
-// If you change Tailwind's screens config, update these values to match.
-
-export const SCREEN = {
-  sm:  640,
-  md:  768,
-  lg:  1024,
-  xl:  1280,
-  "2xl": 1536,
 } as const;
 
 // ── Layout ────────────────────────────────────────────────────────────────────

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Tailwind v4 exposes every @theme breakpoint as a CSS custom property
+// (e.g. --breakpoint-sm: 40rem) on :root, so Tailwind's config stays the
+// single source of truth for both CSS and JS.
+type Breakpoint = "sm" | "md" | "lg" | "xl" | "2xl";
+
+/**
+ * Returns whether the viewport is at least as wide as the given Tailwind
+ * breakpoint. Reads the value from Tailwind's auto-injected --breakpoint-*
+ * CSS variable, so changing the Tailwind theme propagates automatically.
+ *
+ * Note: this is a viewport check, not a device check. A desktop browser
+ * resized to 400px will read as below `sm`.
+ */
+export function useBreakpoint(bp: Breakpoint): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const value = getComputedStyle(document.documentElement)
+      .getPropertyValue(`--breakpoint-${bp}`)
+      .trim();
+    if (!value) return;
+    const mq = window.matchMedia(`(min-width: ${value})`);
+    setMatches(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [bp]);
+
+  return matches;
+}

--- a/src/hooks/useShareCapabilities.ts
+++ b/src/hooks/useShareCapabilities.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { SCREEN } from "@/config/ui";
 
 export interface ShareCapabilities {
   mounted: boolean;
@@ -29,7 +28,8 @@ export function useShareCapabilities(): ShareCapabilities {
       );
     }
 
-    const mq = window.matchMedia(`(min-width: ${SCREEN.sm}px)`);
+    const bp = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-sm").trim();
+    const mq = window.matchMedia(`(min-width: ${bp})`);
     setIsDesktop(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);

--- a/src/hooks/useShareCapabilities.ts
+++ b/src/hooks/useShareCapabilities.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useBreakpoint } from "@/hooks/useBreakpoint";
 
 export interface ShareCapabilities {
   mounted: boolean;
@@ -11,9 +12,9 @@ export interface ShareCapabilities {
 
 export function useShareCapabilities(): ShareCapabilities {
   const [mounted, setMounted] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(true);
   const [canNativeShare, setCanNativeShare] = useState(false);
   const [canShareFile, setCanShareFile] = useState(false);
+  const isDesktop = useBreakpoint("sm");
 
   useEffect(() => {
     setMounted(true);
@@ -27,13 +28,6 @@ export function useShareCapabilities(): ShareCapabilities {
         })
       );
     }
-
-    const bp = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-sm").trim();
-    const mq = window.matchMedia(`(min-width: ${bp})`);
-    setIsDesktop(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
   }, []);
 
   return { mounted, isDesktop, canNativeShare, canShareFile };


### PR DESCRIPTION
## Summary

- Toast shows `top-center` on desktop and `bottom-center` on mobile — no JS detection, position switching is pure CSS via a `@media` override in `globals.css`.
- Removed the manual `SCREEN` breakpoint constant; JS `matchMedia` call sites now read `--breakpoint-sm` directly from Tailwind v4's auto-generated CSS variables, so Tailwind is the single source of truth.
- Lens list grid adds `md:grid-cols-3` to prevent cards from growing too wide (~480px) on 768–1023px viewports.

## What changed

| File | Change |
|---|---|
| `AppToaster.tsx` | Simplified to a static `<Toaster position="top-center" />` — no `useState`/`useEffect` |
| `globals.css` | Added `@media (max-width: calc(theme(--breakpoint-sm) - 1px))` to override toaster to bottom on mobile, using `--compare-bar-height` for compare bar clearance |
| `ui.ts` | Removed `SCREEN` constant (was a manual copy of Tailwind's breakpoints) |
| `CuratedPresetsButton.tsx`, `useShareCapabilities.ts` | Read `--breakpoint-sm` CSS var via `getComputedStyle` instead of hardcoded `640` |
| `LensListClient.tsx` | `lg:grid-cols-3` → `md:grid-cols-3`; max card width at tablet drops from ~480px to ~280px |

## Reviewer notes

- Tailwind v4 automatically injects `--breakpoint-sm: 40rem` (and other breakpoints) into `:root`. No third-party library needed.
- Sonner's own mobile breakpoint is 600px; our CSS override targets 639px (Tailwind `sm - 1`) to stay consistent with the rest of the app.
- Toast animation on mobile will be "enter from above" (top-style) rather than "enter from below" — this is a known trade-off of the CSS-only approach and is imperceptible given toast duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)