### PR TITLE
fix(compare): remove redundant toast notifications

### DIFF
--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -7,7 +7,6 @@ import { getLensesByMount } from "@/lib/lens";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
-import { toast } from "sonner";
 import { motion, AnimatePresence } from "motion/react";
 import { spring } from "@/lib/animation";
 import { X } from "lucide-react";
@@ -107,7 +106,7 @@ export default function CompareBar() {
                         </span>
                       </span>
                       <button
-                        onClick={() => { toggleCompare(lens.id); toast(t("removedFromCompare")); }}
+                        onClick={() => toggleCompare(lens.id)}
                         className={cn(ICON_CLOSE_BTN_CLS, "h-5 w-5 -mr-0.5 mt-0.5")}
                         aria-label={tCompare("removeLens", { model: displayName })}
                       >
@@ -120,7 +119,7 @@ export default function CompareBar() {
             </div>
             <div className="flex items-center justify-end gap-3 sm:shrink-0">
               <button
-                onClick={() => { clearCompare(); toast(t("clearedCompare")); }}
+                onClick={clearCompare}
                 className="shrink-0 text-sm font-medium px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
               >
                 {t("clearCompare")}

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
 import { Z } from "@/config/ui";
 import { useTranslations, useLocale } from "next-intl";
 import { ShareButton } from "@/components/share/ShareButton";
@@ -85,7 +84,7 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
         {activeLenses.length >= minColumns && <CompareAddLensButton />}
         {activeLenses.length > 0 && (
           <button
-            onClick={() => { clearCompare(); toast(tList("clearedCompare")); router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`); }}
+            onClick={() => { clearCompare(); router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`); }}
             className={`shrink-0 text-sm font-medium px-3 py-2 rounded-xl ${TEXT_LINK_CLS}`}
           >
             {tList("clearCompare")}

--- a/src/components/LensCard.tsx
+++ b/src/components/LensCard.tsx
@@ -166,7 +166,7 @@ export default function LensCard({
 
       {/* Mobile-only icon compare toggle — absolute in top-right corner */}
       <button
-        onClick={selectionDisabled ? () => toast(t("compareFullToast")) : () => { onToggle(); toast(isSelected ? t("removedFromCompare") : t("addedToCompare")); }}
+        onClick={selectionDisabled ? () => toast(t("compareFullToast")) : onToggle}
         aria-label={isSelected ? t("removeFromCompare") : selectionDisabled ? t("compareFull") : t("addToCompare")}
         className={`hidden max-xs:flex absolute top-2 right-2 z-10 items-center justify-center h-8 w-8 rounded-full transition-colors ${
           isSelected
@@ -186,7 +186,7 @@ export default function LensCard({
       >
         <Button
           size="sm"
-          onClick={() => { onToggle(); toast(isSelected ? t("removedFromCompare") : t("addedToCompare")); }}
+          onClick={onToggle}
           disabled={selectionDisabled}
           className={`w-full h-10 sm:h-9 font-medium ${
             isSelected


### PR DESCRIPTION
## Summary
- Remove toast notifications for add/remove/clear compare actions — these toasts were redundant since the CompareBar already provides visual feedback for selection state changes
- Kept the "compare full" toast on LensCard since it blocks an attempted action with no other visual indicator

## Test plan
- [ ] Add a lens to compare — no toast, chip appears in CompareBar
- [ ] Remove a lens via chip X button — no toast, chip disappears
- [ ] Clear all via "Clear" button on CompareBar and compare page — no toast
- [ ] Hit max compare limit — toast still appears (intentionally kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)