### PR TITLE
refactor(analytics): centralize compare_add, drop unreliable dwell

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -75,19 +75,6 @@ const Q_LENS_VIEW_TOP = `
   LIMIT 20
 `;
 
-const Q_LENS_DWELL = `
-  SELECT
-    blob4 AS lens_slug,
-    ROUND(SUM(_sample_interval * double1) / SUM(_sample_interval)) AS avg_seconds,
-    SUM(_sample_interval) AS n
-  FROM xglass_events
-  WHERE index1 = 'lens_dwell' AND double1 > 0
-    AND timestamp > NOW() - ${WINDOW}
-  GROUP BY lens_slug
-  ORDER BY n DESC
-  LIMIT 20
-`;
-
 const Q_FEEDBACK = `
   SELECT
     blob4 AS feedback_type,
@@ -236,7 +223,6 @@ export default async function AnalyticsDashboardPage() {
     compareFunnel,
     compareCombos,
     lensViews,
-    lensDwell,
     feedback,
     share,
     shareBySource,
@@ -251,7 +237,6 @@ export default async function AnalyticsDashboardPage() {
     queryAE(Q_COMPARE_FUNNEL),
     queryAE(Q_COMPARE_COMBOS),
     queryAE(Q_LENS_VIEW_TOP),
-    queryAE(Q_LENS_DWELL),
     queryAE(Q_FEEDBACK),
     queryAE(Q_SHARE),
     queryAE(Q_SHARE_BY_SOURCE),
@@ -389,14 +374,12 @@ export default async function AnalyticsDashboardPage() {
         </Card>
 
         <Card title="Detail · avg dwell seconds (top by views)">
-          <Table
-            rows={lensDwell.data}
-            columns={[
-              { key: "lens_slug", label: "Lens" },
-              { key: "avg_seconds", label: "Avg sec", align: "right" },
-              { key: "n", label: "Dwell events", align: "right" },
-            ]}
-          />
+          <p className="text-sm text-zinc-400 dark:text-zinc-500">
+            Not collected. SPA navigation within X-Glass doesn&rsquo;t fire{" "}
+            <code>visibilitychange</code> or <code>pagehide</code>, so the
+            previous dwell timing was unreliable. Pending a redesign that
+            also captures client-side route exits.
+          </p>
         </Card>
 
         <Card title="Feedback · funnel by type">

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -79,7 +79,7 @@ function sanitizeProps(raw: unknown): EventProps {
       out[key] = v.slice(0, MAX_STRING_LEN);
     }
   }
-  for (const key of ["results_count", "lens_count", "depth_pct", "seconds"] as const) {
+  for (const key of ["results_count", "lens_count", "depth_pct"] as const) {
     const v = o[key];
     if (typeof v === "number" && Number.isFinite(v)) {
       out[key] = v;

--- a/src/components/AddToCompareButton.tsx
+++ b/src/components/AddToCompareButton.tsx
@@ -3,7 +3,6 @@
 import { useTranslations } from "next-intl";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
-import { track } from "@/lib/analytics";
 
 interface Props {
   lensId: string;
@@ -18,12 +17,7 @@ export default function AddToCompareButton({ lensId }: Props) {
 
   return (
     <button
-      onClick={() => {
-        if (!isSelected) {
-          track("compare_add", { lens_slug: lensId });
-        }
-        toggleCompare(lensId);
-      }}
+      onClick={() => toggleCompare(lensId)}
       disabled={isFull}
       className={`inline-flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg transition-colors ${
         isSelected

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -7,7 +7,6 @@ import LensSearchDialog from "@/components/LensSearchDialog";
 import { MAX_COMPARE } from "@/lib/lens";
 import { useMountedCompare } from "@/context/CompareProvider";
 import type { Lens } from "@/lib/types";
-import { track } from "@/lib/analytics";
 
 interface Props {
   triggerClassName?: string;
@@ -15,19 +14,15 @@ interface Props {
 
 export default function CompareAddLensButton({ triggerClassName }: Props) {
   const t = useTranslations("Compare");
-  const { compareIds, replaceCompare } = useMountedCompare();
+  const { compareIds, addToCompare } = useMountedCompare();
 
   const canAddMore = compareIds.length < MAX_COMPARE;
 
   const handleSelectLens = useCallback(
     (lens: Lens) => {
-      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
-        return;
-      }
-      track("compare_add", { lens_slug: lens.id });
-      replaceCompare([...compareIds, lens.id]);
+      addToCompare(lens.id);
     },
-    [compareIds, replaceCompare]
+    [addToCompare]
   );
 
   const getResultState = useCallback(

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -20,7 +20,6 @@ import { cn } from "@/lib/utils";
 import { ACTION_PRIMARY_CLS, ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
 import { Z } from "@/config/ui";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
-import { track } from "@/lib/analytics";
 
 export default function CompareBar() {
   const t = useTranslations("LensList");
@@ -29,18 +28,14 @@ export default function CompareBar() {
   const router = useRouter();
   const locale = useLocale();
   const mount = useEffectiveMount();
-  const { compareIds, toggleCompare, replaceCompare } = useMountedCompare();
+  const { compareIds, toggleCompare, addToCompare } = useMountedCompare();
   const clearCompareWithUndo = useClearCompareWithUndo();
 
   const handleAddLens = useCallback(
     (lens: Lens) => {
-      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
-        return;
-      }
-      track("compare_add", { lens_slug: lens.id });
-      replaceCompare([...compareIds, lens.id]);
+      addToCompare(lens.id);
     },
-    [compareIds, replaceCompare]
+    [addToCompare]
   );
 
   const getAddResultState = useCallback(

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -31,7 +31,6 @@ import type { Lens } from "@/lib/types";
 import { PriceCell } from "@/components/PriceCell";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
-import { track } from "@/lib/analytics";
 
 // --- LensHeaderContent: shared inner card content ---
 
@@ -295,7 +294,8 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const locale = useLocale();
   const priceFieldLabel = tPricing("fieldLabel");
   const priceGroupLabel = tPricing("groupLabel");
-  const { compareIds, replaceCompare } = useMountedCompare();
+  const { compareIds, addToCompare, removeFromCompare, reorderCompare, seedCompare } =
+    useMountedCompare();
   // Compare page is the only surface that projects compare state onto the
   // URL. This hook owns that projection so individual write callsites no
   // longer need to know about address-bar bookkeeping.
@@ -319,8 +319,8 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   // preset link click that re-renders the server component with new
   // searchParams).
   useLayoutEffect(() => {
-    replaceCompare(initialLensIds);
-  }, [initialLensIds, replaceCompare]);
+    seedCompare(initialLensIds);
+  }, [initialLensIds, seedCompare]);
 
   const orderedLenses = compareIds
     .map((id) => getLensesByMount(mount, locale).find((lens) => lens.id === id))
@@ -331,13 +331,9 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
 
   const handleAddLens = useCallback(
     (lens: Lens) => {
-      if (compareIds.includes(lens.id) || compareIds.length >= MAX_COMPARE) {
-        return;
-      }
-      track("compare_add", { lens_slug: lens.id });
-      replaceCompare([...compareIds, lens.id]);
+      addToCompare(lens.id);
     },
-    [compareIds, replaceCompare]
+    [addToCompare]
   );
 
   const getAddResultState = useCallback(
@@ -362,7 +358,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   };
 
   function handleRemoveLens(lensId: string) {
-    replaceCompare(compareIds.filter((id) => id !== lensId));
+    removeFromCompare(lensId);
   }
 
   function handleShiftLens(lensId: string, direction: -1 | 1) {
@@ -373,7 +369,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     }
     const next = [...compareIds];
     [next[index], next[newIndex]] = [next[newIndex], next[index]];
-    replaceCompare(next);
+    reorderCompare(next);
   }
 
   const allGroups = useMemo(

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -34,7 +34,6 @@ import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
 import LensSearchDialog from "./LensSearchDialog";
 import FeedbackTrigger from "./FeedbackTrigger";
-import { track } from "@/lib/analytics";
 
 interface Props {
   lenses: Lens[];
@@ -224,12 +223,7 @@ export default function LensListClient({ lenses }: Props) {
                   lens={lens}
                   isSelected={compareIds.includes(lens.id)}
                   selectionDisabled={!canToggle(lens.id)}
-                  onToggle={() => {
-                    if (!compareIds.includes(lens.id)) {
-                      track("compare_add", { lens_slug: lens.id });
-                    }
-                    toggleCompare(lens.id);
-                  }}
+                  onToggle={() => toggleCompare(lens.id)}
                   priority={i < 8}
                 />
               ))}

--- a/src/components/telemetry/LensDetailTelemetry.hooks.ts
+++ b/src/components/telemetry/LensDetailTelemetry.hooks.ts
@@ -7,19 +7,18 @@ const SCROLL_MILESTONES = [50, 90] as const;
 
 // `lens_view`: fires once per slug on mount, with referrer attached so the
 // dashboard can later answer "where do detail-page visits come from?".
-export function useLensViewTelemetry(lensSlug: string, enteredAtRef: React.MutableRefObject<number>) {
+export function useLensViewTelemetry(lensSlug: string) {
   const firedRef = useRef(false);
   useEffect(() => {
     if (firedRef.current) {
       return;
     }
     firedRef.current = true;
-    enteredAtRef.current = Date.now();
     track("lens_view", {
       lens_slug: lensSlug,
       referrer: typeof document !== "undefined" ? document.referrer.slice(0, 256) : undefined,
     });
-  }, [lensSlug, enteredAtRef]);
+  }, [lensSlug]);
 }
 
 // `lens_scroll`: fires at 50% and 90% scroll depth, once each per mount.
@@ -47,32 +46,4 @@ export function useLensScrollTelemetry(lensSlug: string) {
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, [lensSlug]);
-}
-
-// `lens_dwell`: fires on tab-hide or pagehide, once per mount, with seconds
-// spent on the page. `pagehide` is needed because `visibilitychange` doesn't
-// fire reliably on iOS Safari navigation away.
-export function useLensDwellTelemetry(lensSlug: string, enteredAtRef: React.MutableRefObject<number>) {
-  const firedRef = useRef(false);
-  useEffect(() => {
-    function fireDwell() {
-      if (firedRef.current) {
-        return;
-      }
-      firedRef.current = true;
-      const seconds = Math.round((Date.now() - enteredAtRef.current) / 1000);
-      track("lens_dwell", { lens_slug: lensSlug, seconds });
-    }
-    function onVisibilityChange() {
-      if (document.visibilityState === "hidden") {
-        fireDwell();
-      }
-    }
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    window.addEventListener("pagehide", fireDwell);
-    return () => {
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.removeEventListener("pagehide", fireDwell);
-    };
-  }, [lensSlug, enteredAtRef]);
 }

--- a/src/components/telemetry/LensDetailTelemetry.tsx
+++ b/src/components/telemetry/LensDetailTelemetry.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useRef } from "react";
 import {
-  useLensDwellTelemetry,
   useLensScrollTelemetry,
   useLensViewTelemetry,
 } from "./LensDetailTelemetry.hooks";
@@ -12,13 +10,7 @@ interface Props {
 }
 
 export default function LensDetailTelemetry({ lensSlug }: Props) {
-  // Entry timestamp is shared between the view hook (writes it) and the
-  // dwell hook (reads it to compute elapsed seconds), so it lives here.
-  const enteredAtRef = useRef<number>(0);
-
-  useLensViewTelemetry(lensSlug, enteredAtRef);
+  useLensViewTelemetry(lensSlug);
   useLensScrollTelemetry(lensSlug);
-  useLensDwellTelemetry(lensSlug, enteredAtRef);
-
   return null;
 }

--- a/src/context/CompareProvider.tsx
+++ b/src/context/CompareProvider.tsx
@@ -4,20 +4,36 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
+import { track } from "@/lib/analytics";
 import type { Mount } from "@/lib/types";
 
 type CompareState = { X: string[]; G: string[] };
 
 interface CompareContextValue {
   compareState: CompareState;
+  // User-initiated add. Fires `compare_add` exactly once per successful add.
+  // No-ops (and emits no event) when the id is already in the slot or the
+  // slot is at MAX_COMPARE.
+  addToCompare: (id: string, mount: Mount) => void;
+  // User-initiated remove. No-op when the id isn't in the slot.
+  removeFromCompare: (id: string, mount: Mount) => void;
+  // Convenience wrapper. Routes to addToCompare or removeFromCompare based
+  // on current membership, so the call site doesn't need to know.
   toggleCompare: (id: string, mount: Mount) => void;
-  replaceCompare: (ids: string[], mount: Mount) => void;
+  // User-initiated reorder (no membership change). Emits no event.
+  reorderCompare: (ids: string[], mount: Mount) => void;
   clearCompare: (mount: Mount) => void;
+  // Non-user state transition: URL hydration (shared compare links) and
+  // undo-restore both use this. Distinguished from addToCompare so that
+  // analytics counts user clicks only, not state arriving from outside.
+  seedCompare: (ids: string[], mount: Mount) => void;
   canToggle: (id: string, mount: Mount) => boolean;
 }
 
@@ -25,20 +41,66 @@ const CompareContext = createContext<CompareContextValue | null>(null);
 
 export function CompareProvider({ children }: { children: React.ReactNode }) {
   const [compareState, setCompareState] = useState<CompareState>({ X: [], G: [] });
+  // Mirror state into a ref so `toggleCompare` can read the latest value
+  // without re-creating the callback on every state change. User event
+  // handlers always run after effects flush, so the ref is up-to-date by
+  // the time toggleCompare reads it.
+  const stateRef = useRef(compareState);
+  useEffect(() => {
+    stateRef.current = compareState;
+  }, [compareState]);
 
-  const toggleCompare = useCallback((id: string, mount: Mount) => {
+  const addToCompare = useCallback((id: string, mount: Mount) => {
+    let didAdd = false;
     setCompareState((prev) => {
       const slot = prev[mount];
-      const next = slot.includes(id)
-        ? slot.filter((x) => x !== id)
-        : slot.length < MAX_COMPARE
-          ? [...slot, id]
-          : slot;
-      return { ...prev, [mount]: next };
+      if (slot.includes(id) || slot.length >= MAX_COMPARE) {
+        return prev;
+      }
+      didAdd = true;
+      return { ...prev, [mount]: [...slot, id] };
+    });
+    if (didAdd) {
+      track("compare_add", { lens_slug: id });
+    }
+  }, []);
+
+  const removeFromCompare = useCallback((id: string, mount: Mount) => {
+    setCompareState((prev) => {
+      const slot = prev[mount];
+      if (!slot.includes(id)) {
+        return prev;
+      }
+      return { ...prev, [mount]: slot.filter((x) => x !== id) };
     });
   }, []);
 
-  const replaceCompare = useCallback((ids: string[], mount: Mount) => {
+  const toggleCompare = useCallback(
+    (id: string, mount: Mount) => {
+      if (stateRef.current[mount].includes(id)) {
+        removeFromCompare(id, mount);
+      } else {
+        addToCompare(id, mount);
+      }
+    },
+    [addToCompare, removeFromCompare],
+  );
+
+  const reorderCompare = useCallback((ids: string[], mount: Mount) => {
+    setCompareState((prev) => {
+      const slot = prev[mount];
+      if (slot.length === ids.length && slot.every((id, i) => id === ids[i])) {
+        return prev;
+      }
+      return { ...prev, [mount]: ids };
+    });
+  }, []);
+
+  const clearCompare = useCallback((mount: Mount) => {
+    setCompareState((prev) => ({ ...prev, [mount]: [] }));
+  }, []);
+
+  const seedCompare = useCallback((ids: string[], mount: Mount) => {
     const nextIds = Array.from(new Set(ids)).slice(0, MAX_COMPARE);
     setCompareState((prev) => {
       const slot = prev[mount];
@@ -49,10 +111,6 @@ export function CompareProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
-  const clearCompare = useCallback((mount: Mount) => {
-    setCompareState((prev) => ({ ...prev, [mount]: [] }));
-  }, []);
-
   // canToggle reads compareState directly; using a state ref keeps the function
   // reference stable across state changes so that consumers (and any useEffect
   // that depends on it) don't re-run on every mutation.
@@ -61,18 +119,30 @@ export function CompareProvider({ children }: { children: React.ReactNode }) {
       const slot = compareState[mount];
       return slot.includes(id) || slot.length < MAX_COMPARE;
     },
-    [compareState]
+    [compareState],
   );
 
   const value = useMemo(
     () => ({
       compareState,
+      addToCompare,
+      removeFromCompare,
       toggleCompare,
-      replaceCompare,
+      reorderCompare,
       clearCompare,
+      seedCompare,
       canToggle,
     }),
-    [canToggle, clearCompare, compareState, replaceCompare, toggleCompare]
+    [
+      compareState,
+      addToCompare,
+      removeFromCompare,
+      toggleCompare,
+      reorderCompare,
+      clearCompare,
+      seedCompare,
+      canToggle,
+    ],
   );
 
   return <CompareContext value={value}>{children}</CompareContext>;
@@ -98,35 +168,53 @@ export function useCompare() {
 export function useMountedCompare() {
   const ctx = useCompare();
   const mount = useEffectiveMount();
-  const { compareState, toggleCompare, replaceCompare, clearCompare, canToggle } = ctx;
+  const {
+    compareState,
+    addToCompare,
+    removeFromCompare,
+    toggleCompare,
+    reorderCompare,
+    clearCompare,
+    seedCompare,
+    canToggle,
+  } = ctx;
 
   const compareIds = compareState[mount];
 
-  const toggleCompareScoped = useCallback(
-    (id: string) => toggleCompare(id, mount),
-    [toggleCompare, mount]
+  const addScoped = useCallback((id: string) => addToCompare(id, mount), [addToCompare, mount]);
+  const removeScoped = useCallback(
+    (id: string) => removeFromCompare(id, mount),
+    [removeFromCompare, mount],
   );
-  const replaceCompareScoped = useCallback(
-    (ids: string[]) => replaceCompare(ids, mount),
-    [replaceCompare, mount]
+  const toggleScoped = useCallback((id: string) => toggleCompare(id, mount), [toggleCompare, mount]);
+  const reorderScoped = useCallback(
+    (ids: string[]) => reorderCompare(ids, mount),
+    [reorderCompare, mount],
   );
-  const clearCompareScoped = useCallback(
-    () => clearCompare(mount),
-    [clearCompare, mount]
-  );
-  const canToggleScoped = useCallback(
-    (id: string) => canToggle(id, mount),
-    [canToggle, mount]
-  );
+  const clearScoped = useCallback(() => clearCompare(mount), [clearCompare, mount]);
+  const seedScoped = useCallback((ids: string[]) => seedCompare(ids, mount), [seedCompare, mount]);
+  const canToggleScoped = useCallback((id: string) => canToggle(id, mount), [canToggle, mount]);
 
   return useMemo(
     () => ({
       compareIds,
-      toggleCompare: toggleCompareScoped,
-      replaceCompare: replaceCompareScoped,
-      clearCompare: clearCompareScoped,
+      addToCompare: addScoped,
+      removeFromCompare: removeScoped,
+      toggleCompare: toggleScoped,
+      reorderCompare: reorderScoped,
+      clearCompare: clearScoped,
+      seedCompare: seedScoped,
       canToggle: canToggleScoped,
     }),
-    [compareIds, toggleCompareScoped, replaceCompareScoped, clearCompareScoped, canToggleScoped]
+    [
+      compareIds,
+      addScoped,
+      removeScoped,
+      toggleScoped,
+      reorderScoped,
+      clearScoped,
+      seedScoped,
+      canToggleScoped,
+    ],
   );
 }

--- a/src/hooks/useClearCompareWithUndo.ts
+++ b/src/hooks/useClearCompareWithUndo.ts
@@ -8,10 +8,9 @@ import { useMountedCompare } from "@/context/CompareProvider";
 /**
  * Wraps `clearCompare` with an undo affordance: snapshots the current
  * compareIds, clears them, then surfaces a sonner toast whose action
- * restores the snapshot via `replaceCompare`. Used by every surface
- * that exposes a "clear" affordance for the comparison (nav link on
- * compare page, ComparePageHeader's "清空", CompareBar's "清空")
- * so the destructive action has a consistent reversal path.
+ * restores the snapshot via `seedCompare` (not `addToCompare` — those
+ * lenses were already tracked when first added; re-counting them on
+ * undo would double-fire the `compare_add` event).
  *
  * No-ops when `compareIds` is empty so callers don't need to
  * pre-check before invoking.
@@ -24,7 +23,7 @@ import { useMountedCompare } from "@/context/CompareProvider";
  */
 export function useClearCompareWithUndo() {
   const tCompare = useTranslations("Compare");
-  const { compareIds, clearCompare, replaceCompare } = useMountedCompare();
+  const { compareIds, clearCompare, seedCompare } = useMountedCompare();
 
   return useCallback(() => {
     if (compareIds.length === 0) {
@@ -35,8 +34,8 @@ export function useClearCompareWithUndo() {
     toast(tCompare("clearedToast"), {
       action: {
         label: tCompare("undo"),
-        onClick: () => replaceCompare(prevIds),
+        onClick: () => seedCompare(prevIds),
       },
     });
-  }, [compareIds, clearCompare, replaceCompare, tCompare]);
+  }, [compareIds, clearCompare, seedCompare, tCompare]);
 }

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -20,7 +20,6 @@ export const EVENT_NAMES = [
   "compare_scroll",
   "lens_view",
   "lens_scroll",
-  "lens_dwell",
   "feedback_open",
   "feedback_submit",
   "install_action",
@@ -47,7 +46,6 @@ export interface EventProps {
   lens_slugs?: string;
   lens_count?: number;
   depth_pct?: number;
-  seconds?: number;
 
   // CTA / feedback
   feedback_type?: string;
@@ -99,7 +97,6 @@ export function toDataPoint(
   const primaryNumber =
     props.results_count ??
     props.depth_pct ??
-    props.seconds ??
     props.lens_count ??
     0;
 


### PR DESCRIPTION
## Summary

Two changes bundled together because they share a single goal: making the analytics layer reflect reality, not just what was easy to wire up.

### 1. Centralize \`compare_add\` tracking in the provider

\`CompareProvider\` now exposes intent-named methods. The provider is the single source of the \`compare_add\` event — call sites have zero analytics code:

| Method | When called | Fires \`compare_add\` |
|---|---|---|
| \`addToCompare(id)\` | User clicks "+ Add" / search-dialog select / lens-card toggle | ✅ once per successful add |
| \`removeFromCompare(id)\` | User clicks "−" / chip "×" | ❌ |
| \`toggleCompare(id)\` | Convenience — routes to add or remove | (delegates) |
| \`reorderCompare(ids)\` | User drags column / shifts left-right | ❌ |
| \`clearCompare()\` | "Clear all" | ❌ |
| \`seedCompare(ids)\` | URL hydration on /compare, undo restore | ❌ |
| \`canToggle(id)\` | UI disable check | unchanged |

Why this matters: PR #206 had to react to a discovery that three add entry points were silently bypassed. The pattern of "remember to call \`track\` at every new entry" is fundamentally fragile. After this PR, **adding a new add entry just means calling \`addToCompare\`** — the track happens automatically.

\`useClearCompareWithUndo\` now uses \`seedCompare\` for the undo restore (not \`replaceCompare\`/\`addToCompare\`), so re-instating previously-tracked lenses doesn't double-count them.

### 2. Drop \`lens_dwell\` entirely (with placeholder)

The hook only fired on \`visibilitychange\` and \`pagehide\`. Next.js SPA navigation (\`<Link>\` between detail pages) triggers neither, so dwell numbers were biased toward tab-close behavior — not a reliable signal for "how long do users read details."

Rather than ship a half-correct metric, the dataset event, hook, and SQL query are removed. The dashboard Card stays as a labeled placeholder explaining why.

Re-adding dwell properly requires a global route-change listener that flushes the previous page's dwell on client-side exits. Out of scope here.

## Files touched

- \`src/context/CompareProvider.tsx\` — full API redesign
- \`src/hooks/useClearCompareWithUndo.ts\` — \`replaceCompare\` → \`seedCompare\`
- \`src/components/AddToCompareButton.tsx\` — drop inline track
- \`src/components/CompareAddLensButton.tsx\` — drop inline track + guard, use \`addToCompare\`
- \`src/components/LensListClient.tsx\` — drop inline track
- \`src/components/CompareTable.tsx\` — \`addToCompare\` / \`removeFromCompare\` / \`reorderCompare\` / \`seedCompare\`
- \`src/components/CompareBar.tsx\` — drop inline track + guard, use \`addToCompare\`
- \`src/components/telemetry/LensDetailTelemetry{,.hooks}.ts\` — delete \`useLensDwellTelemetry\`
- \`src/lib/analytics-events.ts\` — drop \`lens_dwell\` from EVENT_NAMES, drop \`seconds\` prop
- \`src/app/api/track/route.ts\` — drop \`seconds\` from sanitizer
- \`src/app/admin/analytics/page.tsx\` — replace dwell Card body with placeholder, drop Q_LENS_DWELL

## Verification

- \`npx tsc --noEmit\` — clean
- \`npx eslint\` on changed files — no new errors
- Search: no remaining \`replaceCompare\` callers, no remaining \`lens_dwell\` references

## Test plan

- [ ] On a browse page, click "+" on a lens card → \`POST /api/track\` with \`event: "compare_add"\`
- [ ] On the same card, click "+" again to remove → no \`compare_add\` (only state changes)
- [ ] Open a shared \`/compare?ids=A,B,C\` link → no \`compare_add\` events (it's a seed)
- [ ] Inside CompareTable, add a lens via inline search → one \`compare_add\`
- [ ] CompareBar floating "Add" → one \`compare_add\`
- [ ] Clear compare, then click undo in the toast → no \`compare_add\` (it's a seed restore)
- [ ] Visit lens detail page → no longer see a \`lens_dwell\` POST when navigating away
- [ ] Open \`/admin/analytics\` → dwell Card shows the "Not collected" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)