### PR TITLE
docs(license): include lenses-gfx.json in MIT exclusion list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Applies to: source code only. Excludes src/data/lenses.json — see LICENSE-DATA.
+Applies to: source code only. Excludes src/data/lenses.json and src/data/lenses-gfx.json — see LICENSE-DATA.
 
 Copyright (c) 2026 SentaCraft
 


### PR DESCRIPTION
## Summary
- `LICENSE-DATA` already covers both `lenses.json` and `lenses-gfx.json`, but the MIT `LICENSE` preamble only named `lenses.json` as excluded. The GFX dataset was effectively unclaimed by either license.
- One-line fix to align the two files.

## Test plan
- [x] Diff inspection — single-line change in `LICENSE` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)