### PR TITLE
docs(about): mention Cloudflare Web Analytics in privacy notice

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -358,7 +358,7 @@
     "disclaimerCopyright": "Product images and brand trademarks are the property of their respective owners. If you are a rights holder and believe your content has been used improperly, please contact xglass@sentacraft.com.",
     "privacyTitle": "Privacy",
     "privacyBody": "X-Glass does not require registration, does not collect personal information, and does not use cookies.",
-    "privacyAnalytics": "This site uses Vercel Analytics to collect aggregated, anonymous data such as page views, referrers, and device types — solely to help improve the product. No personally identifiable information is collected.",
+    "privacyAnalytics": "This site uses Vercel Analytics and Cloudflare Web Analytics to collect aggregated, anonymous data such as page views, referrers, and device types — solely to help improve the product. No personally identifiable information is collected.",
     "donationTitle": "Support the Project",
     "donationBody": "X-Glass is open source on GitHub. Every spec in this database went through tedious data extraction and manual cross-checking. If it helped you find the right lens — or saved you some time — consider supporting the project.",
     "donationComingSoon": "Sponsorship options are being set up — check back soon.",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -358,7 +358,7 @@
     "disclaimerCopyright": "本站展示的产品图片及品牌商标，版权归各自所有者所有。如您是权利人并认为存在侵权问题，请联系 xglass@sentacraft.com。",
     "privacyTitle": "隐私",
     "privacyBody": "X-Glass 不要求注册，不收集任何个人信息，也不使用 Cookie。",
-    "privacyAnalytics": "本站接入了 Vercel Analytics，用于统计页面访问量、来源及设备类型等聚合匿名数据，以便持续改善产品体验。这些数据不包含任何可识别个人身份的信息。",
+    "privacyAnalytics": "本站接入了 Vercel Analytics 和 Cloudflare Web Analytics，用于统计页面访问量、来源及设备类型等聚合匿名数据，以便持续改善产品体验。这些数据不包含任何可识别个人身份的信息。",
     "donationTitle": "捐赠与支持",
     "donationBody": "X-Glass 代码已在 GitHub 开源。这里的每一组镜头参数，都经历了繁琐的数据抓取与人工交叉校准。如果你觉得这个数据库帮你选到了心仪的镜头，或者为你节省了时间，欢迎赞赏支持。",
     "donationComingSoon": "",


### PR DESCRIPTION
## Summary

Site is now instrumented with Cloudflare Web Analytics alongside the existing Vercel Analytics. Cloudflare's edge auto-injects the beacon script (`cloudflareinsights.com/beacon.min.js`) into HTML responses for the `sentacraft.com` hostname — no code changes are needed.

Update the About page privacy notice in both locales so the disclosure stays accurate during this transition. The `<Analytics />` and `<SpeedInsights />` components from `@vercel/*` packages will be removed in a later change once we're confident Cloudflare Web Analytics covers our needs.

## Changes

- [src/messages/en.json:361](https://github.com/sentacraft/x-glass/blob/main/src/messages/en.json#L361) — "Vercel Analytics" → "Vercel Analytics and Cloudflare Web Analytics"
- [src/messages/zh.json:361](https://github.com/sentacraft/x-glass/blob/main/src/messages/zh.json#L361) — 同步中文文案

## Test plan

- [ ] Verify Cloudflare Web Analytics shows incoming pageviews after deploy
- [ ] Verify About → Privacy section renders the updated text in both `/en/about` and `/zh/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)