### PR TITLE
fix(lens-detail): container-query secondary button text + zh mount labels

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -279,7 +279,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
           {/* Actions — mt-auto pushes them to the bottom of the stretched
               info column so the row aligns with the image card's bottom. */}
-          <div className="flex flex-wrap gap-3 mt-auto">
+          <div className="flex flex-wrap gap-2 sm:gap-3 mt-auto">
             <AddToCompareButton lensId={lens.id} />
             {url ? (
               <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import { Flag, ArrowUpRight } from "lucide-react";
+import { Flag } from "lucide-react";
 import { routing } from "@/i18n/routing";
 import { getLensesByMount, getLensUrl } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
@@ -258,8 +258,12 @@ export default async function LensDetailPage({ params }: { params: Params }) {
           </div>
         </div>
 
-        {/* Info: title → price → actions */}
-        <div className="flex-1 flex flex-col gap-5">
+        {/* Info: title → price → actions.
+            @container so the actions row below can use container queries
+            to hide secondary button text when the info column gets narrow
+            (small desktop / portrait tablet), avoiding the 4-button row
+            wrapping into 2 rows. */}
+        <div className="@container flex-1 flex flex-col gap-5">
           {/* Title */}
           <div>
             <p className="text-sm text-zinc-500 dark:text-zinc-400">
@@ -279,12 +283,11 @@ export default async function LensDetailPage({ params }: { params: Params }) {
             <AddToCompareButton lensId={lens.id} />
             {url ? (
               <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>
-                <span className="max-xs:hidden">{t("officialSite")}</span>
+                {t("officialSite")}
               </ExternalLink>
             ) : (
               <span className={ACTION_OUTLINE_CLS + " cursor-not-allowed opacity-40"}>
-                <span className="max-xs:hidden">{t("officialSite")}</span>
-                <ArrowUpRight size={12} />
+                {t("officialSite")}
               </span>
             )}
             <ShareButton lenses={[lens]} triggerClassName={ACTION_OUTLINE_CLS} />
@@ -295,7 +298,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
               className={ACTION_OUTLINE_CLS}
             >
               <Flag size={14} />
-              <span className="max-xs:hidden">{t("reportIssue")}</span>
+              <span className="max-xs:hidden @max-md:hidden">{t("reportIssue")}</span>
             </FeedbackTrigger>
           </div>
         </div>

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import { Flag } from "lucide-react";
+import { Flag, ArrowUpRight } from "lucide-react";
 import { routing } from "@/i18n/routing";
 import { getLensesByMount, getLensUrl } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
@@ -239,17 +239,17 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
       {/* Header: image + key info side by side */}
       <div className="flex flex-col sm:flex-row gap-8">
-        {/* Image — 288px so the 1:1 card height matches (or slightly exceeds)
-            the info column, letting mt-auto on the buttons row push them
-            cleanly to the image's bottom edge. */}
-        <div className="w-full max-w-72 mx-auto sm:mx-0 shrink-0 sm:w-72">
+        {/* Image — 256px so the 1:1 card height still exceeds the info
+            column, letting mt-auto on the buttons row push them cleanly to
+            the image's bottom edge. */}
+        <div className="w-full max-w-64 mx-auto sm:mx-0 shrink-0 sm:w-64">
           <div className="flex aspect-square items-center justify-center overflow-hidden rounded-2xl border border-zinc-100 bg-zinc-50/70 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
             <div className="relative aspect-square w-full overflow-hidden">
               <Image
                 src={getLensImageUrl(lens.id)}
                 alt={lens.model}
                 fill
-                sizes="288px"
+                sizes="256px"
                 style={lensImageStyle}
                 className="object-contain"
                 priority
@@ -279,11 +279,12 @@ export default async function LensDetailPage({ params }: { params: Params }) {
             <AddToCompareButton lensId={lens.id} />
             {url ? (
               <ExternalLink href={url} className={ACTION_OUTLINE_CLS}>
-                {t("officialSite")}
+                <span className="max-xs:hidden">{t("officialSite")}</span>
               </ExternalLink>
             ) : (
               <span className={ACTION_OUTLINE_CLS + " cursor-not-allowed opacity-40"}>
-                {t("officialSite")}
+                <span className="max-xs:hidden">{t("officialSite")}</span>
+                <ArrowUpRight size={12} />
               </span>
             )}
             <ShareButton lenses={[lens]} triggerClassName={ACTION_OUTLINE_CLS} />

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -375,7 +375,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-900 text-white shadow-lg outline-none transition-colors hover:bg-zinc-700 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200";
 
   const triggerContent = isFab ? <Share2 className="size-5" /> : (
-    <><Share2 className="size-4" /><span className="max-xs:hidden">{t("button")}</span></>
+    <><Share2 className="size-4" /><span className="max-xs:hidden @max-md:hidden">{t("button")}</span></>
   );
 
   const shareControl = !mounted ? (

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -44,8 +44,8 @@
   },
   "MountSwitcher": {
     "label": "切换卡口系统",
-    "x": "X Mount",
-    "gfx": "G Mount"
+    "x": "X 卡口",
+    "gfx": "G 卡口"
   },
   "Home": {
     "cta": "浏览镜头",


### PR DESCRIPTION
## Summary

Three small UX fixes shipped together.

**Container-query-driven button text hide**
- Mark the lens detail's info column as `@container`.
- Share + Report button text now use `max-xs:hidden @max-md:hidden`. When the info column is below 28rem — narrow desktop, portrait tablet, or the `sm:flex-row` band where the actions row gets tight — the two secondary buttons collapse to icon-only and the 4-button row stops wrapping. On wide desktop the text still shows.
- `ShareButton` is also rendered inside `ComparePageHeader`, which has no `@container` ancestor, so the new variant is a no-op there and that surface keeps its existing "always show text" behaviour. Verified visually.
- Official-site button is left untouched — it keeps its main-branch behaviour (text always rendered).

**Tighter row gap on mobile**
- Actions row drops from `gap-3` (12px) to `gap-2` (8px) below `sm:` (640px). On iPhone SE 2nd/3rd gen (375px) and similar narrow phones, the prior 12px gap pushed the 4-button row 4-11px over the available width even with share/report icon-only, so the report button wrapped. The 4px saving puts the row back on one line.

**Hero image shrink**
- Lens detail hero image goes from `w-72` (288px) to `w-64` (256px), ~11%. The info column is still shorter than the image card on `sm:`+, so `mt-auto` on the actions row continues to align with the image card's bottom edge.

**i18n**
- `zh.json` `MountSwitcher`: `X Mount` / `G Mount` → `X 卡口` / `G 卡口`.

## Test plan

| Width | Result |
| --- | --- |
| 320 (iPhone SE 2016) | Flag still wraps — physically impossible to fit 4 buttons in 288px content width without shrinking text buttons. Out of scope. |
| 375 (iPhone SE 2/3 gen) | 4 buttons in one row ✓ |
| 393 (iPhone 15) | 4 buttons in one row ✓ |
| 760 (narrow desktop / iPad portrait) | Share/Report icon-only, official-site keeps text, one row ✓ |
| 1024 / 1440 (desktop) | All 4 buttons with full text ✓ |
| Compare page header at 760 | Share button still shows "分享" text — `ComparePageHeader` has no `@container` ancestor so the new variant is a no-op there ✓ |
| Nav (zh) | Mount labels render as `X 卡口` / `G 卡口` ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)