### PR TITLE
docs(types): rewrite focusMotor JSDoc to match current data discipline

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -461,33 +461,42 @@ export interface Lens {
   powerZoom?: boolean;
 
   /**
-   * Brand's official AF motor or actuator name, normalized to a short canonical
-   * label during pipeline parsing. Store the brand-specific marketing name so
-   * the display layer can show it verbatim while also mapping to broader
-   * categories (e.g. linear motor, stepping motor) when needed.
+   * Brand's verbatim AF motor or actuator label, copied from the source
+   * spec sheet or product page without normalization. The display layer
+   * renders this string as the brand subvalue and feeds it through
+   * {@link classifyFocusMotor} for the canonical class label (linear /
+   * stepping / dc / other).
    *
-   * Common canonical values by brand:
-   * - Fujifilm: "LM" (linear motor), "STM" (stepping motor),
-   *   "High-Precision Motor"
-   * - Sigma: "HLA" (High-response Linear Actuator)
-   * - Tamron: "RXD" (stepping drive), "VXD" (linear drive)
-   * - Viltrox: "STM", "VCM" (voice coil motor)
-   * - TTArtisan: "STM"
-   * - 7Artisans: "STM"
+   * **Fill only when an official source explicitly names the motor.** If
+   * the brand publishes nothing about the focus drive, omit this field;
+   * the agent should not infer a value from reviews or general knowledge.
+   * Older Fujifilm XF / XC product pages routinely document no motor type,
+   * so absence is the expected state on that generation rather than a
+   * coverage gap.
    *
-   * For lenses whose source only mentions a generic drive mechanism without a
-   * brand-specific name, use the most descriptive term available:
-   * "Lead Screw", "DC Motor", "Focus Motor", etc.
+   * Common values seen in source material:
+   * - Fujifilm: "LM" (model-name suffix on linear-motor lenses),
+   *   "Stepping Motor" (older marketing wording, sometimes shortened to
+   *   "STM"), "DC Motor", "DC Coreless Motor", "High-Precision Motor"
+   *   (older XF / XC marketing label — surfaces as DC class with a
+   *   fieldNote disambiguating it), "Triple Linear Motor" / "Quad Linear
+   *   Motor" (LM lenses with multiple actuators).
+   * - Sigma: "HLA" (linear), "Stepping Motor".
+   * - Tamron: "RXD" (stepping), "VXD" (linear).
+   * - Viltrox: "STM", "VCM", "Dual HyperVCM".
+   * - Third-party APS-C brands: "STM", sometimes "STM+Lead screw" where
+   *   the source spec sheet pairs the motor with its transmission
+   *   mechanism.
    *
-   * Manual-focus-only lenses must use the value `"N/A"` (not applicable).
-   * This is set automatically by the compute stage and should not be filled
-   * by the agent or overridden in review.
+   * Manual-focus-only lenses use the sentinel `SPEC_NA` (`"N/A"`),
+   * written automatically by the compute stage when `af === false`.
+   * Do not use `"N/A"` to mean "data missing" — leave the field
+   * undefined instead.
    *
    * @example "LM"
    * @example "HLA"
-   * @example "STM"
    * @example "VXD"
-   * @example "Lead Screw"
+   * @example "DC Motor"
    * @example "N/A"
    */
   focusMotor?: string;


### PR DESCRIPTION
## Summary
Followup to #194. Rewrites the JSDoc on `Lens.focusMotor` so the field's documented contract matches the data discipline we landed during the recent audit:

- Drops the "Lead Screw / DC Motor / Focus Motor" generic-fallback bucket. Lead Screw is a transmission mechanism, not a motor type, and "Focus Motor" had zero occurrences in the data — together they were nudging the agent to populate the field on lenses whose source said nothing about the drive.
- Reframes the field as a verbatim copy of source wording, not a normalized canonical label. The pipeline now keeps raw brand text and `classifyFocusMotor` does runtime mapping into the four classes.
- States the data-truthfulness rule explicitly: only fill when an official source names the motor; otherwise leave undefined. Older Fujifilm XF / XC product pages routinely document no motor type, so absence on that era is expected.
- Lists actually-observed values per brand (LM, Stepping Motor, DC Motor, DC Coreless Motor, High-Precision Motor, Triple/Quad Linear Motor, HLA, RXD, VXD, VCM, Dual HyperVCM, STM+Lead screw) and notes the High-Precision Motor → DC class disambiguation via fieldNotes.
- Clarifies that `"N/A"` is exclusively the MF sentinel — not a stand-in for "data missing."

## Test plan
- [x] `npx tsc --noEmit` clean (doc-only change, no runtime impact)