### PR TITLE
fix(share): drop page URL from poster share text

### DIFF
--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -188,8 +188,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
       ? t("shareCtaSingle")
       : t("shareCtaMulti", { count: lenses.length });
     const slogan = effectiveSlogan.trim();
-    const pageUrl = window.location.href;
-    const textParts = [cta, slogan, `👉 ${pageUrl}`].filter(Boolean);
+    const textParts = [cta, slogan].filter(Boolean);
     const text = textParts.join("\n");
 
     setPosterGenerating(true);


### PR DESCRIPTION
## Summary
- WeChat's iOS Share Extension packages any payload containing a URL into a `WXWebpageObject` link card: the poster image collapses into a tiny non-tappable thumbnail and tapping the card jumps to the URL instead of viewing the image full-size.
- Removing the URL from the share `text` causes WeChat to fall back to a plain image message — fully tappable, viewable at full size, long-press to save. The poster's embedded QR code still carries the link.
- iMessage loses the auto-generated logo link card, but the poster file itself is already information-dense (focal lengths, apertures, QR code).

## Test plan
- [ ] iOS Safari → Share Sheet → WeChat: poster appears as a normal image message; can be tapped to view full-size and long-pressed to save
- [ ] iOS Safari → Share Sheet → Messages: poster appears as image attachment + CTA text bubble; no auto link card (expected regression)
- [ ] Share-link tab (`handleNativeShare`) behavior unchanged: iMessage still renders logo link card from `og:image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)