### PR TITLE
feat(share-poster): header redesign, WeChat-safe rasterize, drop URL from share text, hide share on iOS Chrome

### DIFF
--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -31,6 +31,8 @@ import { PosterFeatureItem } from "./PosterFeatureItem";
 export interface PosterLabels {
   appName: string;
   siteUrl: string;
+  /** Brand tagline shown directly under the wordmark. */
+  brandTagline: string;
   /** Short CTA / tagline shown in the header top-right. */
   cta: string;
   /** One line per lens — shown as stacked title lines when no custom title is set. */
@@ -383,81 +385,85 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
       style={{ width: POSTER_W }}
     >
       {/* ── Header ────────────────────────────────────────────── */}
-      <div style={{ padding: `24px ${POSTER_PX}px 20px` }}>
-        {/* Brand tag: always at top, not part of vertical centering */}
-        <div style={{ display: "flex", alignItems: "center", gap: 5, marginBottom: 10 }}>
-          <Iris config={IRIS_NAV} size={14} uid="poster" />
-          <span
-            className="text-zinc-400"
-            style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}
-          >
-            X-Glass
-          </span>
+      <div style={{ padding: `28px ${POSTER_PX}px 24px` }}>
+        {/* Top row: brand+tagline (left) ↔ QR+CTA (right), aligned to top */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 24 }}>
+          {/* Left: brand stack */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 2 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Iris config={IRIS_NAV} size={20} uid="poster" />
+              <span
+                className="text-zinc-700"
+                style={{ fontSize: 14, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}
+              >
+                X-Glass
+              </span>
+            </div>
+            <div
+              className="text-zinc-400"
+              style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.4 }}
+            >
+              {labels.brandTagline}
+            </div>
+          </div>
+
+          {/* Right: QR + CTA */}
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", flexShrink: 0, gap: 8 }}>
+            <div
+              style={{
+                width: 96,
+                height: 96,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              {shareUrl ? (
+                <QRCodeSVG
+                  value={shareUrl}
+                  size={96}
+                  level="H"
+                  style={{ display: "block" }}
+                  imageSettings={{
+                    src: "/icons/icon-192-white.png",
+                    width: 18,
+                    height: 18,
+                    excavate: true,
+                  }}
+                />
+              ) : (
+                <span className="text-zinc-300" style={{ fontSize: 8, letterSpacing: 1 }}>QR</span>
+              )}
+            </div>
+            <div style={{ textAlign: "right" }}>
+              <div className="text-zinc-700" style={{ fontSize: 9, fontWeight: 600, lineHeight: 1.5 }}>
+                {labels.cta}
+              </div>
+              <div className="text-zinc-700" style={{ fontSize: 8, fontWeight: 600, marginTop: 2 }}>
+                {labels.siteUrl}
+              </div>
+            </div>
+          </div>
         </div>
 
-        {/* Content row: title+slogan ↔ QR, vertically centered */}
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          {/* Left: title + slogan */}
-          <div style={{ flex: 1, minWidth: 0, paddingRight: 24 }}>
-            <div style={{ marginBottom: slogan ? 8 : 0 }}>
-              {titleLines.map((line, i) => (
-                <div
-                  key={i}
-                  className="text-zinc-900"
-                  style={{ fontSize: titleFontSize, fontWeight: 600, lineHeight: 1.25 }}
-                >
-                  {line}
-                </div>
-              ))}
-            </div>
-            {slogan && (
-              <div className="text-zinc-400" style={{ fontSize: 13, lineHeight: 1.4 }}>
-                {slogan}
+        {/* Title + per-share slogan block */}
+        <div style={{ marginTop: 20 }}>
+          <div style={{ marginBottom: slogan ? 8 : 0 }}>
+            {titleLines.map((line, i) => (
+              <div
+                key={i}
+                className="text-zinc-900"
+                style={{ fontSize: titleFontSize, fontWeight: 600, lineHeight: 1.25 }}
+              >
+                {line}
               </div>
-            )}
+            ))}
           </div>
-
-          {/* Right: QR code + CTA */}
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", flexShrink: 0, gap: 8 }}>
-          {/* QR code */}
-          <div
-            style={{
-              width: 76,
-              height: 76,
-              borderRadius: 6,
-              padding: 4,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            {shareUrl ? (
-              <QRCodeSVG
-                value={shareUrl}
-                size={64}
-                level="H"
-                style={{ display: "block" }}
-                imageSettings={{
-                  src: "/icons/icon-192-white.png",
-                  width: 12,
-                  height: 12,
-                  excavate: true,
-                }}
-              />
-            ) : (
-              <span className="text-zinc-300" style={{ fontSize: 8, letterSpacing: 1 }}>QR</span>
-            )}
-          </div>
-          {/* CTA + site URL */}
-          <div style={{ textAlign: "right" }}>
-            <div className="text-zinc-700" style={{ fontSize: 9, fontWeight: 600, lineHeight: 1.5 }}>
-              {labels.cta}
+          {slogan && (
+            <div className="text-zinc-400" style={{ fontSize: 13, lineHeight: 1.4 }}>
+              {slogan}
             </div>
-            <div className="text-zinc-700" style={{ fontSize: 8, fontWeight: 600, marginTop: 2 }}>
-              {labels.siteUrl}
-            </div>
-          </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -386,28 +386,48 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
     >
       {/* ── Header ────────────────────────────────────────────── */}
       <div style={{ padding: `28px ${POSTER_PX}px 24px` }}>
-        {/* Top row: brand+tagline (left) ↔ QR+CTA (right), aligned to top */}
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 24 }}>
-          {/* Left: brand stack */}
-          <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 2 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <Iris config={IRIS_NAV} size={20} uid="poster" />
-              <span
-                className="text-zinc-700"
-                style={{ fontSize: 14, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}
+          {/* Left column: brand-stack on top, title+slogan below */}
+          <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <Iris config={IRIS_NAV} size={20} uid="poster" />
+                <span
+                  className="text-zinc-700"
+                  style={{ fontSize: 14, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}
+                >
+                  X-Glass
+                </span>
+              </div>
+              <div
+                className="text-zinc-400"
+                style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.4 }}
               >
-                X-Glass
-              </span>
+                {labels.brandTagline}
+              </div>
             </div>
-            <div
-              className="text-zinc-400"
-              style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.4 }}
-            >
-              {labels.brandTagline}
+
+            <div style={{ marginTop: 28 }}>
+              <div style={{ marginBottom: slogan ? 8 : 0 }}>
+                {titleLines.map((line, i) => (
+                  <div
+                    key={i}
+                    className="text-zinc-900"
+                    style={{ fontSize: titleFontSize, fontWeight: 600, lineHeight: 1.25 }}
+                  >
+                    {line}
+                  </div>
+                ))}
+              </div>
+              {slogan && (
+                <div className="text-zinc-400" style={{ fontSize: 13, lineHeight: 1.4 }}>
+                  {slogan}
+                </div>
+              )}
             </div>
           </div>
 
-          {/* Right: QR + CTA */}
+          {/* Right column: QR + CTA */}
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", flexShrink: 0, gap: 8 }}>
             <div
               style={{
@@ -444,26 +464,6 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
               </div>
             </div>
           </div>
-        </div>
-
-        {/* Title + per-share slogan block */}
-        <div style={{ marginTop: 20 }}>
-          <div style={{ marginBottom: slogan ? 8 : 0 }}>
-            {titleLines.map((line, i) => (
-              <div
-                key={i}
-                className="text-zinc-900"
-                style={{ fontSize: titleFontSize, fontWeight: 600, lineHeight: 1.25 }}
-              >
-                {line}
-              </div>
-            ))}
-          </div>
-          {slogan && (
-            <div className="text-zinc-400" style={{ fontSize: 13, lineHeight: 1.4 }}>
-              {slogan}
-            </div>
-          )}
         </div>
       </div>
 

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -389,21 +389,21 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 24 }}>
           {/* Left column: brand-stack on top, title+slogan below */}
           <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <Iris config={IRIS_NAV} size={20} uid="poster" />
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <Iris config={IRIS_NAV} size={40} uid="poster" />
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                 <span
                   className="text-zinc-700"
-                  style={{ fontSize: 14, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}
+                  style={{ fontSize: 14, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", lineHeight: 1 }}
                 >
                   X-Glass
                 </span>
-              </div>
-              <div
-                className="text-zinc-400"
-                style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.4 }}
-              >
-                {labels.brandTagline}
+                <span
+                  className="text-zinc-400"
+                  style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.2 }}
+                >
+                  {labels.brandTagline}
+                </span>
               </div>
             </div>
 

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -196,7 +196,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     setPosterGenerating(true);
     let blobUrl: string | undefined;
     try {
-      blobUrl = await rasterizePoster(posterRef.current);
+      // Cap share output at 1280px to dodge WeChat's first-pass downscale
+      // (any axis > 1280 gets rescaled before its JPEG quality compression).
+      blobUrl = await rasterizePoster(posterRef.current, { maxWidth: 1280 });
       const blob = await (await fetch(blobUrl)).blob();
       const file = new File([blob], `${posterTitle}.png`, { type: "image/png" });
       await navigator.share({

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -189,8 +189,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
       ? t("shareCtaSingle")
       : t("shareCtaMulti", { count: lenses.length });
     const slogan = effectiveSlogan.trim();
-    const pageUrl = window.location.href;
-    const textParts = [cta, slogan, `👉 ${pageUrl}`].filter(Boolean);
+    const textParts = [cta, slogan].filter(Boolean);
     const text = textParts.join("\n");
 
     setPosterGenerating(true);

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -195,8 +195,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     setPosterGenerating(true);
     let blobUrl: string | undefined;
     try {
-      // Cap share output at 1280px to dodge WeChat's first-pass downscale
-      // (any axis > 1280 gets rescaled before its JPEG quality compression).
+      // Cap share output at 1280px — the long-axis threshold used by the
+      // most aggressive mainstream IM compressors. Staying at/below this
+      // avoids the resize stage and only takes a single quality pass.
       blobUrl = await rasterizePoster(posterRef.current, { maxWidth: 1280 });
       const blob = await (await fetch(blobUrl)).blob();
       const file = new File([blob], `${posterTitle}.png`, { type: "image/png" });

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -88,6 +88,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
   const posterLabels: PosterLabels = {
     appName: "X-Glass",
     siteUrl: `xglass.sentacraft.com/${locale}`,
+    brandTagline: tImage("brandTagline"),
     cta: lenses.length === 1 ? tImage("ctaSingle") : tImage("cta"),
     comparison: computedPosterTitle,
     sectionFocalCoverage: tImage("sectionFocalCoverage"),

--- a/src/hooks/useShareCapabilities.ts
+++ b/src/hooks/useShareCapabilities.ts
@@ -19,6 +19,12 @@ function detectCapabilities() {
       files: [testFile],
     });
   }
+  // iOS non-Safari browsers run inside WKWebView, where canShare({ files })
+  // can return true while navigator.share() silently downloads the file
+  // instead of opening the system share sheet.
+  if (/CriOS|FxiOS|EdgiOS|OPiOS|GSA/i.test(navigator.userAgent)) {
+    canShareFile = false;
+  }
   return { canNativeShare, canShareFile };
 }
 

--- a/src/lib/share-image.ts
+++ b/src/lib/share-image.ts
@@ -1,16 +1,29 @@
 import { domToPng } from "modern-screenshot";
 
+interface RasterizeOptions {
+  /** Cap the output width in pixels. Use 1280 when targeting WeChat to
+   * avoid its 1280-axis downscale (which then JPEG-compresses on top). */
+  maxWidth?: number;
+}
+
 /**
- * Rasterize a DOM node to a PNG data URL at 3× scale.
+ * Rasterize a DOM node to a PNG data URL.
+ * Defaults to 3× scale (high-DPI download); pass `maxWidth` to cap the output.
  * The node must already be in the document (painted and visible).
  */
-export async function rasterizePoster(node: HTMLElement): Promise<string> {
+export async function rasterizePoster(
+  node: HTMLElement,
+  opts: RasterizeOptions = {},
+): Promise<string> {
+  const naturalWidth = node.scrollWidth;
+  const cap = opts.maxWidth ?? Infinity;
+  const scale = Math.min(3, cap / naturalWidth);
   // Pass explicit dimensions so domToPng doesn't rely on getBoundingClientRect(),
   // which returns the visually-scaled size when the element lives inside a CSS transform.
   return domToPng(node, {
-    scale: 3,
+    scale,
     backgroundColor: "#ffffff",
-    width: node.scrollWidth,
+    width: naturalWidth,
     height: node.scrollHeight,
   });
 }

--- a/src/lib/share-image.ts
+++ b/src/lib/share-image.ts
@@ -1,8 +1,9 @@
 import { domToPng } from "modern-screenshot";
 
 interface RasterizeOptions {
-  /** Cap the output width in pixels. Use 1280 when targeting WeChat to
-   * avoid its 1280-axis downscale (which then JPEG-compresses on top). */
+  /** Cap the output width in pixels. 1280 is the long-axis threshold used
+   * by the most aggressive mainstream IM compressors; capping there avoids
+   * the resize stage and only takes a single quality-compression hit. */
   maxWidth?: number;
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -266,6 +266,7 @@
     "na": "N/A",
     "cta": "Scan to compare more lenses for Fujifilm",
     "ctaSingle": "Scan to view full lens data",
+    "brandTagline": "Your Personal Fujifilm Lens Atlas",
     "sectionFocalCoverage": "Focal Coverage",
     "sectionFocus": "Focus",
     "sectionSizeWeight": "Size",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -266,6 +266,7 @@
     "na": "N/A",
     "cta": "扫码对比更多富士卡口镜头",
     "ctaSingle": "查看此镜头的详细数据",
+    "brandTagline": "你的专属富士镜头图鉴",
     "sectionFocalCoverage": "焦段覆盖",
     "sectionFocus": "对焦",
     "sectionSizeWeight": "体积与重量",


### PR DESCRIPTION
## Summary

Four related changes to the share-poster flow, bundled into one PR:

### 1. Header redesign
- Iris 14→20, X-GLASS wordmark 10→14, QR 64→96
- Drop the QR wrapper's 4-px inner padding so its right edge lines up flush with the left logo padding (both at POSTER_PX=40)
- Add a brand tagline (`你的专属富士镜头图鉴` / `Your Personal Fujifilm Lens Atlas`) stacked under the wordmark
- Brand-stack + title + slogan live in the left column; QR + CTA in the right column. Single row, top-aligned

### 2. Drop URL from share text
Some IM share extensions detect URLs in the share `text` and bundle the file + URL + caption into a single packaged link card — collapsing the poster into a thumbnail that opens the URL instead of viewing the image. Removing `👉 ${pageUrl}` from the share `text` makes those receivers fall back to a plain image-message path, so the poster shows up tappable and full-size. Trade-off: receivers that auto-render link cards from URLs in text (e.g. iMessage) lose that card; the "Share link" tab remains the canonical link-share path for that use case.

### 3. Cap share rasterize at 1280 px
1280 px is the long-axis threshold used by the most aggressive mainstream IM compressors: anything above it gets resized down to 1280 before a JPEG quality pass, costing detail twice. Sending the existing 2250×3765 PNG meant text went through both stages. Add a `maxWidth` option to `rasterizePoster` and use `maxWidth: 1280` for the share path only — downloads still produce the full 3× (2250-wide) variant.

### 4. Hide share button on iOS non-Safari browsers
iOS Chrome / Firefox / Edge / Opera / Google App all run inside WKWebView, where `navigator.canShare({ files })` reports true but `navigator.share()` silently downloads the file instead of opening the system share sheet. Pattern-match `CriOS|FxiOS|EdgiOS|OPiOS|GSA` and force `canShareFile = false` so these users see only the download button.

## Test plan
- [ ] iOS Safari → poster shares via system sheet as an image-only message (no packaged link card from receivers that bundle text+file)
- [ ] iOS Chrome → share button is hidden; only download button visible
- [ ] Receive on an IM that compresses → poster text is sharper (no second-pass downscale, only the quality pass)
- [ ] Desktop → download produces 2250-wide PNG; share button hidden if no share API
- [ ] QR right edge and logo left edge are visually symmetric on the rendered poster

🤖 Generated with [Claude Code](https://claude.com/claude-code)