### PR TITLE
feat(data): publish lens data 2026.05.11 build 1

### DIFF
--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.10",
-  "lastUpdated": "2026-05-10T11:00:50.136Z",
+  "version": "2026.05.11",
+  "lastUpdated": "2026-05-11T14:32:38.518Z",
   "lensCount": 171,
-  "buildNumber": 3
+  "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.11` build 1
- **X-mount lenses** (`lenses.json`): 152
- **G-mount lenses** (`lenses-gfx.json`): 19
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`