### PR TITLE
fix(home): eliminate hero load layout shift

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -31,9 +31,8 @@ function HomeContent() {
   const t = useTranslations("Common");
 
   return (
-    <div className="flex flex-col h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] overflow-clip">
-      {/* Hero */}
-      <section className="flex flex-col items-center justify-center text-center px-4 py-16 flex-1">
+    <div className="relative h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] overflow-clip grid place-items-center">
+      <section className="flex flex-col items-center text-center px-4">
         <HeroIris />
         <h1 className="mt-8 text-5xl sm:text-6xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50 font-heading">
           <HeroBrand />
@@ -49,8 +48,7 @@ function HomeContent() {
         </div>
       </section>
 
-      {/* Tagline — barely visible footer credit */}
-      <div className="pb-6 flex justify-center">
+      <div className="absolute inset-x-0 bottom-6 flex justify-center">
         <Tagline />
       </div>
     </div>


### PR DESCRIPTION
## Summary

\`Tagline\` mounts client-only via \`useEffect\`, which used to push the hero column down ~16px on hydration. Combined with \`flex-1 + justify-center\`, every page load re-centered the hero ~8px upward — a small but visible jolt on both desktop and mobile.

Switched the container to \`grid place-items-center\` and pinned \`Tagline\` to \`absolute bottom-6\`, so its late mount no longer participates in hero layout.

## Non-obvious note

Hero block visually sits **~20px lower** than before on desktop. Previously it was centered in \`(svh − nav − tagline-area)\`; now it's centered in \`(svh − nav)\` since the tagline area no longer biases hero upward. Acceptable trade-off — the page feels more "dead-center" now.

## Test plan
- [x] Playwright \`PerformanceObserver\` on \`layout-shift\`, buffered: shiftCount=0 / CLS=0 across en×{1440×900, 390×844} and zh×1440×900
- [ ] Manual visual confirmation on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)