### PR TITLE
docs(readme): wrap pipeline output nodes in x-glass repo subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,12 @@ flowchart TD
   SPrNew & SPrUsed --> SP1
   SP1 --> SP_AUDIT
   SP_AUDIT --> SP2
-  SP2 -->|"writes"| DBX[("lenses.json<br/>X Mount lens database")]
-  SP2 -->|"writes"| DBG[("lenses-gfx.json<br/>G Mount lens database")]
+  subgraph xglass["x-glass (this repo)"]
+    DBX[("lenses.json<br/>X Mount lens database")]
+    DBG[("lenses-gfx.json<br/>G Mount lens database")]
+  end
+  SP2 -->|"writes"| DBX
+  SP2 -->|"writes"| DBG
 
   classDef script fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f
   classDef agent fill:#fef9c3,stroke:#ca8a04,color:#713f12


### PR DESCRIPTION
## Summary

- The two pipeline output nodes (`lenses.json`, `lenses-gfx.json`) were floating without context after the previous refactor
- Wraps them in a `subgraph` labeled **x-glass (this repo)** so the diagram clearly shows the files are published into this repository

## What changed

`README.md` only — no code or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)