### PR TITLE
fix(api): unbreak /api/feedback on Cloudflare Workers

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 
-export const runtime = "edge";
-
 type FeedbackType = "data_issue" | "general";
 
 interface FeedbackPayload {
@@ -115,6 +113,22 @@ function buildIssue(payload: FeedbackPayload): {
     labels,
     ...(assignees.length > 0 ? { assignees } : {}),
   };
+}
+
+// Health probe. Reports whether required env vars are wired up in the
+// current runtime, without leaking values — names are already in source.
+export function GET() {
+  const hasToken = Boolean(process.env.GITHUB_TOKEN);
+  const hasRepo = Boolean(process.env.GITHUB_FEEDBACK_REPO);
+  const missingEnv = [
+    ...(hasToken ? [] : ["GITHUB_TOKEN"]),
+    ...(hasRepo ? [] : ["GITHUB_FEEDBACK_REPO"]),
+  ];
+  return NextResponse.json({
+    ok: true,
+    ready: missingEnv.length === 0,
+    missingEnv,
+  });
 }
 
 export async function POST(req: Request) {


### PR DESCRIPTION
## Summary

- Remove `export const runtime = "edge"` from `/api/feedback/route.ts`. On `@opennextjs/cloudflare` the edge build path is not fully wired through the worker shim, so every request to the route returns plaintext `500 Internal Server Error` before the handler runs. Falling back to the default runtime lets the route execute on Workers via `nodejs_compat`; on Vercel it just runs as a Node serverless function.
- Add `GET /api/feedback` that returns `{ ok, ready, missingEnv }` for manual probing. Only boolean readiness is exposed — values are never returned.

## Test plan

- [ ] After merge, `curl https://xglass-cf.sentacraft.com/api/feedback` returns `{"ok":true,"ready":true,"missingEnv":[]}`.
- [ ] Submit a real feedback from the site UI — expect `{"ok":true}` and a new issue in the configured `GITHUB_FEEDBACK_REPO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)