### PR TITLE
feat(ux): unify floating buttons across detail and compare pages

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ExternalLink } from "@/components/ui/external-link";
 import { Link } from "@/i18n/navigation";
 import AddToCompareButton from "@/components/AddToCompareButton";
 import BackToTopButton from "@/components/BackToTopButton";
+import ShareFAB from "@/components/ShareFAB";
 import { ShareButton } from "@/components/share/ShareButton";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 import { ACTION_OUTLINE_CLS } from "@/lib/ui-tokens";
@@ -358,6 +359,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
       </div>
     </div>
     <BackToTopButton />
+    <ShareFAB lenses={[lens]} />
     </>
   );
 }

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -6,6 +6,7 @@ import { getPresetBySlug } from "@/lib/curated-presets";
 import CompareTable from "@/components/CompareTable";
 import ComparePageHeader from "@/components/ComparePageHeader";
 import CuratedComparisons from "@/components/CuratedComparisons";
+import BackToTopButton from "@/components/BackToTopButton";
 import { buildAlternates } from "@/lib/seo";
 import { notFound } from "next/navigation";
 
@@ -86,6 +87,7 @@ export default async function ComparePage({
       <ComparePageHeader minColumns={2} presetTitle={presetTitle} presetSubtitle={presetSubtitle} presetLensIds={foundPreset?.lensIds} />
       <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
       {resolvedMount === "X" && <CuratedComparisons />}
+      <BackToTopButton />
     </div>
   );
 }

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Z } from "@/config/ui";
+import { useMemo } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { ShareButton } from "@/components/share/ShareButton";
+import ShareFAB from "@/components/ShareFAB";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
@@ -59,25 +59,9 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
   const effectivePresetTitle = presetStillMatches ? presetTitle : undefined;
   const effectivePresetSubtitle = presetStillMatches ? presetSubtitle : undefined;
 
-  const headerRef = useRef<HTMLDivElement>(null);
-  const [showFab, setShowFab] = useState(false);
-  // Show the FAB when the header row scrolls behind the nav bar
-  useEffect(() => {
-    const el = headerRef.current;
-    if (!el) {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => setShowFab(!entry.isIntersecting),
-      { root: null, rootMargin: "0px", threshold: 0 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
   return (
     <>
-      <div ref={headerRef} className="flex items-center gap-3">
+      <div className="flex items-center gap-3">
         <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h1>
@@ -97,18 +81,11 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
         )}
       </div>
 
-      {/* Floating share FAB — slides up when the header share button is out of view */}
-      <div
-        data-testid="compare-share-fab"
-        className={`fixed bottom-6 right-4 ${Z.fixed} transition-all duration-200 sm:right-6 ${
-          showFab && activeLenses.length >= 1
-            ? "opacity-100 translate-y-0 pointer-events-auto"
-            : "opacity-0 translate-y-3 pointer-events-none"
-        }`}
-        aria-hidden={!(showFab && activeLenses.length >= 1)}
-      >
-        <ShareButton lenses={activeLenses} variant="fab" presetTitle={effectivePresetTitle} presetSubtitle={effectivePresetSubtitle} />
-      </div>
+      <ShareFAB
+        lenses={activeLenses}
+        presetTitle={effectivePresetTitle}
+        presetSubtitle={effectivePresetSubtitle}
+      />
     </>
   );
 }

--- a/src/components/ShareFAB.tsx
+++ b/src/components/ShareFAB.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Z } from "@/config/ui";
+import { spring } from "@/lib/animation";
+import { ShareButton } from "@/components/share/ShareButton";
+import type { Lens } from "@/lib/types";
+
+const SCROLL_THRESHOLD = 400;
+
+interface Props {
+  lenses: Lens[];
+  presetTitle?: string;
+  presetSubtitle?: string;
+}
+
+export default function ShareFAB({ lenses, presetTitle, presetSubtitle }: Props) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > SCROLL_THRESHOLD);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (lenses.length === 0) {
+    return null;
+  }
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.8 }}
+          transition={spring.bounce}
+          className={`fixed bottom-24 right-6 ${Z.fixed}`}
+          data-testid="share-fab"
+        >
+          <ShareButton
+            lenses={lenses}
+            variant="fab"
+            presetTitle={presetTitle}
+            presetSubtitle={presetSubtitle}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `ShareFAB` component mirroring `BackToTopButton`'s mechanics (scrollY > 400 trigger, hardcoded fixed position, same enter animation) and wire it into both the lens detail page and the compare page.
- Add `BackToTopButton` to the compare page — its spec table now grows long enough that the "long-scroll content" criterion (originally used to justify back-to-top on list/detail/about) applies here too.
- Replace the compare header's IntersectionObserver-driven FAB with the shared component so both floating buttons share one trigger model.

Visual unification covers size (48×48), shadow, radius, z-index, and scroll threshold. Colors stay intentionally distinct: `BackToTop` neutral (white/border) as a utility affordance, `ShareFAB` high-contrast (dark fill) as a primary action.

Layout:
- BackToTop: `fixed bottom-40 right-6`
- ShareFAB:  `fixed bottom-24 right-6` (16px gap above when stacked)

## Test plan
- [x] Detail page: scroll past 400px → both buttons appear, stacked
- [x] Compare page: scroll past 400px → both buttons appear, stacked
- [x] Computed positions verified via DOM (`bottom: 160px` / `96px`, both `right: 24px`, both `z-40`, both 48×48)
- [ ] Mobile spot check on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)