### PR TITLE
feat(seo): add Organization + WebSite JSON-LD for brand recognition

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
 import AssetTelemetry from "@/components/AssetTelemetry";
+import SiteJsonLd from "@/components/SiteJsonLd";
 import { routing } from "@/i18n/routing";
 import Nav from "@/components/Nav";
 import ConsoleEgg from "@/components/ConsoleEgg";
@@ -141,6 +142,7 @@ export default async function LocaleLayout({
   return (
     <html lang={locale} className={fontClassName}>
       <body>
+        <SiteJsonLd locale={locale} />
         <NextIntlClientProvider messages={messages}>
           <MountPreferenceProvider>
           <CompareProvider>

--- a/src/components/SiteJsonLd.tsx
+++ b/src/components/SiteJsonLd.tsx
@@ -1,0 +1,51 @@
+import { SITE } from "@/config/site";
+import { routing } from "@/i18n/routing";
+
+const ORG_ID = `${SITE.url}/#organization`;
+const SITE_ID = `${SITE.url}/#website`;
+
+// Brand alternate names — including the China-market 图鉴 variant — so Google
+// learns that short queries like "xglass" or "富士镜头图鉴" resolve to this site.
+const BRAND_ALTERNATE_NAMES = [
+  "xglass",
+  "x glass",
+  "X Glass",
+  "富士镜头图鉴",
+  "X-Glass 富士镜头图鉴",
+];
+
+export default function SiteJsonLd({ locale }: { locale: string }) {
+  const graph = [
+    {
+      "@type": "Organization",
+      "@id": ORG_ID,
+      name: SITE.name,
+      alternateName: BRAND_ALTERNATE_NAMES,
+      url: SITE.url,
+      logo: {
+        "@type": "ImageObject",
+        url: `${SITE.url}/logo.png`,
+        width: 1912,
+        height: 1912,
+      },
+    },
+    {
+      "@type": "WebSite",
+      "@id": SITE_ID,
+      name: SITE.name,
+      alternateName: BRAND_ALTERNATE_NAMES,
+      url: `${SITE.url}/${locale}`,
+      inLanguage: routing.locales,
+      publisher: { "@id": ORG_ID },
+    },
+  ];
+
+  const json = JSON.stringify({ "@context": "https://schema.org", "@graph": graph });
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  );
+}

--- a/src/components/SiteJsonLd.tsx
+++ b/src/components/SiteJsonLd.tsx
@@ -22,6 +22,9 @@ export default function SiteJsonLd({ locale }: { locale: string }) {
       name: SITE.name,
       alternateName: BRAND_ALTERNATE_NAMES,
       url: SITE.url,
+      sameAs: [
+        "https://github.com/sentacraft/x-glass",
+      ],
       logo: {
         "@type": "ImageObject",
         url: `${SITE.url}/logo.png`,


### PR DESCRIPTION
## Summary

- Emit `Organization` + `WebSite` JSON-LD in the localized layout so Google can bind the X-Glass brand to this domain.
- `alternateName` covers short-name variants users actually type: `xglass`, `x glass`, `X Glass`, `富士镜头图鉴`, `X-Glass 富士镜头图鉴`.
- `sameAs` links the public GitHub repo (https://github.com/sentacraft/x-glass) so brand signals collected there consolidate onto the same entity. Additional channels (社交账号、个人主页) can be added to the same array as they come online.
- Canonical + hreflang were already wired via `buildAlternates` on every page; no changes needed there.

## Why now

GSC shows the site is indexed (85 pages) but gets near-zero impressions, and short brand queries (`x-glass`, `xglass`) don't surface this site at all — there were no structured brand signals on the page for Google to bind. Xiaohongshu marketing produces no Google-visible backlinks, so a structured self-declaration is the lowest-cost lever available.

## Verified

- `npm run lint` clean on the new files (the 33 pre-existing lint errors on `main` are unrelated).
- Local dev render confirms both `/en` and `/zh` emit a valid JSON-LD `<script>` tag containing both nodes, all alternateNames, and the GitHub sameAs link.
- After deploy, run [Rich Results Test](https://search.google.com/test/rich-results) on the production URL to validate the markup syntax, then GSC → URL Inspection → Request indexing on `/`, `/en`, `/zh` to nudge Googlebot.

## Test plan

- [ ] Vercel preview URL renders without error
- [ ] `view-source:` on `/en` shows the `<script type="application/ld+json">` block
- [ ] Rich Results Test reports zero errors on production URL after merge