### PR TITLE
docs(readme): fix drift after Cloudflare migration and G mount addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you find X-Glass useful, a ⭐ on this repo goes a long way — and if you'd 
 
 ## Features
 
-- **Growing lens database** — 8 major brands covered in the first release (Fujifilm, Sigma, Tamron, Viltrox, TTArtisan, 7Artisans, Brightin Star, SG Image), with more brands on the roadmap
+- **Growing lens database** — full coverage of Fujifilm's own X and G mount lineups, plus 7 major third-party X mount brands (Sigma, Tamron, Viltrox, TTArtisan, 7Artisans, Brightin Star, SG Image), with more brands on the roadmap
 - **Clean, focused UI** — distraction-free interface designed around the comparison workflow
 - **Filter and sort** — multi-axis filtering (focal length, aperture, AF, OIS, weather resistance, specialty tags) combined with flexible sorting
 - **Side-by-side comparison** of up to 4 lenses
@@ -47,15 +47,16 @@ It also supports installation as a **Progressive Web App (PWA)**: add it to your
 |-------|--------|
 | Framework | Next.js (App Router) + TypeScript |
 | Styling | Tailwind CSS |
-| Deployment | Vercel |
+| Deployment | Cloudflare Workers (OpenNext) |
 | i18n | next-intl |
 | Data Validation | Zod |
+| Testing | Vitest + Playwright |
 
 ## Data Pipeline
 
 For a lens comparison tool, data accuracy isn't a nice-to-have — it's the product. To keep specs accurate and up to date while minimizing AI hallucination during collection and parsing, X-Glass is backed by a purpose-built, multi-stage data pipeline:
 
-Lens data and images are maintained in a private pipeline repo and written into `src/data/lenses.json`.
+Lens data and images are maintained in a private pipeline repo and written into `src/data/lenses.json` (X mount) and `src/data/lenses-g.json` (G mount).
 
 ```mermaid
 flowchart TD
@@ -116,7 +117,7 @@ flowchart TD
   SPrNew & SPrUsed --> SP1
   SP1 --> SP_AUDIT
   SP_AUDIT --> SP2
-  SP2 -->|"writes src/data/lenses.json"| DB[("x-glass<br/>(this repo)")]
+  SP2 -->|"writes src/data/lenses.json + lenses-g.json"| DB[("x-glass<br/>(this repo)")]
 
   classDef script fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f
   classDef agent fill:#fef9c3,stroke:#ca8a04,color:#713f12
@@ -165,7 +166,7 @@ X-Glass covers both the Fujifilm X mount (APS-C) and the Fujifilm G mount (GFX m
 **What's in the box, and what isn't.**
 - ✅ **Source code** is MIT-licensed. Fork, modify, deploy, ship commercially — all fine. Just keep the `LICENSE` file and copyright notice intact.
 - ✅ **Schema and field design** (`src/lib/types.ts`, Zod schemas, UI taxonomy) are part of the MIT code and free to reuse.
-- ❌ **Lens data** (`src/data/lenses.json`) is under a separate proprietary license and isn't transferable — please don't copy it or use it as seed data, even for a different mount. See [`LICENSE-DATA`](LICENSE-DATA).
+- ❌ **Lens data** (`src/data/lenses.json` and `src/data/lenses-g.json`) is under a separate proprietary license and isn't transferable — please don't copy it or use it as seed data, even for a different mount. See [`LICENSE-DATA`](LICENSE-DATA).
 - ❌ **The data pipeline** (`x-glass-pipeline`) is a separate private repository and isn't part of this fork. You'll need to build your own collection and review workflow.
 
 **Why the pipeline isn't open source (yet).** I get asked this a lot, so to be upfront about it:
@@ -197,7 +198,7 @@ Built on the shoulders of great open source work: [Base UI](https://base-ui.com)
 
 **Source code** — [MIT](LICENSE) © 2026 SentaCraft
 
-**Lens data** (`src/data/lenses.json`) — [Proprietary](LICENSE-DATA) © 2026 SentaCraft
+**Lens data** (`src/data/lenses.json`, `src/data/lenses-g.json`) — [Proprietary](LICENSE-DATA) © 2026 SentaCraft
 Available for personal reference only. Redistribution, commercial use, and bulk scraping are not permitted.
 
 **Product images and brand trademarks** are the property of their respective owners.


### PR DESCRIPTION
## Summary

README had drifted in two areas since recent iterations:

1. **Deployment migrated from Vercel to Cloudflare Workers** (via `@opennextjs/cloudflare`) — Tech Stack table was still listing Vercel.
2. **G mount data was added** as a separate `src/data/lenses-g.json`, but several places in the README still assumed the site only covered X mount or only had a single data file.

## Changes

- **Tech Stack table**: `Vercel` → `Cloudflare Workers (OpenNext)`; added `Testing | Vitest + Playwright` row.
- **Data Pipeline section**: intro paragraph and Mermaid diagram's terminal edge now reference both `lenses.json` (X mount) and `lenses-g.json` (G mount).
- **Features bullet**: "8 major brands" was ambiguous — could be read as 8 brands across both mounts. Rephrased to "Fujifilm's own X and G mount lineups + 7 third-party X mount brands" for accuracy.
- **Forking section + License section**: data file references updated to list both JSON files.

## Test plan

- [x] Reviewed rendered README — Mermaid diagram still parses, table alignment intact
- [x] Confirmed 8 X mount brands and Fujifilm-only G mount against actual `src/data/*.json` contents
- [x] Confirmed production is served from Cloudflare (response headers) and `wrangler.toml` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)