### PR TITLE
feat(compare): top links row, nav GitHub cleanup, preset copy fixes

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -566,6 +566,51 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
         </thead>
 
         <tbody>
+          {/* Top links row — mirrors the footer so users don't need to scroll down */}
+          {orderedLenses.length > 0 && (
+            <tr className="border-b border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
+              <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-4 dark:bg-zinc-800" />
+              {orderedLenses.map((lens) => {
+                const url = getLensUrl(lens, locale);
+                const fields = lensFields.get(lens.id);
+                return (
+                  <td key={lens.id} className="px-3 py-4">
+                    <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
+                      {url ? (
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                        >
+                          <ArrowUpRight className="h-3 w-3" />
+                          {t("officialSite")}
+                        </a>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                          <ArrowUpRight className="h-3 w-3" />
+                          {t("officialSite")}
+                        </span>
+                      )}
+                      <FeedbackTrigger
+                        type="data_issue"
+                        context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
+                        fields={fields}
+                        className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                      >
+                        <Flag className="h-3 w-3" />
+                        {t("reportIssue")}
+                      </FeedbackTrigger>
+                    </div>
+                  </td>
+                );
+              })}
+              {Array.from({ length: emptySlotCount }).map((_, i) => (
+                <td key={`empty-topfoot-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
+              ))}
+            </tr>
+          )}
+
           {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
           {orderedLenses.length === 0 && !hideBodyWhenEmpty && allGroups.map((group) => (
             <React.Fragment key={group.label}>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -575,19 +575,19 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 const fields = lensFields.get(lens.id);
                 return (
                   <td key={lens.id} className="px-3 py-4">
-                    <div className="flex flex-col items-center justify-center gap-2">
+                    <div className="flex flex-col items-center justify-center gap-1">
                       {url ? (
                         <a
                           href={url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
+                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
                         >
                           <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </a>
                       ) : (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
                           <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </span>
@@ -596,7 +596,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                         type="data_issue"
                         context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                         fields={fields}
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
                       >
                         <Flag className="h-3 w-3 shrink-0" />
                         {t("reportIssue")}
@@ -949,19 +949,19 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               const fields = lensFields.get(lens.id);
               return (
                 <td key={lens.id} className="px-3 py-4">
-                  <div className="flex flex-col items-center justify-center gap-2">
+                  <div className="flex flex-col items-center justify-center gap-1">
                     {url ? (
                       <a
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
                       >
                         <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </a>
                     ) : (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
                         <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </span>
@@ -970,7 +970,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                       type="data_issue"
                       context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                       fields={fields}
-                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
+                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
                     >
                       <Flag className="h-3 w-3 shrink-0" />
                       {t("reportIssue")}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -153,6 +153,79 @@ function EmptyLensHeader({
   );
 }
 
+// --- LinksRow: official site + report links, rendered at both top and bottom ---
+
+function LinksRow({
+  orderedLenses,
+  emptySlotCount,
+  lensFields,
+  locale,
+  url: getUrl,
+  officialSiteLabel,
+  reportIssueLabel,
+  tBrand: getBrand,
+  border,
+}: {
+  orderedLenses: Lens[];
+  emptySlotCount: number;
+  lensFields: Map<string, import("@/components/FeedbackDialog").FeedbackField[]>;
+  locale: string;
+  url: (lens: Lens) => string | null | undefined;
+  officialSiteLabel: string;
+  reportIssueLabel: string;
+  tBrand: (brand: string) => string;
+  border: "top" | "bottom";
+}) {
+  const borderCls =
+    border === "top"
+      ? "border-t border-zinc-200 dark:border-zinc-800"
+      : "border-b border-zinc-200 dark:border-zinc-800";
+
+  return (
+    <tr className={`${borderCls} bg-zinc-100/80 dark:bg-zinc-800/60`}>
+      <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
+      {orderedLenses.map((lens) => {
+        const url = getUrl(lens);
+        const fields = lensFields.get(lens.id);
+        return (
+          <td key={lens.id} className="px-3 py-2">
+            <div className="flex flex-col items-center justify-center gap-0.5">
+              {url ? (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
+                >
+                  <ArrowUpRight className="h-3 w-3 shrink-0" />
+                  {officialSiteLabel}
+                </a>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                  <ArrowUpRight className="h-3 w-3 shrink-0" />
+                  {officialSiteLabel}
+                </span>
+              )}
+              <FeedbackTrigger
+                type="data_issue"
+                context={{ lensId: lens.id, lensModel: lens.model, lensBrand: getBrand(lens.brand) }}
+                fields={fields}
+                className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
+              >
+                <Flag className="h-3 w-3 shrink-0" />
+                {reportIssueLabel}
+              </FeedbackTrigger>
+            </div>
+          </td>
+        );
+      })}
+      {Array.from({ length: emptySlotCount }).map((_, i) => (
+        <td key={`empty-links-${border}-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
+      ))}
+    </tr>
+  );
+}
+
 // --- CompareTable ---
 
 interface Props {
@@ -568,47 +641,17 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
         <tbody>
           {/* Top links row — mirrors the footer so users don't need to scroll down */}
           {orderedLenses.length > 0 && (
-            <tr className="border-b border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
-              <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-4 dark:bg-zinc-800" />
-              {orderedLenses.map((lens) => {
-                const url = getLensUrl(lens, locale);
-                const fields = lensFields.get(lens.id);
-                return (
-                  <td key={lens.id} className="px-3 py-2">
-                    <div className="flex flex-col items-center justify-center gap-0.5">
-                      {url ? (
-                        <a
-                          href={url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
-                        >
-                          <ArrowUpRight className="h-3 w-3 shrink-0" />
-                          {t("officialSite")}
-                        </a>
-                      ) : (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
-                          <ArrowUpRight className="h-3 w-3 shrink-0" />
-                          {t("officialSite")}
-                        </span>
-                      )}
-                      <FeedbackTrigger
-                        type="data_issue"
-                        context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
-                        fields={fields}
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
-                      >
-                        <Flag className="h-3 w-3 shrink-0" />
-                        {t("reportIssue")}
-                      </FeedbackTrigger>
-                    </div>
-                  </td>
-                );
-              })}
-              {Array.from({ length: emptySlotCount }).map((_, i) => (
-                <td key={`empty-topfoot-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
-              ))}
-            </tr>
+            <LinksRow
+              orderedLenses={orderedLenses}
+              emptySlotCount={emptySlotCount}
+              lensFields={lensFields}
+              locale={locale}
+              url={(lens) => getLensUrl(lens, locale)}
+              officialSiteLabel={t("officialSite")}
+              reportIssueLabel={t("reportIssue")}
+              tBrand={tBrand}
+              border="bottom"
+            />
           )}
 
           {/* Cold-start skeleton: show all spec dimensions with placeholder cells */}
@@ -941,48 +984,17 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
         </tbody>
 
         {orderedLenses.length > 0 && <tfoot>
-          {/* Footer row: official site + report links per lens */}
-          <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
-            <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-4 dark:bg-zinc-800" />
-            {orderedLenses.map((lens) => {
-              const url = getLensUrl(lens, locale);
-              const fields = lensFields.get(lens.id);
-              return (
-                <td key={lens.id} className="px-3 py-4">
-                  <div className="flex flex-col items-center justify-center gap-1">
-                    {url ? (
-                      <a
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
-                      >
-                        <ArrowUpRight className="h-3 w-3 shrink-0" />
-                        {t("officialSite")}
-                      </a>
-                    ) : (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
-                        <ArrowUpRight className="h-3 w-3 shrink-0" />
-                        {t("officialSite")}
-                      </span>
-                    )}
-                    <FeedbackTrigger
-                      type="data_issue"
-                      context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
-                      fields={fields}
-                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
-                    >
-                      <Flag className="h-3 w-3 shrink-0" />
-                      {t("reportIssue")}
-                    </FeedbackTrigger>
-                  </div>
-                </td>
-              );
-            })}
-            {Array.from({ length: emptySlotCount }).map((_, i) => (
-              <td key={`empty-foot-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
-            ))}
-          </tr>
+          <LinksRow
+            orderedLenses={orderedLenses}
+            emptySlotCount={emptySlotCount}
+            lensFields={lensFields}
+            locale={locale}
+            url={(lens) => getLensUrl(lens, locale)}
+            officialSiteLabel={t("officialSite")}
+            reportIssueLabel={t("reportIssue")}
+            tBrand={tBrand}
+            border="top"
+          />
         </tfoot>}
       </table>
     </div>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -575,7 +575,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 const fields = lensFields.get(lens.id);
                 return (
                   <td key={lens.id} className="px-3 py-4">
-                    <div className="flex flex-col items-center justify-center gap-1">
+                    <div className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-3">
                       {url ? (
                         <a
                           href={url}
@@ -949,7 +949,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               const fields = lensFields.get(lens.id);
               return (
                 <td key={lens.id} className="px-3 py-4">
-                  <div className="flex flex-col items-center justify-center gap-1">
+                  <div className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-3">
                     {url ? (
                       <a
                         href={url}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -575,7 +575,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 const fields = lensFields.get(lens.id);
                 return (
                   <td key={lens.id} className="px-3 py-4">
-                    <div className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-3">
+                    <div className="flex flex-col items-center justify-center gap-1">
                       {url ? (
                         <a
                           href={url}
@@ -949,7 +949,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               const fields = lensFields.get(lens.id);
               return (
                 <td key={lens.id} className="px-3 py-4">
-                  <div className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-3">
+                  <div className="flex flex-col items-center justify-center gap-1">
                     {url ? (
                       <a
                         href={url}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -653,7 +653,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 </td>
               </tr>
               <tr className="border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
-                <td className="sticky left-0 z-10 px-3 py-3 bg-zinc-50 dark:bg-zinc-900 break-words align-top">
+                <td className="sticky left-0 z-10 px-3 py-3 bg-zinc-50 dark:bg-zinc-900 break-words align-middle">
                   {/* Two-line label: row name on top, single action-oriented
                       warn below. Compact enough to avoid orphan characters
                       even in the narrow (6rem) sticky label column. */}

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -575,20 +575,20 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 const fields = lensFields.get(lens.id);
                 return (
                   <td key={lens.id} className="px-3 py-4">
-                    <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
+                    <div className="flex flex-col items-center justify-center gap-2">
                       {url ? (
                         <a
                           href={url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
                         >
-                          <ArrowUpRight className="h-3 w-3" />
+                          <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </a>
                       ) : (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
-                          <ArrowUpRight className="h-3 w-3" />
+                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                          <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </span>
                       )}
@@ -596,9 +596,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                         type="data_issue"
                         context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                         fields={fields}
-                        className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
                       >
-                        <Flag className="h-3 w-3" />
+                        <Flag className="h-3 w-3 shrink-0" />
                         {t("reportIssue")}
                       </FeedbackTrigger>
                     </div>
@@ -949,20 +949,20 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               const fields = lensFields.get(lens.id);
               return (
                 <td key={lens.id} className="px-3 py-4">
-                  <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
+                  <div className="flex flex-col items-center justify-center gap-2">
                     {url ? (
                       <a
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
                       >
-                        <ArrowUpRight className="h-3 w-3" />
+                        <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </a>
                     ) : (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
-                        <ArrowUpRight className="h-3 w-3" />
+                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                        <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </span>
                     )}
@@ -970,9 +970,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                       type="data_issue"
                       context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                       fields={fields}
-                      className={`inline-flex items-center gap-1 text-xs font-medium ${TEXT_LINK_CLS}`}
+                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap ${TEXT_LINK_CLS}`}
                     >
-                      <Flag className="h-3 w-3" />
+                      <Flag className="h-3 w-3 shrink-0" />
                       {t("reportIssue")}
                     </FeedbackTrigger>
                   </div>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -574,20 +574,20 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                 const url = getLensUrl(lens, locale);
                 const fields = lensFields.get(lens.id);
                 return (
-                  <td key={lens.id} className="px-3 py-4">
-                    <div className="flex flex-col items-center justify-center gap-1">
+                  <td key={lens.id} className="px-3 py-2">
+                    <div className="flex flex-col items-center justify-center gap-0.5">
                       {url ? (
                         <a
                           href={url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
+                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
                         >
                           <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </a>
                       ) : (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
                           <ArrowUpRight className="h-3 w-3 shrink-0" />
                           {t("officialSite")}
                         </span>
@@ -596,7 +596,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                         type="data_issue"
                         context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                         fields={fields}
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
                       >
                         <Flag className="h-3 w-3 shrink-0" />
                         {t("reportIssue")}
@@ -955,13 +955,13 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
                       >
                         <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </a>
                     ) : (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                      <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
                         <ArrowUpRight className="h-3 w-3 shrink-0" />
                         {t("officialSite")}
                       </span>
@@ -970,7 +970,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
                       type="data_issue"
                       context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
                       fields={fields}
-                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-2 ${TEXT_LINK_CLS}`}
+                      className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
                     >
                       <Flag className="h-3 w-3 shrink-0" />
                       {t("reportIssue")}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -178,15 +178,6 @@ export default function Nav() {
           <Link href={compareHref} className={linkCls(isCompareActive)}>
             {t("compare")}
           </Link>
-          <a
-            href="https://github.com/sentacraft/x-glass"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors px-1.5"
-            aria-label="GitHub"
-          >
-            <GitHubMark />
-          </a>
           <div ref={menuRef} className="relative">
             <button
               onClick={() => setMobileMenuOpen((v) => !v)}
@@ -217,6 +208,16 @@ export default function Nav() {
                   <Send className="h-4 w-4 shrink-0" />
                   {t("feedback")}
                 </button>
+                <a
+                  href="https://github.com/sentacraft/x-glass"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={mobileLinkCls(false)}
+                  aria-label="GitHub"
+                >
+                  <GitHubMark size={16} className="shrink-0" />
+                  GitHub
+                </a>
               </div>
             )}
           </div>

--- a/src/data/curated-presets.json
+++ b/src/data/curated-presets.json
@@ -73,8 +73,8 @@
         "en": "All-in-one Superzooms"
       },
       "subtitle": {
-        "zh": "旅游首选：适马、腾龙、富士原厂的焦段与画质取舍",
-        "en": "Sigma vs Tamron vs Fuji — focal range and image quality trade-offs"
+        "zh": "旅游首选：适马、腾龙、富士原厂的焦段、重量与价格取舍",
+        "en": "Sigma vs Tamron vs Fuji — focal range, weight and price compared"
       },
       "lensIds": [
         "sigma-contemporary-16-300mm-f35-67-dc-os-x",
@@ -89,8 +89,8 @@
         "en": "Tele Trio"
       },
       "subtitle": {
-        "zh": "打鸟、演唱会、日常远摄——价位与画质",
-        "en": "Wildlife, concerts, daily reach — price vs. performance"
+        "zh": "打鸟、演唱会、日常远摄——焦段、防抖与价格取舍",
+        "en": "Wildlife, concerts, daily reach — focal range, stabilization and price compared"
       },
       "lensIds": [
         "fujifilm-xc-50-230mmf45-67-ois-ii-x",


### PR DESCRIPTION
## Summary

- **Top links row in compare table**: Repeat the "official site + report issue" row immediately below the column headers so users don't have to scroll to the bottom to find these actions.
- **Links row UX polish**: Text is always `whitespace-nowrap` (no mid-label line-breaks), buttons are vertically stacked in all viewport widths (columns are only 9rem wide — side-by-side always overflows), tap targets set to `py-1` with compact `gap-0.5` between the two actions.
- **Pricing row label**: Changed `align-top` → `align-middle` so the "市场参考" label is vertically centred against the price data in adjacent cells.
- **Mobile nav**: Move the GitHub icon from the inline mobile nav bar into the hamburger (overflow) menu, reducing clutter on small screens.
- **Curated preset copy**: Remove "画质" (image quality) references from two preset subtitles ("一镜走天下", "长焦三兄弟") since the compare table cannot show image quality metrics yet. Replaced with concrete, table-verifiable dimensions (focal range, weight, stabilization, price).

## Reviewer notes

- The top links row is a straight duplication of the `<tfoot>` row — same JSX, same data sources, rendered as the first `<tr>` inside `<tbody>` when at least one lens is selected.
- `package-lock.json` changes are from the session-start `npm install` and are intentionally excluded from this PR (no dependency changes were made).