### PR TITLE
refactor(compare): unify URL projection and make ids the single source of truth

### DIFF
--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { parseLensIds } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
-import { getPresetBySlug } from "@/lib/curated-presets";
+import { findPresetByIds } from "@/lib/curated-presets";
 import CompareTable from "@/components/CompareTable";
 import ComparePageHeader from "@/components/ComparePageHeader";
 import CuratedComparisons from "@/components/CuratedComparisons";
@@ -19,7 +19,7 @@ import { notFound } from "next/navigation";
 export const revalidate = 31536000; // 1 year
 
 type Params = Promise<{ locale: string; mount: string }>;
-type SearchParams = Promise<{ ids?: string; from?: "lens" | "home"; lensId?: string; preset?: string }>;
+type SearchParams = Promise<{ ids?: string }>;
 
 export async function generateMetadata({
   params,
@@ -30,7 +30,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const t = await getTranslations("Compare");
   const { locale, mount } = await params;
-  const { ids, preset } = await searchParams;
+  const { ids } = await searchParams;
   const resolvedMount = urlSegmentToMount(mount);
   if (!resolvedMount) {
     return { title: t("title") };
@@ -39,13 +39,14 @@ export async function generateMetadata({
   const lenses = parseLensIds(ids, resolvedMount, locale);
   const alternates = buildAlternates(locale, `lenses/${mount}/compare`);
 
-  if (preset) {
-    const found = getPresetBySlug(preset);
-    if (found) {
-      const lang = locale === "zh" ? "zh" : "en";
-      const title = found.title[lang];
-      return { title, openGraph: { title: `${title} | X-Glass` }, alternates };
-    }
+  // Reverse-derive the curated preset, if any, from the URL's ids.
+  // Lets shared `?ids=...` links render with the curated framing in SEO /
+  // OG metadata without keeping a separate `?preset=` URL param.
+  const matchedPreset = findPresetByIds(lenses.map((l) => l.id));
+  if (matchedPreset) {
+    const lang = locale === "zh" ? "zh" : "en";
+    const title = matchedPreset.title[lang];
+    return { title, openGraph: { title: `${title} | X-Glass` }, alternates };
   }
 
   if (lenses.length < 2) {
@@ -69,7 +70,7 @@ export default async function ComparePage({
 }) {
   const { locale, mount } = await params;
   setRequestLocale(locale);
-  const { ids, preset } = await searchParams;
+  const { ids } = await searchParams;
   const resolvedMount = urlSegmentToMount(mount);
   if (!resolvedMount) {
     notFound();
@@ -77,14 +78,9 @@ export default async function ComparePage({
 
   const lenses = parseLensIds(ids, resolvedMount, locale);
 
-  const lang = locale === "zh" ? "zh" : "en";
-  const foundPreset = preset ? getPresetBySlug(preset) : undefined;
-  const presetTitle = foundPreset?.title[lang];
-  const presetSubtitle = foundPreset?.subtitle[lang];
-
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-8 flex flex-col gap-3 sm:gap-4">
-      <ComparePageHeader minColumns={2} presetTitle={presetTitle} presetSubtitle={presetSubtitle} presetLensIds={foundPreset?.lensIds} />
+      <ComparePageHeader minColumns={2} />
       <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
       {resolvedMount === "X" && <CuratedComparisons />}
       <BackToTopButton />

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -2,8 +2,6 @@
 
 import { useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "@/i18n/navigation";
-import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { toast } from "sonner";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { MAX_COMPARE } from "@/lib/lens";
@@ -16,36 +14,32 @@ interface Props {
 
 export default function CompareAddLensButton({ triggerClassName }: Props) {
   const t = useTranslations("Compare");
-  const router = useRouter();
-  const { buildCompareUrl } = useCompareUrl();
-  const { compareIds } = useMountedCompare();
+  const { compareIds, replaceCompare } = useMountedCompare();
 
   const canAddMore = compareIds.length < MAX_COMPARE;
-  const currentIds = compareIds;
 
   const handleSelectLens = useCallback(
     (lens: Lens) => {
-      if (currentIds.includes(lens.id) || currentIds.length >= MAX_COMPARE) {
+      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
         return;
       }
-      const nextIds = [...currentIds, lens.id];
-      router.replace(buildCompareUrl(nextIds));
+      replaceCompare([...compareIds, lens.id]);
     },
-    [currentIds, router, buildCompareUrl]
+    [compareIds, replaceCompare]
   );
 
   const getResultState = useCallback(
     (candidate: Lens) => ({
-      actionLabel: currentIds.includes(candidate.id)
+      actionLabel: compareIds.includes(candidate.id)
         ? t("alreadyAdded")
-        : currentIds.length >= MAX_COMPARE
+        : compareIds.length >= MAX_COMPARE
           ? t("compareFull")
           : t("addToCompareAction"),
       disabled:
-        currentIds.includes(candidate.id) ||
-        currentIds.length >= MAX_COMPARE,
+        compareIds.includes(candidate.id) ||
+        compareIds.length >= MAX_COMPARE,
     }),
-    [currentIds, t]
+    [compareIds, t]
   );
 
   const btnClass =

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import { useRouter, usePathname } from "@/i18n/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { getLensesByMount } from "@/lib/lens";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
@@ -20,7 +20,6 @@ export default function CompareBar() {
   const tBrand = useTranslations("Brands");
   const tCompare = useTranslations("Compare");
   const router = useRouter();
-  const pathname = usePathname();
   const locale = useLocale();
   const mount = useEffectiveMount();
   const { compareIds, toggleCompare, clearCompare } = useMountedCompare();
@@ -53,18 +52,10 @@ export default function CompareBar() {
     }
   }, []);
 
-  // Extract lens ID if currently on a lens detail page (/lenses/[mount]/[id])
-  const currentLensId = useMemo(() => {
-    const seg = mountToUrlSegment(mount);
-    const match = pathname.match(new RegExp(`\\/lenses\\/${seg}\\/(?!compare\\b)([^/]+)$`));
-    return match?.[1] ?? null;
-  }, [pathname, mount]);
-
   function handleCompare() {
     const ids = selectedLenses.map((l) => l.id).join(",");
     const seg = mountToUrlSegment(mount);
-    const fromParam = currentLensId ? `&from=lens&lensId=${currentLensId}` : "";
-    router.push(`/lenses/${seg}/compare?ids=${ids}${fromParam}`);
+    router.push(`/lenses/${seg}/compare?ids=${ids}`);
   }
 
   return (

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -7,30 +7,23 @@ import ShareFAB from "@/components/ShareFAB";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
-import { mountToUrlSegment } from "@/lib/mount";
 import { getLensesByMount } from "@/lib/lens";
-import { useRouter } from "@/i18n/navigation";
+import { findPresetByIds } from "@/lib/curated-presets";
 import type { Lens } from "@/lib/types";
 import { TEXT_LINK_CLS } from "@/lib/ui-tokens";
 
 interface Props {
   /** Matches CompareTable minColumns — button is hidden while empty slot columns are visible. */
   minColumns?: number;
-  /** Preset title to pre-fill the poster title field. */
-  presetTitle?: string;
-  /** Preset subtitle to pre-fill the poster slogan field. */
-  presetSubtitle?: string;
-  /** Original lens IDs of the preset — used to detect when the user has modified the comparison. */
-  presetLensIds?: string[];
 }
 
-export default function ComparePageHeader({ minColumns = 0, presetTitle, presetSubtitle, presetLensIds }: Props) {
+export default function ComparePageHeader({ minColumns = 0 }: Props) {
   const t = useTranslations("Compare");
   const tList = useTranslations("LensList");
   const { compareIds, clearCompare } = useMountedCompare();
   const mount = useEffectiveMount();
   const locale = useLocale();
-  const router = useRouter();
+  const lang = locale === "zh" ? "zh" : "en";
 
   // Resolve full Lens objects from context IDs.
   // CompareTable seeds context via useLayoutEffect (before paint), so
@@ -43,21 +36,14 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
     [compareIds, mount, locale],
   );
 
-  // Only forward preset title/subtitle when the current comparison still
-  // matches the original preset (same set of lens IDs, order-insensitive).
-  const presetStillMatches = useMemo(() => {
-    if (!presetLensIds || presetLensIds.length === 0) {
-      return false;
-    }
-    if (compareIds.length !== presetLensIds.length) {
-      return false;
-    }
-    const currentSet = new Set(compareIds);
-    return presetLensIds.every((id) => currentSet.has(id));
-  }, [compareIds, presetLensIds]);
-
-  const effectivePresetTitle = presetStillMatches ? presetTitle : undefined;
-  const effectivePresetSubtitle = presetStillMatches ? presetSubtitle : undefined;
+  // Reverse-derive the matching curated preset (if any) from the current
+  // compare state. `?ids=` is the URL's single source of truth, so a preset
+  // is "active" iff its lensIds exactly equal the live compareIds —
+  // regardless of how the user got here (curated link, deep link, or
+  // assembling by hand on the compare page itself).
+  const matchedPreset = useMemo(() => findPresetByIds(compareIds), [compareIds]);
+  const presetTitle = matchedPreset?.title[lang];
+  const presetSubtitle = matchedPreset?.subtitle[lang];
 
   return (
     <>
@@ -68,7 +54,7 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
         {activeLenses.length >= minColumns && <CompareAddLensButton />}
         {activeLenses.length > 0 && (
           <button
-            onClick={() => { clearCompare(); router.replace(`/lenses/${mountToUrlSegment(mount)}/compare`); }}
+            onClick={clearCompare}
             className={`shrink-0 text-sm font-medium px-3 py-2 rounded-xl ${TEXT_LINK_CLS}`}
           >
             {tList("clearCompare")}
@@ -76,15 +62,15 @@ export default function ComparePageHeader({ minColumns = 0, presetTitle, presetS
         )}
         {activeLenses.length >= 1 && (
           <div className="ml-auto">
-            <ShareButton lenses={activeLenses} presetTitle={effectivePresetTitle} presetSubtitle={effectivePresetSubtitle} />
+            <ShareButton lenses={activeLenses} presetTitle={presetTitle} presetSubtitle={presetSubtitle} />
           </div>
         )}
       </div>
 
       <ShareFAB
         lenses={activeLenses}
-        presetTitle={effectivePresetTitle}
-        presetSubtitle={effectivePresetSubtitle}
+        presetTitle={presetTitle}
+        presetSubtitle={presetSubtitle}
       />
     </>
   );

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -20,7 +20,7 @@ import { FieldNotePopover } from "@/components/ui/field-note-popover";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 import type { FeedbackField } from "@/components/FeedbackDialog";
 import { useMountedCompare } from "@/context/CompareProvider";
-import { useCompareUrl } from "@/hooks/useCompareUrl";
+import { useCompareUrlSync } from "@/hooks/useCompareUrlSync";
 import { getLensesByMount, getLensUrl, MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import LensSearchDialog from "@/components/LensSearchDialog";
@@ -295,7 +295,10 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const priceFieldLabel = tPricing("fieldLabel");
   const priceGroupLabel = tPricing("groupLabel");
   const { compareIds, replaceCompare } = useMountedCompare();
-  const { buildLocalizedCompareUrl } = useCompareUrl();
+  // Compare page is the only surface that projects compare state onto the
+  // URL. This hook owns that projection so individual write callsites no
+  // longer need to know about address-bar bookkeeping.
+  useCompareUrlSync();
   const mount = useEffectiveMount();
   const initialLensIds = useMemo(
     () => initialLenses.map((lens) => lens.id),
@@ -325,26 +328,14 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   // Number of empty slot columns to render (search triggers filling up to minColumns)
   const emptySlotCount = Math.max(0, minColumns - orderedLenses.length);
 
-  const updateCompare = useCallback(
-    (nextIds: string[]) => {
-      replaceCompare(nextIds);
-      // Update only the address bar — avoids RSC round-trip and the redundant
-      // server-side re-parse of ids that the client already computed.
-      // Use the locale-prefixed form because replaceState writes the path
-      // verbatim (next-intl's router would have auto-prefixed it for us).
-      window.history.replaceState(null, "", buildLocalizedCompareUrl(nextIds));
-    },
-    [replaceCompare, buildLocalizedCompareUrl]
-  );
-
   const handleAddLens = useCallback(
     (lens: Lens) => {
       if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
         return;
       }
-      updateCompare([...compareIds, lens.id]);
+      replaceCompare([...compareIds, lens.id]);
     },
-    [compareIds, updateCompare]
+    [compareIds, replaceCompare]
   );
 
   const getAddResultState = useCallback(
@@ -369,7 +360,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   };
 
   function handleRemoveLens(lensId: string) {
-    updateCompare(compareIds.filter((id) => id !== lensId));
+    replaceCompare(compareIds.filter((id) => id !== lensId));
   }
 
   function handleShiftLens(lensId: string, direction: -1 | 1) {
@@ -380,7 +371,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     }
     const next = [...compareIds];
     [next[index], next[newIndex]] = [next[newIndex], next[index]];
-    updateCompare(next);
+    replaceCompare(next);
   }
 
   const allGroups = useMemo(

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -23,7 +23,7 @@ export function PresetCard({ preset, onSelect }: { preset: CuratedPreset; onSele
     .filter(Boolean);
 
   function handleClick() {
-    router.replace(buildCompareUrl(preset.lensIds, { preset: preset.slug }));
+    router.replace(buildCompareUrl(preset.lensIds));
     onSelect?.();
   }
 

--- a/src/hooks/useCompareUrl.ts
+++ b/src/hooks/useCompareUrl.ts
@@ -1,13 +1,11 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useLocale } from "next-intl";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
 
 /**
- * Builds mount-aware compare page URLs while preserving back-navigation context
- * (from / lensId) that was set when the user first entered the compare page.
+ * Builds mount-aware compare page URLs.
  *
  * Two flavors are returned:
  *
@@ -23,42 +21,28 @@ import { mountToUrlSegment } from "@/lib/mount";
  * to keep commas in the `ids` list unencoded (`A,B` instead of `A%2CB`).
  * Commas are valid query-string characters and the readable form matches
  * what users expect when copying or sharing the URL.
+ *
+ * `ids` is the URL's single source of truth for compare state. The curated
+ * preset that a comparison may match is derived from `ids` (see
+ * `findPresetByIds`), not carried as a separate URL param.
  */
 export function useCompareUrl() {
-  const searchParams = useSearchParams();
   const mount = useEffectiveMount();
   const locale = useLocale();
 
-  function buildQuery(ids: string[], extra?: { preset?: string }): string {
-    const parts: string[] = [];
-    if (ids.length > 0) {
-      parts.push(`ids=${ids.join(",")}`);
-    }
-    if (extra?.preset) {
-      parts.push(`preset=${encodeURIComponent(extra.preset)}`);
-    }
-
-    const from = searchParams.get("from");
-    const lensId = searchParams.get("lensId");
-    if (from) {
-      parts.push(`from=${encodeURIComponent(from)}`);
-    }
-    if (lensId) {
-      parts.push(`lensId=${encodeURIComponent(lensId)}`);
-    }
-
-    return parts.join("&");
+  function buildQuery(ids: string[]): string {
+    return ids.length > 0 ? `ids=${ids.join(",")}` : "";
   }
 
-  function buildCompareUrl(ids: string[], extra?: { preset?: string }) {
+  function buildCompareUrl(ids: string[]) {
     const seg = mountToUrlSegment(mount);
-    const qs = buildQuery(ids, extra);
+    const qs = buildQuery(ids);
     return qs ? `/lenses/${seg}/compare?${qs}` : `/lenses/${seg}/compare`;
   }
 
-  function buildLocalizedCompareUrl(ids: string[], extra?: { preset?: string }) {
+  function buildLocalizedCompareUrl(ids: string[]) {
     const seg = mountToUrlSegment(mount);
-    const qs = buildQuery(ids, extra);
+    const qs = buildQuery(ids);
     const path = `/${locale}/lenses/${seg}/compare`;
     return qs ? `${path}?${qs}` : path;
   }

--- a/src/hooks/useCompareUrlSync.ts
+++ b/src/hooks/useCompareUrlSync.ts
@@ -1,31 +1,51 @@
 "use client";
 
 import { useEffect } from "react";
+import { useLocale } from "next-intl";
 import { useMountedCompare } from "@/context/CompareProvider";
-import { useCompareUrl } from "@/hooks/useCompareUrl";
+import { useEffectiveMount } from "@/hooks/useMountParam";
+import { mountToUrlSegment } from "@/lib/mount";
 
 /**
  * Projects the current compare state onto the address bar for the compare
  * page surface — and only the compare page.
  *
- * CompareContext is the single client-side source of truth for the lens
- * selection. The compare page's URL (`?ids=A,B,C`) is a derived projection
- * so the comparison can be linked, refreshed, or shared. Other surfaces
+ * `CompareContext` is the single client-side source of truth for the lens
+ * selection. The compare page's URL (`?ids=A,B,C`) is a write-only derived
+ * view so the comparison can be linked, refreshed, or shared. Other surfaces
  * (lens list, lens detail) carry compare state via context only; their URLs
  * have nothing to sync, so this hook is never mounted there.
  *
- * Implementation note: `window.history.replaceState` is used instead of
- * `router.replace` because the latter triggers an RSC round-trip, which is
- * wasteful here — the new URL maps to the same page and the new compareIds
- * are already authoritative on the client. `history.replaceState` updates
- * the address bar without contacting the server; Next.js' monkey-patched
- * history API still notifies `usePathname` / `useSearchParams` consumers.
+ * Why `window.history.replaceState` instead of `router.replace`: the latter
+ * forces an RSC round-trip even though the new ids are already authoritative
+ * on the client. `history.replaceState` (monkey-patched by Next.js) updates
+ * the address bar without contacting the server while still notifying
+ * `usePathname` / `useSearchParams` subscribers.
+ *
+ * Why this hook does NOT read `useSearchParams`: the URL only carries `ids`.
+ * Anything else previously squatting on the query string (`preset`, `from`,
+ * `lensId`) has been removed — `preset` is reverse-derived from `ids` where
+ * needed, `from` / `lensId` were dead code. With nothing else to preserve,
+ * the projection becomes a pure function of compare state, and the effect's
+ * deps are all stable primitives. No race window between `useSearchParams`
+ * updating synchronously after a router navigation and `compareIds` syncing
+ * via `useLayoutEffect` moments later.
  */
 export function useCompareUrlSync() {
   const { compareIds } = useMountedCompare();
-  const { buildLocalizedCompareUrl } = useCompareUrl();
+  const mount = useEffectiveMount();
+  const locale = useLocale();
 
   useEffect(() => {
-    window.history.replaceState(null, "", buildLocalizedCompareUrl(compareIds));
-  }, [compareIds, buildLocalizedCompareUrl]);
+    const seg = mountToUrlSegment(mount);
+    const qs = compareIds.length > 0 ? `?ids=${compareIds.join(",")}` : "";
+    const url = `/${locale}/lenses/${seg}/compare${qs}`;
+
+    // No-op when the URL already matches — avoids re-emitting a router event
+    // (and the associated subscriber re-renders) for an already-correct URL.
+    if (window.location.pathname + window.location.search === url) {
+      return;
+    }
+    window.history.replaceState(null, "", url);
+  }, [compareIds, mount, locale]);
 }

--- a/src/hooks/useCompareUrlSync.ts
+++ b/src/hooks/useCompareUrlSync.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompareUrl } from "@/hooks/useCompareUrl";
+
+/**
+ * Projects the current compare state onto the address bar for the compare
+ * page surface — and only the compare page.
+ *
+ * CompareContext is the single client-side source of truth for the lens
+ * selection. The compare page's URL (`?ids=A,B,C`) is a derived projection
+ * so the comparison can be linked, refreshed, or shared. Other surfaces
+ * (lens list, lens detail) carry compare state via context only; their URLs
+ * have nothing to sync, so this hook is never mounted there.
+ *
+ * Implementation note: `window.history.replaceState` is used instead of
+ * `router.replace` because the latter triggers an RSC round-trip, which is
+ * wasteful here — the new URL maps to the same page and the new compareIds
+ * are already authoritative on the client. `history.replaceState` updates
+ * the address bar without contacting the server; Next.js' monkey-patched
+ * history API still notifies `usePathname` / `useSearchParams` consumers.
+ */
+export function useCompareUrlSync() {
+  const { compareIds } = useMountedCompare();
+  const { buildLocalizedCompareUrl } = useCompareUrl();
+
+  useEffect(() => {
+    window.history.replaceState(null, "", buildLocalizedCompareUrl(compareIds));
+  }, [compareIds, buildLocalizedCompareUrl]);
+}

--- a/src/lib/curated-presets.ts
+++ b/src/lib/curated-presets.ts
@@ -15,6 +15,29 @@ export function getPresetBySlug(slug: string): CuratedPreset | undefined {
   return curatedPresets.find((p) => p.slug === slug);
 }
 
+/**
+ * Reverse lookup: find a curated preset whose `lensIds` exactly match the
+ * given set of ids (order-insensitive). Lets the compare URL be a pure
+ * `?ids=A,B,C` projection of compare state while the server still recognises
+ * the comparison as a curated preset for SEO / share-poster metadata.
+ *
+ * If the user manually assembles a comparison whose ids happen to equal a
+ * curated preset's, that comparison gets the preset's framing — that's a
+ * bonus, not a collision: the lens set fully defines the comparison.
+ */
+export function findPresetByIds(ids: string[]): CuratedPreset | undefined {
+  if (ids.length === 0) {
+    return undefined;
+  }
+  const set = new Set(ids);
+  if (set.size !== ids.length) {
+    return undefined;
+  }
+  return curatedPresets.find(
+    (p) => p.lensIds.length === set.size && p.lensIds.every((id) => set.has(id))
+  );
+}
+
 export function getPresetLenses(preset: CuratedPreset, locale: string): Lens[] {
   return preset.lensIds
     .map((id) => getAllLenses(locale).find((l) => l.id === id))


### PR DESCRIPTION
## Summary

Splits out the architectural part of #189 so it can land independently and the feature work can rebase on a clean base. Two commits:

### 1. `refactor(compare): centralize URL projection in useCompareUrlSync hook`

`CompareContext` was already documented as the single client-side source of truth, with the URL as a write-only projection on the compare page. Two callsites had been leaking that boundary:

- `CompareTable.updateCompare` wrote both context and URL atomically, inlining `window.history.replaceState`.
- `CompareAddLensButton.handleSelectLens` skipped the context API entirely and called `router.replace(buildCompareUrl(...))`, which triggers a full RSC round-trip just to push new ids into a page whose state is already client-authoritative.

Moves address-bar projection into a dedicated `useCompareUrlSync()` hook mounted once by `CompareTable`. Every write callsite — table remove/shift, table empty-slot add, header `+ Add lens` — now does the same thing: call `replaceCompare(nextIds)` and let the hook handle the URL. No more RSC round-trip on add-to-compare, no scattered `replaceState` calls. Browser back/forward, refresh, deep-link share all unchanged.

### 2. `refactor(compare): make URL ids the single source of truth for compare state`

`?ids=` was already authoritative on what the comparison contained, but the URL also carried `?preset=`, `?from=`, and `?lensId=` that duplicated or never-quite-aligned with it. Drop all three:

- `?preset=` is redundant with `?ids=`. A curated preset is fully determined by its lens set, so the server reverse-derives the matching preset from the URL's ids via the new `findPresetByIds` helper. Curated metadata (page `<title>`, OG title) still works for deep links and shared URLs.
- `?from=` and `?lensId=` were dead code — written by `CompareBar.handleCompare`, but only ever read by the URL builder echoing them back. They were a "back to the lens I came from" hint that never grew a consumer.

Preset reverse-lookup also moves to the client side. Previously the server passed `presetTitle / presetSubtitle / presetLensIds` down to `ComparePageHeader` as props, and the client compared the live `compareIds` to that frozen prop to decide whether the share poster pre-fill should use the preset's title. That made preset matching an asymmetric one-shot: cold-start curated URLs got the framing, but in-page mutations could never promote into a match. With `findPresetByIds` callable on both surfaces — server for SEO, client for share UI — preset is consistently derived from the live ids regardless of how the user got there.

Knock-on simplifications:

- `useCompareUrlSync` no longer reads `useSearchParams`. With nothing else to preserve in the query string, its effect deps are pure primitives — no race window between `useSearchParams` updating synchronously after a router navigation and `compareIds` syncing via `useLayoutEffect` moments later.
- `useCompareUrl.buildCompareUrl(ids, extra)` loses the `extra` param.
- `ComparePageHeader` no longer takes preset props.
- `clearCompare` on the page header no longer calls `router.replace`; the hook projects the empty state. No RSC trip.

## Behaviour changes worth noting

- Clicking `+ Add lens` on the compare page no longer triggers an RSC round-trip.
- A user who manually assembles a comparison whose lens set happens to equal a curated preset will get that preset's framing in the share poster. This is a uniform consequence of the new design — the lens set defines the comparison.

## Test plan

| Scenario | URL | Page `<title>` |
| --- | --- | --- |
| Cold `/compare` | bare | `镜头对比 \| X-Glass` |
| Click curated | `?ids=...` (no `preset` param) | `标准变焦对决 \| X-Glass` (server-derived) |
| Remove one lens | `?ids=...` minus one | unchanged (no RSC) — share poster pre-fill correctly drops |
| Clear all | bare `/compare` | unchanged |
| Click another curated | `?ids=...` new set | new preset title (RSC trip) |
| Direct navigate to curated URL | `?ids=...` | server reverse-derives correctly |

All five flows verified via Playwright, 0 pageerrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)