### PR TITLE
chore: drop Vercel Analytics and Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/source-serif-4": "^5.2.9",
-        "@vercel/analytics": "^2.0.1",
-        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "geist": "^1.7.0",
@@ -7175,86 +7173,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
-      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/source-serif-4": "^5.2.9",
-    "@vercel/analytics": "^2.0.1",
-    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,8 +3,6 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import RegisterSW from "@/components/RegisterSW";
 import AssetTelemetry from "@/components/AssetTelemetry";
 import SiteJsonLd from "@/components/SiteJsonLd";
@@ -176,8 +174,6 @@ export default async function LocaleLayout({
         </NextIntlClientProvider>
         <RegisterSW />
         <AssetTelemetry />
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -376,7 +376,7 @@
     "disclaimerCopyright": "Product images and brand trademarks are the property of their respective owners. If you are a rights holder and believe your content has been used improperly, please contact xglass@sentacraft.com.",
     "privacyTitle": "Privacy",
     "privacyBody": "X-Glass does not require registration, does not collect personal information, and does not use cookies.",
-    "privacyAnalytics": "This site uses Vercel Analytics and Cloudflare Web Analytics to collect aggregated, anonymous data such as page views, referrers, and device types — solely to help improve the product. No personally identifiable information is collected.",
+    "privacyAnalytics": "This site uses Cloudflare Web Analytics to collect aggregated, anonymous data such as page views, referrers, and device types — solely to help improve the product. No personally identifiable information is collected.",
     "donationTitle": "Support the Project",
     "donationBody": "X-Glass is open source on GitHub. Every spec in this database went through tedious data extraction and manual cross-checking. If it helped you find the right lens — or saved you some time — consider supporting the project.",
     "donationComingSoon": "Sponsorship options are being set up — check back soon.",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -376,7 +376,7 @@
     "disclaimerCopyright": "本站展示的产品图片及品牌商标，版权归各自所有者所有。如您是权利人并认为存在侵权问题，请联系 xglass@sentacraft.com。",
     "privacyTitle": "隐私",
     "privacyBody": "X-Glass 不要求注册，不收集任何个人信息，也不使用 Cookie。",
-    "privacyAnalytics": "本站接入了 Vercel Analytics 和 Cloudflare Web Analytics，用于统计页面访问量、来源及设备类型等聚合匿名数据，以便持续改善产品体验。这些数据不包含任何可识别个人身份的信息。",
+    "privacyAnalytics": "本站接入了 Cloudflare Web Analytics，用于统计页面访问量、来源及设备类型等聚合匿名数据，以便持续改善产品体验。这些数据不包含任何可识别个人身份的信息。",
     "donationTitle": "捐赠与支持",
     "donationBody": "X-Glass 代码已在 GitHub 开源。这里的每一组镜头参数，都经历了繁琐的数据抓取与人工交叉校准。如果你觉得这个数据库帮你选到了心仪的镜头，或者为你节省了时间，欢迎赞赏支持。",
     "donationComingSoon": "",


### PR DESCRIPTION
## Summary
The project is now stably running on Cloudflare Workers, so the Vercel Analytics and Speed Insights scripts are no longer pointed at any collector — they were just shipping dead weight to the client.

- Removed `@vercel/analytics` and `@vercel/speed-insights` from dependencies; refreshed the lock file.
- Removed the `<Analytics />` and `<SpeedInsights />` mounts (and their imports) from `src/app/[locale]/layout.tsx`.
- Updated About → Privacy copy in `en.json` / `zh.json` to mention only **Cloudflare Web Analytics**, which is the analytics surface that's actually live.

## Out of scope (kept on purpose)
- `vercel.json` (git-deploy gating), `VERCEL_URL` / `VERCEL_PROJECT_PRODUCTION_URL` fallbacks in `resolveMetadataBase`, and the `_vercel` exclusion in the middleware matcher — none of these touch Analytics, and removing them is a separate decision about whether to make the codebase fully Vercel-agnostic.
- The README link to the Geist font (`https://vercel.com/font`) — that's a font credit, unrelated to Analytics.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] Visit `/en/about` and `/zh/about` → Privacy section reads "Cloudflare Web Analytics" only, no Vercel mention
- [ ] DevTools network tab on prod build: no requests to `va.vercel-scripts.com` or `vitals.vercel-insights.com`
- [ ] Cloudflare Web Analytics dashboard still records page views post-deploy