### PR TITLE
feat(data): publish lens data 2026.05.14 build 1

### DIFF
--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -434,10 +434,6 @@
     "model": "GF 32-90mmT3.5 PZ OIS WR",
     "focalLengthMin": 32,
     "focalLengthMax": 90,
-    "maxAperture": [
-      32,
-      90
-    ],
     "maxTStop": 3.5,
     "minTStop": 32,
     "specialtyTags": [

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.11",
-  "lastUpdated": "2026-05-11T14:32:38.518Z",
+  "version": "2026.05.14",
+  "lastUpdated": "2026-05-14T01:29:23.072Z",
   "lensCount": 171,
   "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.14` build 1
- **X-mount lenses** (`lenses.json`): 152
- **G-mount lenses** (`lenses-gfx.json`): 19
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`