### PR TITLE
feat(redaction): query-param blur layer for demo recordings

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
@@ -149,7 +150,11 @@ export default async function LocaleLayout({
           <CompareProvider>
             <ScrollContainerProvider>
               <ConsoleEgg />
-              <Redaction />
+              {/* Suspense gate — Redaction uses useSearchParams, which would
+                  otherwise force a CSR bailout on every prerendered page. */}
+              <Suspense fallback={null}>
+                <Redaction />
+              </Suspense>
               <Nav />
               {/* Offset fixed nav and iOS home indicator. Body also carries
                   bg-background, so the safe-area strip and any short-page gap

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import SiteJsonLd from "@/components/SiteJsonLd";
 import { routing } from "@/i18n/routing";
 import Nav from "@/components/Nav";
 import ConsoleEgg from "@/components/ConsoleEgg";
+import Redaction from "@/components/Redaction";
 import TestHookPanel from "@/components/TestHookPanel";
 import { CompareProvider } from "@/context/CompareProvider";
 import { MountPreferenceProvider } from "@/context/MountPreferenceProvider";
@@ -148,6 +149,7 @@ export default async function LocaleLayout({
           <CompareProvider>
             <ScrollContainerProvider>
               <ConsoleEgg />
+              <Redaction />
               <Nav />
               {/* Offset fixed nav and iOS home indicator. Body also carries
                   bg-background, so the safe-area strip and any short-page gap

--- a/src/components/PriceCell.tsx
+++ b/src/components/PriceCell.tsx
@@ -69,7 +69,10 @@ export function PriceCell({ lens, compact = false }: Props) {
       </div>
 
       {/* Row 2: source — persistent caption */}
-      <span className="text-[10px] leading-tight text-zinc-400 dark:text-zinc-500 break-words">
+      <span
+        data-redact-hook="priceSource"
+        className="text-[10px] leading-tight text-zinc-400 dark:text-zinc-500 break-words"
+      >
         {entry.source}
       </span>
 

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -59,7 +59,7 @@ export function PriceSection({ lens }: Props) {
       {/* Row 2: Source + sampled date — calendar icon makes the date read
           as data, not prose. */}
       <div className="inline-flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
-        <span>{sourceDisplay}</span>
+        <span data-redact-hook="priceSource">{sourceDisplay}</span>
         <span className="opacity-30">|</span>
         <span className="inline-flex items-center gap-1 tabular-nums">
           <Calendar className="size-3" aria-hidden="true" />

--- a/src/components/Redaction.tsx
+++ b/src/components/Redaction.tsx
@@ -1,21 +1,12 @@
 "use client";
 
-// Mounts the demo-mode redaction CSS layer. See lib/redaction.ts for the
-// target registry. Activation contract:
-//   - `?redact=posterQr,priceSource` on any URL turns those targets on; the
-//     param is stripped from the address bar after parsing so screen
-//     recordings don't expose it.
-//   - `?redactBlur=<px>` overrides the blur radius (default 5px).
-//   - The active set is mirrored to localStorage so it persists across tab
-//     close / browser restart until explicitly cleared.
-//   - `?redact=` (empty value) clears the active set; `?redactBlur=`
-//     resets the blur radius back to the default.
-//
-// Caller (layout.tsx) must wrap this in <Suspense fallback={null}> because
-// useSearchParams forces CSR bailout on prerendered pages otherwise.
-//
-// The component holds no React state — the only consumer of the active set
-// is a single <style> element in document.head, which we update imperatively.
+// Mounts the demo-mode redaction CSS layer. Activation:
+//   ?redact=posterQr,priceSource   — toggle the active set (empty clears)
+//   ?redactBlur=8                  — blur radius in px (default 5, empty resets)
+// Both params are stripped from the URL after parsing and mirrored to
+// localStorage so the effect persists across browser restarts until cleared.
+// Caller must wrap this in <Suspense fallback={null}> because useSearchParams
+// would otherwise force a CSR bailout on prerendered pages.
 
 import { useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -26,59 +17,10 @@ import {
   REDACTION_QUERY_KEY,
   REDACTION_STORAGE_KEY,
   buildRedactionCss,
-  parseRedactionBlur,
-  parseRedactionParam,
-  serializeRedactionKeys,
+  parseKeys,
 } from "@/lib/redaction";
 
-const STYLE_ELEMENT_ID = "redaction-css";
-
-function applyCss(activeKeys: readonly string[], blurPx: number): void {
-  let el = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
-  if (!el) {
-    el = document.createElement("style");
-    el.id = STYLE_ELEMENT_ID;
-    document.head.appendChild(el);
-  }
-  el.textContent = buildRedactionCss(activeKeys, blurPx);
-}
-
-function readStoredKeys(): readonly string[] {
-  try {
-    const stored = localStorage.getItem(REDACTION_STORAGE_KEY);
-    if (stored === null) {
-      return [];
-    }
-    return stored ? stored.split(",").filter(Boolean) : [];
-  } catch {
-    return [];
-  }
-}
-
-function readStoredBlur(): number {
-  try {
-    const raw = localStorage.getItem(REDACTION_BLUR_STORAGE_KEY);
-    return parseRedactionBlur(raw) ?? DEFAULT_REDACTION_BLUR_PX;
-  } catch {
-    return DEFAULT_REDACTION_BLUR_PX;
-  }
-}
-
-function writeStoredKeys(keys: readonly string[]): void {
-  try {
-    localStorage.setItem(REDACTION_STORAGE_KEY, serializeRedactionKeys(keys));
-  } catch {
-    // localStorage unavailable — applied for this page load only.
-  }
-}
-
-function writeStoredBlur(px: number): void {
-  try {
-    localStorage.setItem(REDACTION_BLUR_STORAGE_KEY, String(px));
-  } catch {
-    // localStorage unavailable — applied for this page load only.
-  }
-}
+const STYLE_ID = "redaction-css";
 
 export default function Redaction() {
   const pathname = usePathname();
@@ -89,33 +31,33 @@ export default function Redaction() {
     const rawKeys = searchParams.get(REDACTION_QUERY_KEY);
     const rawBlur = searchParams.get(REDACTION_BLUR_QUERY_KEY);
 
-    let keys: readonly string[];
+    let keys: string[];
     if (rawKeys !== null) {
-      keys = parseRedactionParam(rawKeys) ?? [];
-      writeStoredKeys(keys);
+      keys = parseKeys(rawKeys);
+      try { localStorage.setItem(REDACTION_STORAGE_KEY, keys.join(",")); } catch {}
     } else {
-      keys = readStoredKeys();
+      try { keys = parseKeys(localStorage.getItem(REDACTION_STORAGE_KEY)); } catch { keys = []; }
     }
 
-    let blurPx: number;
+    let blur: number;
     if (rawBlur !== null) {
-      // Empty value = reset to default. Out-of-range = ignored (keep prior).
-      const parsed = rawBlur === "" ? DEFAULT_REDACTION_BLUR_PX : parseRedactionBlur(rawBlur);
-      blurPx = parsed ?? readStoredBlur();
-      if (parsed !== null) {
-        writeStoredBlur(blurPx);
-      }
+      blur = Number(rawBlur) || DEFAULT_REDACTION_BLUR_PX;
+      try { localStorage.setItem(REDACTION_BLUR_STORAGE_KEY, String(blur)); } catch {}
     } else {
-      blurPx = readStoredBlur();
+      try { blur = Number(localStorage.getItem(REDACTION_BLUR_STORAGE_KEY)) || DEFAULT_REDACTION_BLUR_PX; } catch { blur = DEFAULT_REDACTION_BLUR_PX; }
     }
 
-    applyCss(keys, blurPx);
+    let el = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+    if (!el) {
+      el = document.createElement("style");
+      el.id = STYLE_ID;
+      document.head.appendChild(el);
+    }
+    el.textContent = buildRedactionCss(keys, blur);
 
     if (rawKeys === null && rawBlur === null) {
       return;
     }
-
-    // Strip both params so screen recordings of the address bar stay clean.
     const next = new URLSearchParams(searchParams.toString());
     next.delete(REDACTION_QUERY_KEY);
     next.delete(REDACTION_BLUR_QUERY_KEY);

--- a/src/components/Redaction.tsx
+++ b/src/components/Redaction.tsx
@@ -5,12 +5,14 @@
 //   - `?redact=posterQr,priceSource` on any URL turns those targets on; the
 //     param is stripped from the address bar after parsing so screen
 //     recordings don't expose it.
-//   - `?redactBlur=<px>` overrides the blur radius (default 5px). Persists
-//     for the tab session like the target set.
-//   - The active set is mirrored to sessionStorage so it survives in-app
-//     navigations and hard refreshes within the same tab.
+//   - `?redactBlur=<px>` overrides the blur radius (default 5px).
+//   - The active set is mirrored to localStorage so it persists across tab
+//     close / browser restart until explicitly cleared.
 //   - `?redact=` (empty value) clears the active set; `?redactBlur=`
 //     resets the blur radius back to the default.
+//
+// Caller (layout.tsx) must wrap this in <Suspense fallback={null}> because
+// useSearchParams forces CSR bailout on prerendered pages otherwise.
 //
 // The component holds no React state — the only consumer of the active set
 // is a single <style> element in document.head, which we update imperatively.
@@ -43,7 +45,7 @@ function applyCss(activeKeys: readonly string[], blurPx: number): void {
 
 function readStoredKeys(): readonly string[] {
   try {
-    const stored = sessionStorage.getItem(REDACTION_STORAGE_KEY);
+    const stored = localStorage.getItem(REDACTION_STORAGE_KEY);
     if (stored === null) {
       return [];
     }
@@ -55,7 +57,7 @@ function readStoredKeys(): readonly string[] {
 
 function readStoredBlur(): number {
   try {
-    const raw = sessionStorage.getItem(REDACTION_BLUR_STORAGE_KEY);
+    const raw = localStorage.getItem(REDACTION_BLUR_STORAGE_KEY);
     return parseRedactionBlur(raw) ?? DEFAULT_REDACTION_BLUR_PX;
   } catch {
     return DEFAULT_REDACTION_BLUR_PX;
@@ -64,17 +66,17 @@ function readStoredBlur(): number {
 
 function writeStoredKeys(keys: readonly string[]): void {
   try {
-    sessionStorage.setItem(REDACTION_STORAGE_KEY, serializeRedactionKeys(keys));
+    localStorage.setItem(REDACTION_STORAGE_KEY, serializeRedactionKeys(keys));
   } catch {
-    // sessionStorage unavailable — applied for this page load only.
+    // localStorage unavailable — applied for this page load only.
   }
 }
 
 function writeStoredBlur(px: number): void {
   try {
-    sessionStorage.setItem(REDACTION_BLUR_STORAGE_KEY, String(px));
+    localStorage.setItem(REDACTION_BLUR_STORAGE_KEY, String(px));
   } catch {
-    // sessionStorage unavailable — applied for this page load only.
+    // localStorage unavailable — applied for this page load only.
   }
 }
 

--- a/src/components/Redaction.tsx
+++ b/src/components/Redaction.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// Mounts the demo-mode redaction CSS layer. See lib/redaction.ts for the
+// target registry. Activation contract:
+//   - `?redact=posterQr,priceSource` on any URL turns those targets on; the
+//     param is stripped from the address bar after parsing so screen
+//     recordings don't expose it.
+//   - `?redactBlur=<px>` overrides the blur radius (default 5px). Persists
+//     for the tab session like the target set.
+//   - The active set is mirrored to sessionStorage so it survives in-app
+//     navigations and hard refreshes within the same tab.
+//   - `?redact=` (empty value) clears the active set; `?redactBlur=`
+//     resets the blur radius back to the default.
+//
+// The component holds no React state — the only consumer of the active set
+// is a single <style> element in document.head, which we update imperatively.
+
+import { useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  DEFAULT_REDACTION_BLUR_PX,
+  REDACTION_BLUR_QUERY_KEY,
+  REDACTION_BLUR_STORAGE_KEY,
+  REDACTION_QUERY_KEY,
+  REDACTION_STORAGE_KEY,
+  buildRedactionCss,
+  parseRedactionBlur,
+  parseRedactionParam,
+  serializeRedactionKeys,
+} from "@/lib/redaction";
+
+const STYLE_ELEMENT_ID = "redaction-css";
+
+function applyCss(activeKeys: readonly string[], blurPx: number): void {
+  let el = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+  if (!el) {
+    el = document.createElement("style");
+    el.id = STYLE_ELEMENT_ID;
+    document.head.appendChild(el);
+  }
+  el.textContent = buildRedactionCss(activeKeys, blurPx);
+}
+
+function readStoredKeys(): readonly string[] {
+  try {
+    const stored = sessionStorage.getItem(REDACTION_STORAGE_KEY);
+    if (stored === null) {
+      return [];
+    }
+    return stored ? stored.split(",").filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function readStoredBlur(): number {
+  try {
+    const raw = sessionStorage.getItem(REDACTION_BLUR_STORAGE_KEY);
+    return parseRedactionBlur(raw) ?? DEFAULT_REDACTION_BLUR_PX;
+  } catch {
+    return DEFAULT_REDACTION_BLUR_PX;
+  }
+}
+
+function writeStoredKeys(keys: readonly string[]): void {
+  try {
+    sessionStorage.setItem(REDACTION_STORAGE_KEY, serializeRedactionKeys(keys));
+  } catch {
+    // sessionStorage unavailable — applied for this page load only.
+  }
+}
+
+function writeStoredBlur(px: number): void {
+  try {
+    sessionStorage.setItem(REDACTION_BLUR_STORAGE_KEY, String(px));
+  } catch {
+    // sessionStorage unavailable — applied for this page load only.
+  }
+}
+
+export default function Redaction() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const rawKeys = searchParams.get(REDACTION_QUERY_KEY);
+    const rawBlur = searchParams.get(REDACTION_BLUR_QUERY_KEY);
+
+    let keys: readonly string[];
+    if (rawKeys !== null) {
+      keys = parseRedactionParam(rawKeys) ?? [];
+      writeStoredKeys(keys);
+    } else {
+      keys = readStoredKeys();
+    }
+
+    let blurPx: number;
+    if (rawBlur !== null) {
+      // Empty value = reset to default. Out-of-range = ignored (keep prior).
+      const parsed = rawBlur === "" ? DEFAULT_REDACTION_BLUR_PX : parseRedactionBlur(rawBlur);
+      blurPx = parsed ?? readStoredBlur();
+      if (parsed !== null) {
+        writeStoredBlur(blurPx);
+      }
+    } else {
+      blurPx = readStoredBlur();
+    }
+
+    applyCss(keys, blurPx);
+
+    if (rawKeys === null && rawBlur === null) {
+      return;
+    }
+
+    // Strip both params so screen recordings of the address bar stay clean.
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete(REDACTION_QUERY_KEY);
+    next.delete(REDACTION_BLUR_QUERY_KEY);
+    const qs = next.toString();
+    router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [searchParams, pathname, router]);
+
+  return null;
+}

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -430,6 +430,7 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
           {/* Right column: QR + CTA */}
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", flexShrink: 0, gap: 8 }}>
             <div
+              data-redact-hook="posterQr"
               style={{
                 width: 96,
                 height: 96,
@@ -619,7 +620,7 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                     )}
                   </span>
                   {/* Caption row 1: source */}
-                  <span className="tabular-nums text-zinc-400 leading-tight text-center" style={{ fontSize: 9, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  <span data-redact-hook="priceSource" className="tabular-nums text-zinc-400 leading-tight text-center" style={{ fontSize: 9, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {sel.entry.source}
                   </span>
                   {/* Caption row 2: sampled date */}

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -1,0 +1,122 @@
+// Demo-mode redaction layer.
+//
+// Independent of TestHooks — always available, including in production. Driven
+// purely by a URL query param (?redact=key1,key2) and a sessionStorage echo so
+// the effect persists across in-app navigations after the URL is cleaned.
+//
+// To add a new redactable surface:
+//   1. Append an entry to REDACTION_TARGETS below.
+//   2. Add `data-redact-hook="<key>"` to the element that should blur.
+// The CSS applies blur + pointer/select suppression so the surface can't be
+// scanned, hovered into a popover, or copied while active.
+
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+export const REDACTION_QUERY_KEY = "redact";
+export const REDACTION_BLUR_QUERY_KEY = "redactBlur";
+export const REDACTION_STORAGE_KEY = "x-glass:redact";
+export const REDACTION_BLUR_STORAGE_KEY = "x-glass:redact:blur";
+export const REDACTION_ATTR = "data-redact-hook";
+
+// Light enough to leave the surrounding layout untouched while still defeating
+// OCR / QR-scanner pipelines on the channel-name string. Override per session
+// with ?redactBlur=<px>.
+export const DEFAULT_REDACTION_BLUR_PX = 5;
+const MIN_REDACTION_BLUR_PX = 1;
+const MAX_REDACTION_BLUR_PX = 40;
+
+export interface RedactionTarget {
+  key: string;
+  label: string;
+  description: string;
+  selector: string;
+}
+
+export const REDACTION_TARGETS: readonly RedactionTarget[] = [
+  {
+    key: "posterQr",
+    label: "Poster QR code",
+    description: "Blur the QR code inside share posters.",
+    selector: `[${REDACTION_ATTR}="posterQr"]`,
+  },
+  {
+    key: "priceSource",
+    label: "Price source channel",
+    description: "Blur the channel-name caption (e.g. JD flagship, Xianyu) under each price. Price value and sampled date stay visible.",
+    selector: `[${REDACTION_ATTR}="priceSource"]`,
+  },
+];
+
+const REDACTION_KEYS = new Set(REDACTION_TARGETS.map((t) => t.key));
+
+// Parses the raw query value. Returns null when the param is absent (caller
+// should leave existing state alone); returns the validated key list when
+// present, including the empty array for an explicit clear (?redact=).
+export function parseRedactionParam(raw: string | null): readonly string[] | null {
+  if (raw === null) {
+    return null;
+  }
+  if (raw === "") {
+    return [];
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const part of raw.split(",")) {
+    const key = part.trim();
+    if (key && REDACTION_KEYS.has(key) && !seen.has(key)) {
+      seen.add(key);
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+export function readRedactionParam(
+  input: URLSearchParams | ReadonlyURLSearchParams
+): readonly string[] | null {
+  return parseRedactionParam(input.get(REDACTION_QUERY_KEY));
+}
+
+export function serializeRedactionKeys(keys: readonly string[]): string {
+  return keys.join(",");
+}
+
+// Returns null when the param is absent or unparseable; caller should fall
+// back to existing state / default. Empty string is treated as "reset".
+export function parseRedactionBlur(raw: string | null): number | null {
+  if (raw === null || raw === "") {
+    return null;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    return null;
+  }
+  return Math.min(MAX_REDACTION_BLUR_PX, Math.max(MIN_REDACTION_BLUR_PX, Math.round(n)));
+}
+
+export function readRedactionBlur(
+  input: URLSearchParams | ReadonlyURLSearchParams
+): number | null {
+  const raw = input.get(REDACTION_BLUR_QUERY_KEY);
+  // An explicit `?redactBlur=` resets to default; treat as a clear signal.
+  if (raw === "") {
+    return DEFAULT_REDACTION_BLUR_PX;
+  }
+  return parseRedactionBlur(raw);
+}
+
+export function buildRedactionCss(
+  activeKeys: readonly string[],
+  blurPx: number = DEFAULT_REDACTION_BLUR_PX
+): string {
+  if (activeKeys.length === 0) {
+    return "";
+  }
+  // pointer-events: none also stops the Used-badge popover from leaking
+  // copy on hover during demo capture.
+  const body = `filter: blur(${blurPx}px) !important; pointer-events: none !important; user-select: none !important;`;
+  const active = new Set(activeKeys);
+  return REDACTION_TARGETS.filter((t) => active.has(t.key))
+    .map((t) => `${t.selector} { ${body} }`)
+    .join("\n");
+}

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -1,125 +1,29 @@
-// Demo-mode redaction layer.
-//
-// Independent of TestHooks — always available, including in production. Driven
-// purely by a URL query param (?redact=key1,key2) and a sessionStorage echo so
-// the effect persists across in-app navigations after the URL is cleaned.
-//
-// To add a new redactable surface:
-//   1. Append an entry to REDACTION_TARGETS below.
-//   2. Add `data-redact-hook="<key>"` to the element that should blur.
-// The CSS applies blur + pointer/select suppression so the surface can't be
-// scanned, hovered into a popover, or copied while active.
+// Demo-mode redaction. Used to blur sensitive surfaces (poster QR, price
+// source channel) while screen-recording, so platform moderators don't flag
+// the footage. To redact another surface, add a key here and mark the
+// element with `data-redact-hook="<key>"`.
 
-import type { ReadonlyURLSearchParams } from "next/navigation";
+export const REDACTION_KEYS = ["posterQr", "priceSource"] as const;
 
 export const REDACTION_QUERY_KEY = "redact";
 export const REDACTION_BLUR_QUERY_KEY = "redactBlur";
-// localStorage so the setting persists across tab close / browser restart —
-// the demo state survives any number of sessions until explicitly cleared
-// with `?redact=`.
 export const REDACTION_STORAGE_KEY = "x-glass:redact";
 export const REDACTION_BLUR_STORAGE_KEY = "x-glass:redact:blur";
-export const REDACTION_ATTR = "data-redact-hook";
-
-// Light enough to leave the surrounding layout untouched while still defeating
-// OCR / QR-scanner pipelines on the channel-name string. Override per session
-// with ?redactBlur=<px>.
 export const DEFAULT_REDACTION_BLUR_PX = 5;
-const MIN_REDACTION_BLUR_PX = 1;
-const MAX_REDACTION_BLUR_PX = 40;
 
-export interface RedactionTarget {
-  key: string;
-  label: string;
-  description: string;
-  selector: string;
-}
+const ALLOWED = new Set<string>(REDACTION_KEYS);
 
-export const REDACTION_TARGETS: readonly RedactionTarget[] = [
-  {
-    key: "posterQr",
-    label: "Poster QR code",
-    description: "Blur the QR code inside share posters.",
-    selector: `[${REDACTION_ATTR}="posterQr"]`,
-  },
-  {
-    key: "priceSource",
-    label: "Price source channel",
-    description: "Blur the channel-name caption (e.g. JD flagship, Xianyu) under each price. Price value and sampled date stay visible.",
-    selector: `[${REDACTION_ATTR}="priceSource"]`,
-  },
-];
-
-const REDACTION_KEYS = new Set(REDACTION_TARGETS.map((t) => t.key));
-
-// Parses the raw query value. Returns null when the param is absent (caller
-// should leave existing state alone); returns the validated key list when
-// present, including the empty array for an explicit clear (?redact=).
-export function parseRedactionParam(raw: string | null): readonly string[] | null {
-  if (raw === null) {
-    return null;
-  }
-  if (raw === "") {
+export function parseKeys(raw: string | null): string[] {
+  if (!raw) {
     return [];
   }
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const part of raw.split(",")) {
-    const key = part.trim();
-    if (key && REDACTION_KEYS.has(key) && !seen.has(key)) {
-      seen.add(key);
-      result.push(key);
-    }
-  }
-  return result;
+  return raw.split(",").map((s) => s.trim()).filter((s) => ALLOWED.has(s));
 }
 
-export function readRedactionParam(
-  input: URLSearchParams | ReadonlyURLSearchParams
-): readonly string[] | null {
-  return parseRedactionParam(input.get(REDACTION_QUERY_KEY));
-}
-
-export function serializeRedactionKeys(keys: readonly string[]): string {
-  return keys.join(",");
-}
-
-// Returns null when the param is absent or unparseable; caller should fall
-// back to existing state / default. Empty string is treated as "reset".
-export function parseRedactionBlur(raw: string | null): number | null {
-  if (raw === null || raw === "") {
-    return null;
-  }
-  const n = Number(raw);
-  if (!Number.isFinite(n)) {
-    return null;
-  }
-  return Math.min(MAX_REDACTION_BLUR_PX, Math.max(MIN_REDACTION_BLUR_PX, Math.round(n)));
-}
-
-export function readRedactionBlur(
-  input: URLSearchParams | ReadonlyURLSearchParams
-): number | null {
-  const raw = input.get(REDACTION_BLUR_QUERY_KEY);
-  // An explicit `?redactBlur=` resets to default; treat as a clear signal.
-  if (raw === "") {
-    return DEFAULT_REDACTION_BLUR_PX;
-  }
-  return parseRedactionBlur(raw);
-}
-
-export function buildRedactionCss(
-  activeKeys: readonly string[],
-  blurPx: number = DEFAULT_REDACTION_BLUR_PX
-): string {
+export function buildRedactionCss(activeKeys: readonly string[], blurPx: number): string {
   if (activeKeys.length === 0) {
     return "";
   }
-  // pointer-events: none also stops the Used-badge popover from leaking
-  // copy on hover during demo capture.
   const body = `filter: blur(${blurPx}px) !important; pointer-events: none !important; user-select: none !important;`;
-  const active = new Set(activeKeys);
-  return REDACTION_TARGETS.filter((t) => active.has(t.key))
-    .map((t) => `${t.selector} { ${body} }`)
-    .join("\n");
+  return activeKeys.map((k) => `[data-redact-hook="${k}"] { ${body} }`).join("\n");
 }

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -14,6 +14,9 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 
 export const REDACTION_QUERY_KEY = "redact";
 export const REDACTION_BLUR_QUERY_KEY = "redactBlur";
+// localStorage so the setting persists across tab close / browser restart —
+// the demo state survives any number of sessions until explicitly cleared
+// with `?redact=`.
 export const REDACTION_STORAGE_KEY = "x-glass:redact";
 export const REDACTION_BLUR_STORAGE_KEY = "x-glass:redact:blur";
 export const REDACTION_ATTR = "data-redact-hook";


### PR DESCRIPTION
## Summary
- Add a tiny client-side redaction layer (`src/lib/redaction.ts`, `src/components/Redaction.tsx`) that blurs surfaces marked with `data-redact-hook="<key>"` whenever a hidden URL param is set, so screen-recorded demos don't trip platform moderation on QR codes or sampled price-source channel names.
- Wire up two initial targets: poster QR (`SharePoster`) and price-source caption (`PriceSection`, `PriceCell`, `SharePoster`). Price value and sampled date stay visible.
- Mounted globally in `[locale]/layout.tsx`, independent of `TESTHOOK_ALLOWED` — works in production without env-var gating.

## Activation
```
?redact=posterQr,priceSource   # toggle the active set
?redactBlur=8                  # override blur radius (default 5px, clamp 1–40)
?redact=                       # clear all
?redactBlur=                   # reset radius
```
Both params are stripped from the address bar after parsing and mirrored to `sessionStorage`, so the effect persists across in-app navigations and survives hard refresh within the same tab.

## Extending
Add an entry to `REDACTION_TARGETS` and tag the element with `data-redact-hook="<key>"`. No other plumbing.

## Test plan
- [x] `?redact=priceSource` → only the source caption is blurred; price and date stay crisp
- [x] `?redact=posterQr,priceSource&redactBlur=6` → both surfaces blurred at 6px in the share-poster preview
- [x] URL params stripped from address bar after first paint
- [x] Effect persists across navigations (compare → detail) via sessionStorage
- [x] `npx eslint` and `vitest run` on touched files clean