### PR TITLE
docs(readme): highlight per-locale market customization in Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ If you find X-Glass useful, a ⭐ on this repo goes a long way — and if you'd 
 - **Pipeline-backed accuracy** — every spec originates from official manufacturer sources and goes through a staged pipeline with human review at every step
 - **Shareable comparison posters**
 - **Progressive Web App (PWA)** — X-Glass is a web app at its core, but installs and runs like a native app. Add it to your home screen (iOS / Android) or dock (macOS) for instant, full-screen access — no App Store required
-- **English + Chinese** (中文)
+- **Deep localization, not just translation** — English and Chinese (中文) editions are wired to the market each audience actually shops in:
+  - **New-price sources** — global storefronts in English; China-domestic channels in Chinese
+  - **Used-market sampling** — eBay for English; 闲鱼 for Chinese
+  - **Manufacturer "official site" links** — global product pages in English; Chinese-region pages in Chinese
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ If you find X-Glass useful, a ⭐ on this repo goes a long way — and if you'd 
 - **Pipeline-backed accuracy** — every spec originates from official manufacturer sources and goes through a staged pipeline with human review at every step
 - **Shareable comparison posters**
 - **Progressive Web App (PWA)** — X-Glass is a web app at its core, but installs and runs like a native app. Add it to your home screen (iOS / Android) or dock (macOS) for instant, full-screen access — no App Store required
-- **Deep localization, not just translation** — English and Chinese (中文) editions are wired to the market each audience actually shops in:
-  - **New-price sources** — global storefronts in English; China-domestic channels in Chinese
-  - **Used-market sampling** — eBay for English; 闲鱼 for Chinese
-  - **Manufacturer "official site" links** — global product pages in English; Chinese-region pages in Chinese
+- **Deep localization** — English and Chinese (中文) editions go beyond UI translation: pricing sources, used-market listings, and manufacturer links are all tailored to each audience's local market
 
 ## Install
 


### PR DESCRIPTION
## Summary

The Features section had a thin one-liner — "English + Chinese (中文)" — that undersold what the project actually does. Each locale is wired to the market the audience actually shops in, not just translated UI strings.

This was originally part of [#172](https://github.com/sentacraft/x-glass/pull/172) but didn't make it into the squash merge, so re-landing it here on its own.

## Changes

[README.md](README.md) Features bullet replaces `- **English + Chinese** (中文)` with:

> **Deep localization, not just translation** — English and Chinese (中文) editions are wired to the market each audience actually shops in:
> - **New-price sources** — global storefronts in English; China-domestic channels in Chinese
> - **Used-market sampling** — eBay for English; 闲鱼 for Chinese
> - **Manufacturer "official site" links** — global product pages in English; Chinese-region pages in Chinese

All three behaviors were verified against the codebase (eBay / 闲鱼 sources in `lenses.json`, `officialLinks` field on each lens).

## Test plan

- [x] Markdown renders cleanly on GitHub
- [x] Claims verified against `src/data/lenses.json` and `src/lib/types.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)