### PR TITLE
i18n(feedback): rename affectedLensLabel for natural phrasing

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -407,7 +407,7 @@
     "titleGeneral": "Send feedback",
     "descriptionDataIssue": "Wrong spec, broken image, typo, missing lens — tell us what you found. It goes straight to the maintainer.",
     "descriptionGeneral": "Thoughts, bug reports, and feature ideas are all welcome.",
-    "affectedLensLabel": "Affected lens",
+    "affectedLensLabel": "Reporting on",
     "fieldPickerLabel": "Affected field",
     "fieldPickerPlaceholder": "Choose a field…",
     "currentValueLabel": "Current value:",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -407,7 +407,7 @@
     "titleGeneral": "提交反馈",
     "descriptionDataIssue": "参数不对、图片有问题、哪里写错了、发现缺失镜头——都可以反馈给我们。",
     "descriptionGeneral": "有想法、发现 Bug，或者想提功能建议，都欢迎。",
-    "affectedLensLabel": "相关镜头",
+    "affectedLensLabel": "反馈对象",
     "fieldPickerLabel": "问题字段",
     "fieldPickerPlaceholder": "请选择字段…",
     "currentValueLabel": "当前显示：",


### PR DESCRIPTION
## Summary

Rename `Feedback.affectedLensLabel` to read more naturally — the previous wording was a literal translation that didn't match how the dialog actually frames feedback (the lens is the *subject* of the feedback, not something that was *affected*).

- zh: `相关镜头` → `反馈对象`
- en: `Affected lens` → `Reporting on`

## Test plan

- [ ] Open a lens detail page in zh and click "反馈问题" → header label reads "反馈对象"
- [ ] Same in en → label reads "Reporting on"

🤖 Generated with [Claude Code](https://claude.com/claude-code)