### PR TITLE
fix(api): send User-Agent to GitHub from /api/feedback

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -189,6 +189,9 @@ export async function POST(req: Request) {
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
       "Content-Type": "application/json",
+      // Required by the GitHub REST API. Workers' fetch sends no default
+      // UA, so omitting it returns 403 before reaching the endpoint.
+      "User-Agent": "x-glass-feedback",
     },
     body: JSON.stringify(issue),
   });


### PR DESCRIPTION
## Summary

Adds a `User-Agent: x-glass-feedback` header to the `fetch` that creates the GitHub issue. The REST API requires User-Agent on every request and returns 403 \"Request forbidden by administrative rules\" without it. Workers' `fetch` does not inject a default UA the way Node's `fetch` sometimes does, which is why the route worked under Vercel's Node runtime but failed on Cloudflare.

## Verified by

CF Worker log showed:
> [feedback] GitHub API error 403 Request forbidden by administrative rules. Please make sure your request has a User-Agent header

## Test plan

- [ ] After merge + redeploy, submit a real feedback from the site — expect 200 and a new issue in `sentacraft/x-glass-pipeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)