### PR TITLE
fix(analytics): cover three missing compare_add entry points

### DIFF
--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -20,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { ACTION_PRIMARY_CLS, ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
 import { Z } from "@/config/ui";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
+import { track } from "@/lib/analytics";
 
 export default function CompareBar() {
   const t = useTranslations("LensList");
@@ -36,6 +37,7 @@ export default function CompareBar() {
       if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
         return;
       }
+      track("compare_add", { lens_slug: lens.id });
       replaceCompare([...compareIds, lens.id]);
     },
     [compareIds, replaceCompare]

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -31,6 +31,7 @@ import type { Lens } from "@/lib/types";
 import { PriceCell } from "@/components/PriceCell";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
+import { track } from "@/lib/analytics";
 
 // --- LensHeaderContent: shared inner card content ---
 
@@ -333,6 +334,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
       if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
         return;
       }
+      track("compare_add", { lens_slug: lens.id });
       replaceCompare([...compareIds, lens.id]);
     },
     [compareIds, replaceCompare]

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -34,6 +34,7 @@ import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
 import LensSearchDialog from "./LensSearchDialog";
 import FeedbackTrigger from "./FeedbackTrigger";
+import { track } from "@/lib/analytics";
 
 interface Props {
   lenses: Lens[];
@@ -223,7 +224,12 @@ export default function LensListClient({ lenses }: Props) {
                   lens={lens}
                   isSelected={compareIds.includes(lens.id)}
                   selectionDisabled={!canToggle(lens.id)}
-                  onToggle={() => toggleCompare(lens.id)}
+                  onToggle={() => {
+                    if (!compareIds.includes(lens.id)) {
+                      track("compare_add", { lens_slug: lens.id });
+                    }
+                    toggleCompare(lens.id);
+                  }}
                   priority={i < 8}
                 />
               ))}


### PR DESCRIPTION
## Summary

PR #205 wired \`compare_add\` into \`AddToCompareButton\` (lens detail page) and \`CompareAddLensButton\` (/compare add-via-search). Three other user-facing add entry points were silently bypassed:

| File | Entry point | Why it matters |
|---|---|---|
| \`LensListClient.tsx\` | \`LensCard\`'s "+" toggle on browse pages | **Primary** add path. The previous data severely underestimated true add volume. |
| \`CompareTable.tsx\` | Inline search to fill empty columns inside the /compare table | Used while already on the comparison page. |
| \`CompareBar.tsx\` | Floating bottom-bar "Add" search dialog | Used to add more lenses without leaving the current browse page. |

Each call site checks "is this actually an add (not a remove / not a dup / not at MAX_COMPARE)" before firing, matching the guard pattern already used by \`AddToCompareButton\`.

## Why this wasn't caught the first time

I grepped for components named \`*AddCompare*\` and assumed coverage was complete — that filename heuristic missed three legitimate add paths whose names don't include "Add". The next time we add a new tracked action class, the right search is on the underlying state mutation hook (\`useMountedCompare\` here), not on component names.

## Why not push the event into the provider

A centralized fire inside \`CompareProvider.toggleCompare\` / \`replaceCompare\` would produce false positives: \`replaceCompare\` is also called by URL-seeding logic in \`CompareTable\` (initial \`?ids=A,B,C\` parse), which is not a user action.

## Test plan

- [ ] Visit a browse page, click "+" on a lens card → Network panel shows \`POST /api/track\` with \`event: "compare_add"\`
- [ ] On /compare, search and add a lens via the inline slot → same event fires
- [ ] On any browse page with at least one selected lens, click "+ Add" in the floating CompareBar → same event fires
- [ ] Click "+" to remove a selected lens → \`compare_add\` does NOT fire
- [ ] Click "+" when already at MAX_COMPARE (button should be disabled) → no event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)