### PR TITLE
feat(home): page-level fade-in transition

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -31,9 +31,8 @@ function HomeContent() {
   const t = useTranslations("Common");
 
   return (
-    <div className="flex flex-col h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] overflow-clip">
-      {/* Hero */}
-      <section className="flex flex-col items-center justify-center text-center px-4 py-16 flex-1">
+    <div className="relative h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] overflow-clip grid place-items-center">
+      <section className="flex flex-col items-center text-center px-4">
         <HeroIris />
         <h1 className="mt-8 text-5xl sm:text-6xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50 font-heading">
           <HeroBrand />
@@ -49,8 +48,7 @@ function HomeContent() {
         </div>
       </section>
 
-      {/* Tagline — barely visible footer credit */}
-      <div className="pb-6 flex justify-center">
+      <div className="absolute inset-x-0 bottom-6 flex justify-center">
         <Tagline />
       </div>
     </div>

--- a/src/app/[locale]/template.tsx
+++ b/src/app/[locale]/template.tsx
@@ -1,0 +1,3 @@
+export default function Template({ children }: { children: React.ReactNode }) {
+  return <div className="animate-in fade-in duration-200">{children}</div>;
+}

--- a/src/app/[locale]/template.tsx
+++ b/src/app/[locale]/template.tsx
@@ -1,3 +1,16 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
 export default function Template({ children }: { children: React.ReactNode }) {
-  return <div className="animate-in fade-in duration-400">{children}</div>;
+  const [shown, setShown] = useState(false);
+  useEffect(() => { setShown(true); }, []);
+  return (
+    <div
+      className="transition-opacity duration-200"
+      style={{ opacity: shown ? 1 : 0 }}
+    >
+      {children}
+    </div>
+  );
 }

--- a/src/app/[locale]/template.tsx
+++ b/src/app/[locale]/template.tsx
@@ -1,3 +1,3 @@
 export default function Template({ children }: { children: React.ReactNode }) {
-  return <div className="animate-in fade-in duration-200">{children}</div>;
+  return <div className="animate-in fade-in duration-400">{children}</div>;
 }

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { usePathname, Link } from "@/i18n/navigation";
-import { motion, AnimatePresence } from "motion/react";
 import { useTranslations } from "next-intl";
 import type { Lens } from "@/lib/types";
 import { TEXT_LINK_CLS } from "@/lib/ui-tokens";
@@ -178,58 +177,45 @@ export default function LensListClient({ lenses }: Props) {
           </div>
         </div>
 
-        <AnimatePresence mode="wait" initial={false}>
-          {displayed.length === 0 ? (
-            <motion.div
-              key="empty"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              className="flex flex-col gap-2"
-            >
-              <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                {t("noResults")}
-              </p>
-              <p className="text-xs text-zinc-400 dark:text-zinc-500">
-                {t("suggestLens")}{" "}
-                <FeedbackTrigger
-                  type="general"
-                  className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                >
-                  {t("suggestLensLink")}
-                </FeedbackTrigger>
-                <span className="mx-2 opacity-40">·</span>
-                <Link
-                  href="/about#coverage"
-                  className="hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                >
-                  {t("coverageLink")}
-                </Link>
-              </p>
-            </motion.div>
-          ) : (
-            <motion.div
-              key={displayed.map((l) => l.id).join()}
-              {...hookAttr("grid")}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.18, ease: "easeOut" }}
-              className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
-            >
-              {displayed.map((lens, i) => (
-                <LensCard
-                  key={lens.id}
-                  lens={lens}
-                  isSelected={compareIds.includes(lens.id)}
-                  selectionDisabled={!canToggle(lens.id)}
-                  onToggle={() => toggleCompare(lens.id)}
-                  priority={i < 8}
-                />
-              ))}
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {displayed.length === 0 ? (
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              {t("noResults")}
+            </p>
+            <p className="text-xs text-zinc-400 dark:text-zinc-500">
+              {t("suggestLens")}{" "}
+              <FeedbackTrigger
+                type="general"
+                className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              >
+                {t("suggestLensLink")}
+              </FeedbackTrigger>
+              <span className="mx-2 opacity-40">·</span>
+              <Link
+                href="/about#coverage"
+                className="hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              >
+                {t("coverageLink")}
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <div
+            {...hookAttr("grid")}
+            className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
+          >
+            {displayed.map((lens, i) => (
+              <LensCard
+                key={lens.id}
+                lens={lens}
+                isSelected={compareIds.includes(lens.id)}
+                selectionDisabled={!canToggle(lens.id)}
+                onToggle={() => toggleCompare(lens.id)}
+                priority={i < 8}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       <BackToTopButton />


### PR DESCRIPTION
## Summary

Add a page-level fade-in transition for every client-side navigation under \`[locale]\`. The new \`template.tsx\` is a small client component that holds opacity at 0 on mount and flips it to 1 in \`useEffect\`, so the CSS \`transition-opacity\` only runs *after* hydration completes.

Why not the simpler CSS \`animate-in fade-in\` approach: on heavy routes (lenses listing with 150+ cards, compare), React hydration blocks the main thread for ~265ms. During that window the browser can't commit paint frames, so the CSS animation ticks invisibly and is effectively ~66% done by the time the screen updates — users perceive a sudden pop, not a fade. Deferring the transition trigger to \`useEffect\` puts it entirely after the hydration window, so the full 200ms fade is visually present on every route regardless of weight.

Also drops a redundant motion-based opacity fade on the lens grid (\`LensListClient\`) — with the page-level fade in place, the grid-level one was double-fading the same surface and remounting all 150+ LensCards on every filter/sort change.

## Depends on
- \#204 (hero layout shift) — this branch currently includes that fix because it was developed on the same branch; once #204 lands and this branch is rebased on main, the duplicate commit drops automatically.

## Non-obvious notes
- Skeleton (\`loading.tsx\`) visibility on slow data routes is delayed by the same ~265ms hydration window since the wrapper hides its contents during the opaque period. Acceptable for our typical warm-cache navigation; revisit if slow-network UX regresses.
- Filter/sort changes on the lens grid now snap instantly (no fade). If a refresh feel is wanted, add a lighter pattern that doesn't remount the children.
- \`template.tsx\` re-mounts on every navigation including locale switches. If a child later needs to persist state across same-segment navigation, this is the constraint to keep in mind.

## Test plan
- [x] Playwright rAF opacity sampling confirms full 0→1 curve on \`/lenses/x\` (previously stuck at 0 then jumped to ~0.84)
- [x] Verified \`enter\` transition fires on both forward and back client-side nav
- [ ] Manual visual check on a real device (mobile Safari PWA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)