### PR TITLE
refactor(pricing): replace price tier with real price and clearer disclaimer

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -238,15 +238,17 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
       {/* Header: image + key info side by side */}
       <div className="flex flex-col sm:flex-row gap-8">
-        {/* Image */}
-        <div className="w-full max-w-56 mx-auto sm:mx-0 shrink-0 sm:w-56">
+        {/* Image — 288px so the 1:1 card height matches (or slightly exceeds)
+            the info column, letting mt-auto on the buttons row push them
+            cleanly to the image's bottom edge. */}
+        <div className="w-full max-w-72 mx-auto sm:mx-0 shrink-0 sm:w-72">
           <div className="flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-zinc-100 bg-zinc-50/70 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
             <div className="relative aspect-square w-full overflow-hidden">
               <Image
                 src={getLensImageUrl(lens.id)}
                 alt={lens.model}
                 fill
-                sizes="224px"
+                sizes="288px"
                 style={lensImageStyle}
                 className="object-contain"
                 priority
@@ -270,8 +272,9 @@ export default async function LensDetailPage({ params }: { params: Params }) {
           {/* Price */}
           <PriceSection lens={lens} />
 
-          {/* Actions */}
-          <div className="flex flex-wrap gap-3 mt-3">
+          {/* Actions — mt-auto pushes them to the bottom of the stretched
+              info column so the row aligns with the image card's bottom. */}
+          <div className="flex flex-wrap gap-3 mt-auto">
             <AddToCompareButton lensId={lens.id} />
             {url ? (
               <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -28,7 +28,7 @@ import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
 import { buildSpecGroups, resolveSpecRow } from "@/lib/lens-spec-groups";
 import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens-spec-groups";
 import type { Lens } from "@/lib/types";
-import { PriceBand } from "@/components/PriceBand";
+import { PriceCell } from "@/components/PriceCell";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
 
@@ -635,7 +635,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                   return (
                     <td key={lens.id} className="px-3 py-3">
                       <div className="flex justify-center">
-                        <PriceBand lens={lens} compact />
+                        <PriceCell lens={lens} compact />
                       </div>
                     </td>
                   );

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -12,7 +12,7 @@ import { usePwa } from "@/lib/usePwa";
 import Image from "next/image";
 import { ExternalLink } from "@/components/ui/external-link";
 import { useTranslations, useLocale } from "next-intl";
-import { ChevronLeft, ChevronRight, Flag, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flag, TriangleAlert, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ICON_CLOSE_BTN_CLS, TEXT_LINK_CLS } from "@/lib/ui-tokens";
 import { BoolCell } from "@/components/ui/bool-cell";
@@ -595,8 +595,11 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
             </React.Fragment>
           ))}
 
