### PR TITLE
fix(ui): drop duplicate N/A caption and redundant copy toast

### DIFF
--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { Popover } from "@base-ui/react/popover";
 import { Drawer } from "@base-ui/react/drawer";
@@ -424,23 +423,5 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, pre
     </Drawer.Root>
   );
 
-  // On mobile the Drawer covers anything inside a parent stacking context.
-  // Render the "Copied!" toast via portal so it always appears above the Drawer.
-  const copiedToast =
-    mounted && copied && !isDesktop
-      ? createPortal(
-          <div className="pointer-events-none fixed top-4 left-1/2 z-[70] flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-green-600 px-4 py-2 text-sm font-medium text-white shadow-lg animate-in fade-in slide-in-from-top-2 duration-150">
-            <Check className="size-4" />
-            {t("copied")}
-          </div>,
-          document.body
-        )
-      : null;
-
-  return (
-    <>
-      {shareControl}
-      {copiedToast}
-    </>
-  );
+  return shareControl;
 }

--- a/src/lib/lens-spec-groups.ts
+++ b/src/lib/lens-spec-groups.ts
@@ -514,7 +514,7 @@ export function buildSpecGroups(labels: SpecGroupLabels): SpecGroup[] {
             const cls = classifyFocusMotor(l);
             return cls ? motorClass[cls] : l.focusMotor;
           },
-          getSubValue: (l) => l.focusMotor,
+          getSubValue: (l) => (classifyFocusMotor(l) ? l.focusMotor : undefined),
         },
         // internalFocusing row hidden — data quality issues, to be re-added later
         {


### PR DESCRIPTION
## Summary
- Focus motor row no longer renders **"N/A"** on both the primary line and the caption for manual-focus lenses — when `classifyFocusMotor` returns undefined, the raw-value caption is suppressed and only the primary "N/A" remains.
- Removed the mobile-only `createPortal` toast that fired after copying the share link. The copy button itself already swaps to a green "Copied!" / red "Failed" pill inside the drawer, so the toast was redundant.

## Test plan
- [ ] Detail page: open a manual-focus lens (e.g. any TTArtisan / 7Artisans MF prime) and confirm the focus motor row shows a single "N/A", no caption underneath.
- [ ] Compare page: pick an AF lens vs. an MF lens; the AF row still shows class label + raw motor caption (e.g. "Stepping" / "STM"), the MF cell shows "N/A" once.
- [ ] Mobile share drawer: tap *Copy link* → button turns green with "Copied!", no separate toast at the top of the screen.
- [ ] Desktop share popover: behavior unchanged.