### PR TITLE
chore: restore Vercel Analytics ahead of traffic switch back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/source-serif-4": "^5.2.9",
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "geist": "^1.7.0",
@@ -7173,6 +7175,86 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/source-serif-4": "^5.2.9",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from "next";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
 import AssetTelemetry from "@/components/AssetTelemetry";
 import { routing } from "@/i18n/routing";
@@ -165,6 +167,8 @@ export default async function LocaleLayout({
         </NextIntlClientProvider>
         <RegisterSW />
         <AssetTelemetry />
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

PR #177's Cloudflare Workers optimizations (long-lived static cache, lens-grid prefetch/lazy fixes, telemetry sink) shipped but did not resolve the mainland-China image-load problem. The root cause is structural — free-tier Cloudflare tromboning trans-Pacific to LAX for mainland traffic ([Cloudflare blog, 2015](https://blog.cloudflare.com/how-we-extended-cloudflares-performance-and-security-into-mainland-china/)) — and is not fixable at the code layer.

Preparing to point traffic back at the Vercel deployment. This PR only restores the two Vercel observability packages so that data starts flowing again on the Vercel side.

## Changes

- `package.json`: re-add `@vercel/analytics` and `@vercel/speed-insights`.
- `src/app/[locale]/layout.tsx`: re-mount `<Analytics />` and `<SpeedInsights />` next to the existing `<RegisterSW />` and `<AssetTelemetry />`.

## What is intentionally retained from PR #177

These changes are platform-neutral and stay useful on Vercel:

- `public/_headers` — ignored by Vercel (it's a Cloudflare convention), harmless.
- `src/components/AssetTelemetry.tsx` + `/api/telemetry` route — captures `asset-error` and `slow-asset` regardless of host. The CF-IPCountry / CF-Ray headers it relies on will be absent on a direct-Vercel hit; the route already handles missing headers and just logs `country=??`, `pop=-`.
- `LensCard` `<Link prefetch={false}>` and image `loading=\"lazy\"` — universally beneficial.
- design-lab CF-incompatibility README + warnings — historical context, fine to keep.

## Test plan

- [x] Typecheck + lint clean
- [ ] Verify after deploy: Vercel Analytics + Speed Insights dashboards start receiving events
- [ ] Verify after DNS switch: a mainland-China request hits Vercel's edge (not Cloudflare anycast)
- [ ] Compare: image load behavior on mainland-China Safari before vs. after switch