### PR TITLE
chore(cf): pin plain-text vars in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,14 @@ compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
 directory = ".open-next/assets"
 binding = "ASSETS"
 
+# Workers Builds rewrites Text bindings from this section on every deploy,
+# overwriting anything added via the Dashboard. Non-secret config must
+# live here. Secrets (e.g. GITHUB_TOKEN) stay in the Dashboard.
+[vars]
+SITE_URL = "https://xglass.sentacraft.com"
+GITHUB_FEEDBACK_REPO = "sentacraft/x-glass-pipeline"
+GITHUB_FEEDBACK_ASSIGNEES = "sentacraft"
+
 [observability]
 enabled = false
 head_sampling_rate = 1


### PR DESCRIPTION
## Summary

Add a `[vars]` section to `wrangler.toml` with three non-secret bindings:

| Variable | Value |
|---|---|
| `SITE_URL` | `https://xglass.sentacraft.com` |
| `GITHUB_FEEDBACK_REPO` | `sentacraft/x-glass-pipeline` |
| `GITHUB_FEEDBACK_ASSIGNEES` | `sentacraft` |

`GITHUB_TOKEN` remains a Dashboard Secret.

## Why

Cloudflare Workers Builds treats `wrangler.toml`'s `[vars]` block as the source of truth for plain-text bindings — Text variables added via the Dashboard are overwritten on every deploy. This caused `/api/feedback` to return `server_misconfigured` whenever a redeploy wiped the manually-added vars. Pinning them in source fixes the loop permanently.

## Test plan

- [ ] After merge, `curl https://xglass.sentacraft.com/api/feedback` returns `{"ok":true,"ready":true,"missingEnv":[]}`.
- [ ] Submit a real feedback from the site — expect 200 and a new issue in `sentacraft/x-glass-pipeline`, assigned to `sentacraft`.
- [ ] Trigger one more Workers Builds redeploy and re-check `/api/feedback` to confirm the vars survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)