-          {/* Pricing group — shown when at least one lens has pricing data */}
-          {orderedLenses.length > 0 && orderedLenses.some(l => pickPriceEntry(l.pricing, locale) !== null) && (
+          {/* Pricing group — shown when at least one lens has pricing data.
+              Disclaimer rows are rendered OUTSIDE the scrollable table so
+              they wrap within viewport width instead of being clipped by the
+              horizontal overflow container. */}
+          {orderedLenses.length > 0 && orderedLenses.some((l) => pickPriceEntry(l.pricing, locale) !== null) && (
             <React.Fragment>
               <tr className="border-b border-zinc-100 bg-zinc-100/80 dark:border-zinc-800/60 dark:bg-zinc-800/60">
                 <td colSpan={totalColSpan} className="h-8 text-center">
@@ -606,11 +609,19 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 </td>
               </tr>
               <tr className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
-                <td className="sticky left-0 z-10 px-3 py-3 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-50 dark:bg-zinc-900 break-words">
-                  <span className="inline-flex items-center justify-end gap-1">
-                    <FieldNotePopover note={tPricing("tierNote")} variant="warning" />
-                    {tPricing("fieldLabel")}
-                  </span>
+                <td className="sticky left-0 z-10 px-3 py-3 bg-zinc-50 dark:bg-zinc-900 break-words align-top">
+                  {/* Two-line label: row name on top, single action-oriented
+                      warn below. Compact enough to avoid orphan characters
+                      even in the narrow (6rem) sticky label column. */}
+                  <div className="flex flex-col items-end gap-0.5 text-right">
+                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                      {tPricing("rowLabel")}
+                    </span>
+                    <span className="text-[11px] leading-tight text-amber-600 dark:text-amber-400">
+                      <TriangleAlert className="inline-block align-[-0.125em] size-3 mr-0.5" aria-hidden="true" />
+                      {tPricing("rowWarn")}
+                    </span>
+                  </div>
                 </td>
                 {orderedLenses.map((lens) => {
                   const sel = pickPriceEntry(lens.pricing, locale);

--- a/src/components/PriceBand.tsx
+++ b/src/components/PriceBand.tsx
@@ -1,86 +1,22 @@
 "use client";
 
+// Per-lens price cell used in the compare table.
+//
+// Shows the real captured price, optional Used badge (clickable — explains
+// why a used reference was picked), and persistent source · sampled-date
+// caption below. The unified disclaimer for the whole pricing column lives
+// next to the "Price" field label on the left, not repeated per cell.
+
 import { Popover } from "@base-ui/react/popover";
+import { Calendar, Info } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
-import { priceTier } from "@/lib/lens";
 import {
   pickPriceEntry,
   formatPrice,
-  formatTierRange,
   formatSampledAt,
-  type PriceSelection,
 } from "@/lib/lens-pricing";
 import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
-
-// Popover anchored to the tier symbols showing per-lens price details.
-function TierPopover({
-  selection,
-  locale,
-  tier,
-  compact,
-  symbol,
-}: {
-  selection: PriceSelection;
-  locale: string;
-  tier: 1 | 2 | 3 | 4 | 5;
-  compact: boolean;
-  symbol: string;
-}) {
-  const t = useTranslations("Pricing");
-  const { entry, condition } = selection;
-  const isUsed = condition === "used";
-  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
-  const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
-
-  return (
-    <Popover.Root>
-      <Popover.Trigger
-        className={cn(
-          "cursor-pointer rounded-sm decoration-zinc-300 decoration-dashed underline-offset-4 outline-none transition-colors hover:decoration-zinc-500 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:decoration-zinc-600 dark:hover:decoration-zinc-400",
-          "underline",
-        )}
-      >
-        <span
-          className={cn(
-            "font-semibold tabular-nums tracking-wide",
-            compact ? "text-sm" : "text-base",
-            "text-zinc-700 dark:text-zinc-200"
-          )}
-          aria-hidden="true"
-        >
-          {symbol.repeat(tier)}
-        </span>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Positioner side="top" align="center" sideOffset={6}>
-          <Popover.Popup className="max-w-64 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2.5 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-            <div className="flex flex-col gap-1">
-              <p className="flex items-center gap-1.5 text-sm font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
-                {priceDisplay}
-                {isUsed && (
-                  <span className="inline-flex items-center rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                    {t("usedBadge")}
-                  </span>
-                )}
-              </p>
-              <p className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                {entry.source}
-                <span className="mx-1 opacity-30">|</span>
-                {t("sampledAt", { date: sampledDisplay })}
-              </p>
-              {isUsed && (
-                <p className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                  {t("usedReason")}
-                </p>
-              )}
-            </div>
-          </Popover.Popup>
-        </Popover.Positioner>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}
 
 interface Props {
   lens: Lens;
@@ -97,36 +33,52 @@ export function PriceBand({ lens, compact = false }: Props) {
   }
 
   const { entry, condition } = selection;
-  const tier = priceTier(entry.price, entry.currency);
-  if (tier === undefined) {
-    return null;
-  }
   const isUsed = condition === "used";
-  const symbol = t("tierSymbol");
-  const rangeDisplay = formatTierRange(tier, entry.currency, locale);
+  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t.raw("cnyAmount"));
+  const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
   return (
-    <div className="flex flex-col items-center gap-0.5">
+    <div className="flex flex-col items-center gap-1 text-center">
+      {/* Row 1: price + (optional) Used badge with info popover */}
       <div className="inline-flex items-center gap-1.5">
-        <TierPopover
-          selection={selection}
-          locale={locale}
-          tier={tier}
-          compact={compact}
-          symbol={symbol}
-        />
+        <span
+          className={cn(
+            "font-semibold tabular-nums text-zinc-700 dark:text-zinc-200",
+            compact ? "text-sm" : "text-base",
+          )}
+        >
+          {priceDisplay}
+        </span>
         {isUsed && (
-          <span className="inline-flex shrink-0 items-center rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-            {t("usedBadge")}
-          </span>
+          <Popover.Root>
+            <Popover.Trigger
+              className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+            >
+              <span>{t("usedBadge")}</span>
+              <Info className="size-2.5 opacity-70" aria-hidden="true" />
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Positioner side="top" align="center" sideOffset={6}>
+                <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                  {t("usedReason")}
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
         )}
       </div>
-      {/* Range subtext */}
-      <p className="tabular-nums text-[11px] text-zinc-400 dark:text-zinc-500">
-        {entry.currency === "CNY"
-          ? t("cnyAmount", { value: rangeDisplay })
-          : `$${rangeDisplay}`}
-      </p>
+
+      {/* Row 2: source — persistent caption */}
+      <span className="text-[10px] leading-tight text-zinc-400 dark:text-zinc-500 break-words">
+        {entry.source}
+      </span>
+
+      {/* Row 3: sampled date — persistent caption with calendar icon so the
+          row reads as data not prose. */}
+      <span className="inline-flex items-center gap-1 text-[10px] leading-tight text-zinc-400 dark:text-zinc-500 tabular-nums">
+        <Calendar className="size-2.5" aria-hidden="true" />
+        {sampledDisplay}
+      </span>
     </div>
   );
 }

--- a/src/components/PriceCell.tsx
+++ b/src/components/PriceCell.tsx
@@ -23,7 +23,7 @@ interface Props {
   compact?: boolean;
 }
 
-export function PriceBand({ lens, compact = false }: Props) {
+export function PriceCell({ lens, compact = false }: Props) {
   const t = useTranslations("Pricing");
   const locale = useLocale();
   const selection = pickPriceEntry(lens.pricing, locale);

--- a/src/components/PriceDisclaimer.tsx
+++ b/src/components/PriceDisclaimer.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// Inline price disclaimer block.
+//
+// Reads as one continuous paragraph: a sentence-style lead (e.g. "市场
+// 行情，仅供参考。") in amber, followed by the body in the zinc caption
+// color — no middle-dot separator, just whitespace, so the two pieces
+// flow as a single statement.
+
+import { TriangleAlert } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  PRICE_DISCLAIMER_BODY_CLS,
+  PRICE_DISCLAIMER_ICON_CLS,
+  PRICE_DISCLAIMER_WARN_CLS,
+} from "@/lib/ui-tokens";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** Tighter text for compact contexts (compare table footer, poster). */
+  compact?: boolean;
+  className?: string;
+}
+
+export function PriceDisclaimer({ compact = false, className }: Props) {
+  const t = useTranslations("Pricing");
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-1.5 leading-relaxed",
+        compact ? "text-[11px]" : "text-xs",
+        className,
+      )}
+    >
+      <TriangleAlert
+        className={cn(PRICE_DISCLAIMER_ICON_CLS, compact ? "size-3 mt-px" : "size-3.5 mt-px")}
+        aria-hidden="true"
+      />
+      <span className={PRICE_DISCLAIMER_BODY_CLS}>
+        <span className={PRICE_DISCLAIMER_WARN_CLS}>{t("disclaimerLead")}</span>
+        {" "}
+        {t("disclaimerBody")}
+      </span>
+    </div>
+  );
+}

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -2,24 +2,24 @@
 
 // Expanded price display for the lens detail page.
 //
-// Layout:
-//   $139  [Used]  ⚠ For reference only
-//   source | Sampled date
+// Layout (visually bound as a single "price info" card):
+//   ¥1,299  [Used ⓘ]   ← Used badge is clickable; explains why used was picked
+//   source · Sampled date
+//   ⚠ 仅供参考 · …
 //
-// The ⚠ disclaimer opens a popover with the full note.
-// The tier/range is intentionally omitted — on the detail page the exact
-// price is visible, so the range adds no information.
+// All three rows share a soft background so the disclaimer is
+// unambiguously about THIS price, not the spec table that follows below.
 
 import { Popover } from "@base-ui/react/popover";
-import { TriangleAlert } from "lucide-react";
+import { Calendar, Info } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
-import { priceTier } from "@/lib/lens";
 import {
   pickPriceEntry,
   formatPrice,
   formatSampledAt,
 } from "@/lib/lens-pricing";
 import type { Lens } from "@/lib/types";
+import { PriceDisclaimer } from "@/components/PriceDisclaimer";
 
 interface Props {
   lens: Lens;
@@ -35,52 +35,66 @@ export function PriceSection({ lens }: Props) {
   }
 
   const { entry, condition } = selection;
-  const tier = priceTier(entry.price, entry.currency);
-  if (tier === undefined) {
-    return null;
-  }
-
   const isUsed = condition === "used";
 
-  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t);
+  const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t.raw("cnyAmount"));
   const sourceDisplay = entry.source;
   const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
   return (
+    // No background card — the price block is bound visually by tight inner
+    // gaps (gap-1) while the outer column's gap-5 separates it from title
+    // above and action buttons below. This trades the card's explicit
+    // "unit" boundary for clean left alignment of every text line with the
+    // title and buttons.
     <div className="flex flex-col gap-1">
-      {/* Row 1: Price + used badge + disclaimer */}
+      {/* Row 1: Price + used badge (clickable when used) */}
       <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
         <span className="text-xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
           {priceDisplay}
         </span>
-        {isUsed && (
-          <span className="inline-flex items-center rounded bg-zinc-200/70 px-1.5 py-px text-[11px] font-medium text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
-            {t("conditionUsed")}
-          </span>
-        )}
-        <Popover.Root>
-          <Popover.Trigger
-            className="inline-flex shrink-0 items-center gap-1 rounded-sm text-[11px] text-amber-500 outline-none transition-colors hover:text-amber-600 focus-visible:ring-2 focus-visible:ring-amber-400 dark:text-amber-400 dark:hover:text-amber-300"
-          >
-            <TriangleAlert className="size-3" />
-            <span>{t("disclaimerTrigger")}</span>
-          </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner side="top" align="center" sideOffset={6}>
-              <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                {isUsed ? t("detailUsedNote") : t("detailNewNote")}
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>
+        {isUsed && <UsedBadge size="md" reason={t("usedReason")} label={t("conditionUsed")} />}
       </div>
 
-      {/* Row 2: Source + sampled date */}
-      <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-        {sourceDisplay}
-        <span className="mx-1.5 opacity-30">|</span>
-        {t("sampledAt", { date: sampledDisplay })}
+      {/* Row 2: Source + sampled date — calendar icon makes the date read
+          as data, not prose. */}
+      <div className="inline-flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
+        <span>{sourceDisplay}</span>
+        <span className="opacity-30">|</span>
+        <span className="inline-flex items-center gap-1 tabular-nums">
+          <Calendar className="size-3" aria-hidden="true" />
+          {sampledDisplay}
+        </span>
       </div>
+
+      {/* Row 3: Inline disclaimer */}
+      <PriceDisclaimer className="mt-0.5" />
     </div>
+  );
+}
+
+// Inline-defined so the click affordance (cursor + hover background + trailing
+// info icon) stays paired with the badge's visual treatment. If a second
+// surface ever needs the same clickable badge, hoist this to its own file.
+function UsedBadge({ size, reason, label }: { size: "sm" | "md"; reason: string; label: string }) {
+  const padding = size === "md" ? "px-1.5 py-px" : "px-1 py-px";
+  const fontSize = size === "md" ? "text-[11px]" : "text-[10px]";
+  const iconSize = size === "md" ? "size-3" : "size-2.5";
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        className={`inline-flex cursor-pointer items-center gap-1 rounded ${padding} ${fontSize} font-medium text-zinc-500 outline-none transition-colors bg-zinc-200/70 hover:bg-zinc-300/70 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-600 dark:focus-visible:ring-zinc-500`}
+      >
+        <span>{label}</span>
+        <Info className={`${iconSize} opacity-70`} aria-hidden="true" />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner side="top" align="center" sideOffset={6}>
+          <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+            {reason}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -8,8 +8,9 @@ import { FEATURE_ICONS } from "@/lib/feature-icons";
 import type { Lens } from "@/lib/types";
 import { Weight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { classifyFocusMotor, priceTier } from "@/lib/lens";
-import { pickPriceEntry, formatTierRange } from "@/lib/lens-pricing";
+import { TriangleAlert } from "lucide-react";
+import { classifyFocusMotor } from "@/lib/lens";
+import { pickPriceEntry, formatPrice, formatSampledAt } from "@/lib/lens-pricing";
 import { getLensImageUrl } from "@/lib/lens-image";
 import {
   filterSizeDisplay,
@@ -76,8 +77,13 @@ export interface PosterLabels {
   tagProbe: string;
   // Pricing
   priceLabel: string;
-  tierSymbol: string;
   usedBadge: string;
+  /** CNY display template, e.g. "{value} 元" or "¥{value}". {value} is replaced with the formatted number. */
+  cnyAmount: string;
+  /** Sampled-date template, e.g. "采样于 {date}" / "Sampled {date}". */
+  sampledAt: string;
+  /** Short warn label rendered under each price, e.g. "仅供参考" / "Indicative price". */
+  disclaimerWarn: string;
   // Fallback
   na: string;
   // Locale hint for formatting
@@ -570,9 +576,13 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
           ))}
         </div>
 
-        {/* Row 3: Price tier */}
+        {/* Row 3: Price column — value (+Used badge) / source · date / ⚠ warn.
+            The warn line sits BELOW the value (not above) so it doesn't
+            occupy the field-name slot used by other hero stats (focal,
+            aperture). Each column carries its own warn line — repetition is
+            intentional: every price independently needs the caveat. */}
         {showPrice && (
-          <div style={{ ...gridStyle(n), marginTop: 16 }}>
+          <div style={{ ...gridStyle(n), marginTop: 32 }}>
             {lenses.map((lens, i) => {
               const sel = priceSelections[i];
               if (!sel) {
@@ -582,24 +592,21 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                   </div>
                 );
               }
-              const tier = priceTier(sel.entry.price, sel.entry.currency);
-              if (tier === undefined) {
-                return (
-                  <div key={i} style={{ display: "flex", justifyContent: "center" }}>
-                    <span className="text-zinc-300" style={{ fontSize: 9 }}>—</span>
-                  </div>
-                );
-              }
-              const rangeDisplay = formatTierRange(tier, sel.entry.currency, labels.locale);
-              const rangeFormatted = sel.entry.currency === "CNY"
-                ? `¥${rangeDisplay}`
-                : `$${rangeDisplay}`;
               const isUsed = sel.condition === "used";
+              const priceDisplay = formatPrice(
+                sel.entry.price,
+                sel.entry.currency,
+                labels.locale,
+                sel.condition,
+                labels.cnyAmount,
+              );
+              const sampledDisplay = formatSampledAt(sel.entry.sampledAt, labels.locale);
               return (
-                <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}>
+                <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+                  {/* Value + Used badge */}
                   <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
-                    <span className={cn("font-semibold tabular-nums tracking-wide text-zinc-700 leading-none", statSize)}>
-                      {labels.tierSymbol.repeat(tier)}
+                    <span className={cn("font-semibold tabular-nums text-zinc-700 leading-none", statSize)}>
+                      {priceDisplay}
                     </span>
                     {isUsed && (
                       <span className="rounded bg-zinc-200 px-1 py-px text-zinc-500" style={{ fontSize: 8, fontWeight: 500 }}>
@@ -607,8 +614,18 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                       </span>
                     )}
                   </span>
-                  <span className="tabular-nums text-zinc-400" style={{ fontSize: 10 }}>
-                    {rangeFormatted}
+                  {/* Caption row 1: source */}
+                  <span className="tabular-nums text-zinc-400 leading-tight text-center" style={{ fontSize: 9, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {sel.entry.source}
+                  </span>
+                  {/* Caption row 2: sampled date */}
+                  <span className="tabular-nums text-zinc-400 leading-tight" style={{ fontSize: 9 }}>
+                    {labels.sampledAt.replace("{date}", sampledDisplay)}
+                  </span>
+                  {/* Caption row 3: ⚠ warn (amber, slightly bolder) */}
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 3, color: "#d97706", fontSize: 9, fontWeight: 600 }}>
+                    <TriangleAlert size={9} />
+                    {labels.disclaimerWarn}
                   </span>
                 </div>
               );

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -54,6 +54,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   const locale = useLocale();
   const tImage = useTranslations("ShareImage");
   const tBrand = useTranslations("Brands");
+  const tPricing = useTranslations("Pricing");
 
   const { mounted, isDesktop, canNativeShare, canShareFile } = useShareCapabilities();
 
@@ -122,8 +123,10 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     tagProbe: tImage("tagProbe"),
     na: tImage("na"),
     priceLabel: tImage("priceLabel"),
-    tierSymbol: tImage("tierSymbol"),
     usedBadge: tImage("usedBadge"),
+    cnyAmount: tPricing.raw("cnyAmount"),
+    sampledAt: tPricing.raw("sampledAt"),
+    disclaimerWarn: tPricing("disclaimerWarn"),
     locale,
   };
 

--- a/src/lib/lens-pricing.ts
+++ b/src/lib/lens-pricing.ts
@@ -14,8 +14,11 @@ type PricingData = { cn?: PricingBucket; global?: PricingBucket };
 
 // Translator is loosely typed so callers can pass next-intl's `t` function from
 // either useTranslations (client) or getTranslations (server) without coupling
-// this module to next-intl.
-type Translator = (key: string, values?: Record<string, string | number>) => string;
+// this module to next-intl. `raw(key)` returns the unprocessed message string
+// — used to fetch ICU templates we want to substitute manually.
+type Translator = ((key: string, values?: Record<string, string | number>) => string) & {
+  raw: (key: string) => string;
+};
 
 // Maps app locale → BCP-47 tag for Intl APIs. Project locales are always
 // {zh, en}; fall back to en-US for any unexpected value.
@@ -44,52 +47,28 @@ export function pickPriceEntry(
   return null;
 }
 
-export const CNY_THRESHOLDS: readonly number[] = [0, 500, 1500, 5000, 15000];
-export const USD_THRESHOLDS: readonly number[] = [0, 150, 400, 800, 1500];
-
-export function tierRange(
-  tier: 1 | 2 | 3 | 4 | 5,
-  currency: "CNY" | "USD"
-): { min: number; max: number | null } {
-  const thresholds = currency === "CNY" ? CNY_THRESHOLDS : USD_THRESHOLDS;
-  const min = thresholds[tier - 1];
-  const max = tier < 5 ? thresholds[tier] - 1 : null;
-  return { min, max };
-}
-
-// Numeric-only range, no currency symbol — the caller pairs it with $$$ / ¥¥¥.
-// Examples: "1,500–4,999", "15,000+"
-export function formatTierRange(
-  tier: 1 | 2 | 3 | 4 | 5,
-  currency: "CNY" | "USD",
-  locale: string
-): string {
-  const { min, max } = tierRange(tier, currency);
-  if (max === null) {
-    return `${formatNumber(min, locale)}+`;
-  }
-  return `${formatNumber(min, locale)}–${formatNumber(max, locale)}`;
-}
-
 export function formatPrice(
   price: number,
   currency: "CNY" | "USD",
   locale: string,
-  condition: Condition,
-  t: Translator
+  // Unused; retained for callsite API stability. Both new and used prices
+  // render as bare numbers (no ~ prefix). The visual "Used" indication is
+  // handled by a separate badge component, not by mutating the number.
+  _condition: Condition,
+  // CNY display template, e.g. "{value} 元" (zh) or "¥{value}" (en). Pass the
+  // resolved i18n value (`t.raw("cnyAmount")` or `labels.cnyAmount` for the
+  // props-driven SharePoster). The {value} placeholder is replaced with the
+  // locale-formatted number.
+  cnyTemplate: string
 ): string {
-  let formatted: string;
   if (currency === "CNY") {
-    // CNY display template lives in i18n: "{value} 元" in zh, "¥{value}" in en.
-    formatted = t("cnyAmount", { value: formatNumber(price, locale) });
-  } else {
-    formatted = new Intl.NumberFormat(intlLocaleFor(locale), {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 0,
-    }).format(price);
+    return cnyTemplate.replace("{value}", formatNumber(price, locale));
   }
-  return condition === "used" ? `~${formatted}` : formatted;
+  return new Intl.NumberFormat(intlLocaleFor(locale), {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(price);
 }
 
 export function formatSampledAt(date: string, locale: string): string {
@@ -108,7 +87,7 @@ export function formatPriceForReport(
   t: Translator
 ): string {
   const { entry, condition } = selection;
-  const price = formatPrice(entry.price, entry.currency, locale, condition, t);
+  const price = formatPrice(entry.price, entry.currency, locale, condition, t.raw("cnyAmount"));
   const conditionLabel = t(condition === "new" ? "conditionNew" : "conditionUsed");
   return `${price} · ${entry.source} · ${entry.sampledAt} · ${conditionLabel}`;
 }

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -3,7 +3,6 @@ import gfxLensesData from "../data/lenses-g.json";
 import metaData from "../data/meta.json";
 import { lensCatalogSchema } from "./lens-schema";
 import { resolveTranslations, type Lens, type LensCatalog, type Mount, type SpecialtyTag } from "./types";
-import { CNY_THRESHOLDS, USD_THRESHOLDS } from "./lens-pricing";
 export type { SpecialtyTag };
 
 const xLenses: Lens[] = lensCatalogSchema.parse(lensesData) as LensCatalog;
@@ -292,16 +291,6 @@ export function sortLenses(
     const delta = (a[field] as number) - (b[field] as number);
     return dir === "asc" ? delta : -delta;
   });
-}
-
-export function priceTier(price: number, currency: "CNY" | "USD"): 1 | 2 | 3 | 4 | 5 | undefined {
-  const thresholds = currency === "CNY" ? CNY_THRESHOLDS : USD_THRESHOLDS;
-  for (let i = thresholds.length - 1; i >= 0; i--) {
-    if (price >= thresholds[i]) {
-      return (i + 1) as 1 | 2 | 3 | 4 | 5;
-    }
-  }
-  return undefined;
 }
 
 export function defaultMarketForLocale(locale: string): "cn" | "global" {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -639,7 +639,6 @@ export interface Lens {
    * and the UI renders them as separate data points.
    *
    * Markets are independent; omit a market when no price data is available.
-   * For UI bucketing into tiers 1–5, see `priceTier()` in lens.ts.
    */
   pricing?: {
     cn?: {

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -59,3 +59,20 @@ export const ICON_CLOSE_BTN_CLS =
   "inline-flex shrink-0 items-center justify-center rounded-full transition-colors " +
   "text-zinc-500 hover:bg-red-50 hover:text-red-500 active:bg-red-50 active:text-red-500 " +
   "dark:text-zinc-400 dark:hover:bg-red-950/30 dark:hover:text-red-400 dark:active:bg-red-950/30 dark:active:text-red-400";
+
+/**
+ * Price disclaimer tokens — used by PriceDisclaimer (detail page, compare
+ * table popover) and the SharePoster price caption.
+ *
+ * Visual hierarchy:
+ *   warn → amber, bold (warning prefix, e.g. "仅供参考" / "Indicative price")
+ *   body → zinc, normal weight (the actual disclaimer sentence)
+ *
+ * The leading TriangleAlert icon shares the warn color.
+ */
+export const PRICE_DISCLAIMER_WARN_CLS =
+  "font-semibold text-amber-600 dark:text-amber-400";
+export const PRICE_DISCLAIMER_BODY_CLS =
+  "text-zinc-500 dark:text-zinc-400";
+export const PRICE_DISCLAIMER_ICON_CLS =
+  "shrink-0 text-amber-600 dark:text-amber-400";

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -292,8 +292,7 @@
     "tagUltraMacro": "Ultra Macro",
     "tagFisheye": "Fisheye",
     "tagProbe": "Probe",
-    "priceLabel": "Price Range",
-    "tierSymbol": "$",
+    "priceLabel": "Price",
     "usedBadge": "Used"
   },
   "About": {
@@ -344,7 +343,7 @@
     "dataPricingPoint2Title": "Sourced from brand-official storefronts",
     "dataPricingPoint2Body": "Prices come from brand-operated e-commerce. When a brand has no unified global storefront, the US storefront is used as a reference.",
     "dataPricingPoint3Title": "Used market as fallback",
-    "dataPricingPoint3Body": "When no official listing is available, used market listings are sampled, and a median of multiple listings is computed to reduce outlier impact.",
+    "dataPricingPoint3Body": "When no official listing is available, used market listings are sampled, and a median of multiple listings is computed to reduce outlier impact — though used prices still vary substantially with condition and timing, so treat them as a rough reference.",
     "dataPricingPoint4Title": "Point-in-time snapshots, not real-time",
     "dataPricingPoint4Body": "Prices reflect the state at sampling time and are not continuously updated.",
     "dataGitHubCardTitle": "Full pipeline architecture",
@@ -442,12 +441,12 @@
     "conditionNew": "New",
     "conditionUsed": "Used",
     "cnyAmount": "¥{value}",
-    "tierSymbol": "$",
-    "disclaimerTrigger": "For reference only",
-    "detailNewNote": "This price was sampled from one storefront at one point in time and is not continuously updated. Actual prices may differ due to promotions, coupons, or regional pricing, and may not represent the lowest available price.",
-    "detailUsedNote": "This is the median of several listings sampled from one platform at one point in time. Actual prices vary with condition, accessories, and seller, and may differ significantly.",
-    "tierNote": "The price tier gives you a quick sense of the lens's price range. Click to see the exact sampled price and source. Prices are not continuously updated and are for reference only.",
-    "usedReason": "A new price could not be found from official channels; showing a used market price instead.",
+    "disclaimerWarn": "Indicative price",
+    "disclaimerLead": "Market reference, indicative only.",
+    "disclaimerBody": "Actual prices may differ significantly from this reference due to retailer, promotions, condition, and market dynamics — please verify the latest price.",
+    "rowLabel": "Reference",
+    "rowWarn": "please do verify the latest price",
+    "usedReason": "No new-price listing was found in official channels; showing a used-market reference instead.",
     "sampledAt": "Sampled {date}"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -292,8 +292,7 @@
     "tagUltraMacro": "超微距",
     "tagFisheye": "鱼眼",
     "tagProbe": "探针镜头",
-    "priceLabel": "价位",
-    "tierSymbol": "¥",
+    "priceLabel": "价格",
     "usedBadge": "二手"
   },
   "About": {
@@ -344,7 +343,7 @@
     "dataPricingPoint2Title": "价格采自官方电商",
     "dataPricingPoint2Body": "采样自品牌官方电商渠道（如京东旗舰店、天猫旗舰店）。",
     "dataPricingPoint3Title": "无官方渠道时降级到二手",
-    "dataPricingPoint3Body": "上述渠道采集不到新品时，转而采样二手市场，并取多条挂牌的中位数以降低单个异常值的影响。",
+    "dataPricingPoint3Body": "上述渠道采集不到新品时，转而采样二手市场，并取多条挂牌的中位数以降低单个异常值的影响。但二手市场价格仍会因成色与时段产生较大波动，仅作为大致参考。",
     "dataPricingPoint4Title": "时间点快照，并非实时数据",
     "dataPricingPoint4Body": "价格是采样当时的状态，不会持续更新。",
     "dataGitHubCardTitle": "完整 Pipeline 架构图",
@@ -442,12 +441,12 @@
     "conditionNew": "新品",
     "conditionUsed": "二手",
     "cnyAmount": "{value} 元",
-    "tierSymbol": "¥",
-    "disclaimerTrigger": "价格仅供参考",
-    "detailNewNote": "价格采集自某一渠道的某一时间点，不会持续更新。实际价格可能因促销、优惠券或地区差异而不同，不代表全网最低价。",
-    "detailUsedNote": "二手价格取自采样时该平台若干挂牌的中位数。实际成交价因成色、配件和卖家而异，可能与此有较大出入。",
-    "tierNote": "价位帮你快速判断镜头的大致价格范围，点击可查看采集时的具体价格和来源。价格不会持续更新，仅供参考。",
-    "usedReason": "未能从官方渠道采集到新品价格，此处为二手市场价。",
+    "disclaimerWarn": "仅供参考",
+    "disclaimerLead": "市场行情，仅供参考。",
+    "disclaimerBody": "渠道、优惠活动、成色与市场行情都可能让实际价格显著偏离此参考值，请务必核实最新价格。",
+    "rowLabel": "市场参考",
+    "rowWarn": "请务必核实最新价格",
+    "usedReason": "官方渠道未采集到该镜头的新品价格，此处展示二手市场参考价。",
     "sampledAt": "采样于 {date}"
   }
 }


### PR DESCRIPTION
## Summary
- Drops the `$$$`/`¥¥¥` tier symbols + range subtext — they read as "masked prices" rather than "rough price band". Shows the real captured price across detail, compare, and share-poster surfaces instead.
- New unified disclaimer copy with action-oriented closing: `市场行情，仅供参考。 … 请务必核实最新价格。` (en: `Market reference, indicative only. … please do verify the latest price.`).
- Removed the `~` prefix on used prices — uses a clickable Used badge with a popover that explains *why* a used reference was picked (no new-price listing in official channels). Same behavior on detail and compare pages.
- Compare-page price row: per-lens caption now stacks source + sampled date persistently (no popover-on-click). Sticky label cell collapses to a two-line `市场参考` / `⚠ 请务必核实最新价格` matched to the caption height.
- Share poster: bottom disclaimer block removed; each price column stacks `value / source / 📅 date / ⚠ 仅供参考` so the caveat stays attached to data on a static share image.
- About page Point 3 (used-market median): acknowledges that the median reduction can't eliminate volatility, so its framing aligns with the disclaimer's tone.
- Calendar icon for date captions across detail / compare / poster.
- Image on detail page scaled to 288px so info column bottom aligns to image bottom via flex stretch + `mt-auto`.

## Implementation notes
- `formatPrice` now takes `cnyTemplate: string` (e.g. `"{value} 元"`) instead of a next-intl translator, so `SharePoster` (props-driven) can format prices without an i18n hook.
- Dead code removed: `priceTier`, `tierRange`, `formatTierRange`, `CNY_THRESHOLDS`/`USD_THRESHOLDS`, `tierSymbol`/`tierNote` i18n keys, `disclaimerTrigger`, and the old `detailNewNote`/`detailUsedNote` popover copy.
- New `PriceDisclaimer` component (detail-page only). Compare table renders its disclaimer inline in the label cell; share poster renders its warn caption inline per price column.

## Test plan
- [ ] Detail page (zh/en, new + used): real price, no `~` prefix, single-paragraph disclaimer; Used badge popover explains the reason; image bottom aligns to action-button row bottom.
- [ ] Compare page (zh/en, new + used + mixed): per-lens cell shows value + source + sampled date; Used badge clickable; sticky left label cell shows `市场参考` / `⚠ 请务必核实最新价格`.
- [ ] Share poster: each price column shows value (+ Used badge) / source / 📅 date / ⚠ 仅供参考; no bottom disclaimer block.
- [ ] About page Point 3 (zh/en): tone now consistent with disclaimer.
- [ ] Mobile (375px) for detail and compare: no overflow, captions wrap cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)