### PR TITLE
feat(data): publish lens data 2026.05.14 build 3

### DIFF
--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -251,11 +251,12 @@
       "tilt",
       "shift"
     ],
-    "af": true,
+    "af": false,
     "ois": false,
     "wr": false,
     "apertureRing": false,
     "powerZoom": false,
+    "focusMotor": "N/A",
     "weightG": 1340,
     "diameterMm": 87.1,
     "length": {
@@ -1283,11 +1284,12 @@
       "shift",
       "macro"
     ],
-    "af": true,
+    "af": false,
     "ois": false,
     "wr": false,
     "apertureRing": false,
     "powerZoom": false,
+    "focusMotor": "N/A",
     "weightG": 1255,
     "diameterMm": 95,
     "length": {

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.14",
-  "lastUpdated": "2026-05-14T03:24:07.759Z",
+  "lastUpdated": "2026-05-14T03:43:27.813Z",
   "lensCount": 171,
-  "buildNumber": 2
+  "buildNumber": 3
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.14` build 3
- **X-mount lenses** (`lenses.json`): 152
- **G-mount lenses** (`lenses-gfx.json`): 19
- **Blocked** (validation gate failures, see pipeline logs): 0

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`