### PR TITLE
feat(admin): polish analytics dashboard + add overview / locale / referrer panels

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -6,11 +6,49 @@
 // The route itself is open — auth lives one layer above at the platform.
 
 import { queryAE } from "@/lib/analytics-query";
+import {
+  formatFilterSnapshot,
+  formatHref,
+  formatLensSlug,
+  formatLensSlugList,
+  formatShareMethod,
+} from "@/lib/analytics-format";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const WINDOW = "INTERVAL '30' DAY";
+
+const Q_OVERVIEW = `
+  SELECT
+    SUM(_sample_interval) AS events,
+    uniq(blob1) AS sessions,
+    uniqIf(blob4, index1 = 'search') AS unique_queries,
+    uniqIf(blob4, index1 = 'lens_view') AS unique_lenses_viewed
+  FROM xglass_events
+  WHERE timestamp > NOW() - ${WINDOW}
+`;
+
+const Q_LOCALE_SPLIT = `
+  SELECT
+    blob2 AS locale,
+    SUM(_sample_interval) AS events,
+    uniq(blob1) AS sessions
+  FROM xglass_events
+  WHERE timestamp > NOW() - ${WINDOW} AND blob2 != ''
+  GROUP BY locale
+  ORDER BY events DESC
+`;
+
+const Q_REFERRER = `
+  SELECT blob5 AS referrer, SUM(_sample_interval) AS n
+  FROM xglass_events
+  WHERE index1 = 'lens_view' AND blob5 != ''
+    AND timestamp > NOW() - ${WINDOW}
+  GROUP BY referrer
+  ORDER BY n DESC
+  LIMIT 15
+`;
 
 const Q_SEARCH_ZERO = `
   SELECT blob4 AS query, SUM(_sample_interval) AS n
@@ -162,10 +200,14 @@ function num(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+function fmtNum(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-      <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+      <h2 className="font-heading text-base font-semibold text-zinc-800 dark:text-zinc-100">
         {title}
       </h2>
       <div className="mt-3">{children}</div>
@@ -173,24 +215,31 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
   );
 }
 
-function Table({
-  rows,
-  columns,
-}: {
-  rows: Array<Record<string, unknown>>;
-  columns: { key: string; label: string; align?: "left" | "right" }[];
-}) {
+interface Column {
+  key: string;
+  label: string;
+  align?: "left" | "right";
+  // When set, also use the value at this key (the raw / unformatted form)
+  // for the cell's `title` tooltip attribute so truncated content remains
+  // discoverable on hover.
+  titleKey?: string;
+  // Constrain a numeric column so a 1-digit count doesn't take half the
+  // row width; left undefined for primary string columns to let them fill.
+  widthClass?: string;
+}
+
+function Table({ rows, columns }: { rows: Array<Record<string, unknown>>; columns: Column[] }) {
   if (rows.length === 0) {
     return <p className="text-sm text-zinc-400">No data yet.</p>;
   }
   return (
-    <table className="w-full text-sm">
+    <table className="w-full table-fixed text-sm">
       <thead>
         <tr className="text-xs uppercase tracking-wider text-zinc-400">
           {columns.map((c) => (
             <th
               key={c.key}
-              className={`pb-2 font-medium ${c.align === "right" ? "text-right" : "text-left"}`}
+              className={`pb-2 font-medium ${c.align === "right" ? "text-right" : "text-left"} ${c.widthClass ?? ""}`}
             >
               {c.label}
             </th>
@@ -200,14 +249,19 @@ function Table({
       <tbody>
         {rows.map((r, i) => (
           <tr key={i} className="border-t border-zinc-100 dark:border-zinc-800">
-            {columns.map((c) => (
-              <td
-                key={c.key}
-                className={`py-1.5 ${c.align === "right" ? "text-right tabular-nums" : "text-left"} ${c.align !== "right" ? "truncate max-w-[24rem]" : ""}`}
-              >
-                {String(r[c.key] ?? "")}
-              </td>
-            ))}
+            {columns.map((c) => {
+              const raw = r[c.key];
+              const title = c.titleKey ? String(r[c.titleKey] ?? "") : undefined;
+              return (
+                <td
+                  key={c.key}
+                  title={title}
+                  className={`py-1.5 ${c.align === "right" ? "text-right tabular-nums" : "truncate text-left"}`}
+                >
+                  {String(raw ?? "")}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>
@@ -215,8 +269,29 @@ function Table({
   );
 }
 
+// Single-number stat for the top overview bar.
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <span className="text-xs uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+        {label}
+      </span>
+      <span className="font-heading text-3xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// Narrow width class shared by every "count" / "n" column so the long
+// primary string column gets the remaining space.
+const COUNT_WIDTH = "w-20";
+
 export default async function AnalyticsDashboardPage() {
   const [
+    overview,
+    localeSplit,
+    referrers,
     searchZero,
     searchAll,
     filterUsage,
@@ -231,6 +306,9 @@ export default async function AnalyticsDashboardPage() {
     outbound,
     outboundBySource,
   ] = await Promise.all([
+    queryAE(Q_OVERVIEW),
+    queryAE(Q_LOCALE_SPLIT),
+    queryAE(Q_REFERRER),
     queryAE(Q_SEARCH_ZERO),
     queryAE(Q_SEARCH_ALL),
     queryAE(Q_FILTER_USAGE),
@@ -246,10 +324,10 @@ export default async function AnalyticsDashboardPage() {
     queryAE(Q_OUTBOUND_BY_SOURCE),
   ]);
 
-  if (searchZero.error === "missing_credentials") {
+  if (overview.error === "missing_credentials") {
     return (
       <main className="mx-auto max-w-2xl px-6 py-16">
-        <h1 className="text-2xl font-bold">Analytics not configured</h1>
+        <h1 className="font-heading text-2xl font-bold">Analytics not configured</h1>
         <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
           Set <code className="rounded bg-zinc-100 px-1.5 py-0.5 dark:bg-zinc-800">CF_ACCOUNT_ID</code> and{" "}
           <code className="rounded bg-zinc-100 px-1.5 py-0.5 dark:bg-zinc-800">CF_ANALYTICS_TOKEN</code>{" "}
@@ -260,6 +338,15 @@ export default async function AnalyticsDashboardPage() {
       </main>
     );
   }
+
+  const overviewRow = overview.data[0] as
+    | {
+        events?: number;
+        sessions?: number;
+        unique_queries?: number;
+        unique_lenses_viewed?: number;
+      }
+    | undefined;
 
   const funnel = compareFunnel.data[0] as
     | {
@@ -280,22 +367,88 @@ export default async function AnalyticsDashboardPage() {
 
   const installCount = num((install.data[0] as { n?: number } | undefined)?.n);
 
+  // Pre-format rows so JSX cells stay simple and `title` tooltips can
+  // reference the original strings.
+  const compareCombosRows = compareCombos.data.map((r) => ({
+    ...r,
+    display: formatLensSlugList(String(r.slugs ?? "")),
+  }));
+  const lensViewsRows = lensViews.data.map((r) => ({
+    ...r,
+    display: formatLensSlug(String(r.lens_slug ?? "")),
+  }));
+  const filterUsageRows = filterUsage.data.map((r) => ({
+    ...r,
+    display: formatFilterSnapshot(String(r.filters ?? "")),
+  }));
+  const shareRows = share.data.map((r) => ({
+    ...r,
+    display: formatShareMethod(String(r.method ?? "")),
+  }));
+  const shareBySourceRows = shareBySource.data.map((r) => ({
+    ...r,
+    method_display: formatShareMethod(String(r.method ?? "")),
+  }));
+  const outboundRows = outbound.data.map((r) => ({
+    ...r,
+    display: formatHref(String(r.href ?? "")),
+  }));
+  const outboundBySourceRows = outboundBySource.data.map((r) => ({
+    ...r,
+    href_display: formatHref(String(r.href ?? "")),
+  }));
+  const referrerRows = referrers.data.map((r) => ({
+    ...r,
+    display: formatHref(String(r.referrer ?? "")),
+  }));
+
   return (
     <main className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
       <header className="mb-6">
-        <h1 className="text-2xl font-bold">Analytics — last 30 days</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Counts are sampling-corrected via <code>SUM(_sample_interval)</code>.
+        <h1 className="font-heading text-3xl font-bold text-zinc-900 dark:text-zinc-50">
+          Analytics
+        </h1>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Last 30 days · numbers adjusted for sampling
         </p>
       </header>
 
+      {/* Overview stats bar */}
+      <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Stat label="Events" value={fmtNum(num(overviewRow?.events))} />
+        <Stat label="Sessions" value={fmtNum(num(overviewRow?.sessions))} />
+        <Stat label="Unique queries" value={fmtNum(num(overviewRow?.unique_queries))} />
+        <Stat label="Unique lenses viewed" value={fmtNum(num(overviewRow?.unique_lenses_viewed))} />
+      </div>
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card title="Locale · split">
+          <Table
+            rows={localeSplit.data}
+            columns={[
+              { key: "locale", label: "Locale" },
+              { key: "events", label: "Events", align: "right", widthClass: COUNT_WIDTH },
+              { key: "sessions", label: "Sessions", align: "right", widthClass: COUNT_WIDTH },
+            ]}
+          />
+        </Card>
+
+        <Card title="Detail · referrer sources">
+          <Table
+            rows={referrerRows}
+            columns={[
+              { key: "display", label: "Referrer", titleKey: "referrer" },
+              { key: "n", label: "Views", align: "right", widthClass: COUNT_WIDTH },
+            ]}
+          />
+        </Card>
+
         <Card title="Search · zero-result queries">
           <Table
             rows={searchZero.data}
             columns={[
               { key: "query", label: "Query" },
-              { key: "n", label: "Count", align: "right" },
+              { key: "n", label: "Count", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
@@ -305,38 +458,38 @@ export default async function AnalyticsDashboardPage() {
             rows={searchAll.data}
             columns={[
               { key: "query", label: "Query" },
-              { key: "n", label: "Count", align: "right" },
+              { key: "n", label: "Count", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Compare · funnel">
-          <table className="w-full text-sm">
+          <table className="w-full table-fixed text-sm">
             <thead>
               <tr className="text-xs uppercase tracking-wider text-zinc-400">
                 <th className="pb-2 text-left font-medium">Step</th>
-                <th className="pb-2 text-right font-medium">Events</th>
-                <th className="pb-2 text-right font-medium">Sessions</th>
-                <th className="pb-2 text-right font-medium">vs. add</th>
+                <th className={`pb-2 text-right font-medium ${COUNT_WIDTH}`}>Events</th>
+                <th className={`pb-2 text-right font-medium ${COUNT_WIDTH}`}>Sessions</th>
+                <th className={`pb-2 text-right font-medium ${COUNT_WIDTH}`}>vs. add</th>
               </tr>
             </thead>
             <tbody>
               <tr className="border-t border-zinc-100 dark:border-zinc-800">
                 <td className="py-1.5">compare_add</td>
-                <td className="py-1.5 text-right tabular-nums">{adds}</td>
-                <td className="py-1.5 text-right tabular-nums">{sidsAdd}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(adds)}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(sidsAdd)}</td>
                 <td className="py-1.5 text-right tabular-nums">100%</td>
               </tr>
               <tr className="border-t border-zinc-100 dark:border-zinc-800">
                 <td className="py-1.5">compare_view</td>
-                <td className="py-1.5 text-right tabular-nums">{views}</td>
-                <td className="py-1.5 text-right tabular-nums">{sidsView}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(views)}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(sidsView)}</td>
                 <td className="py-1.5 text-right tabular-nums">{pct(sidsView, sidsAdd)}</td>
               </tr>
               <tr className="border-t border-zinc-100 dark:border-zinc-800">
                 <td className="py-1.5">compare_scroll</td>
-                <td className="py-1.5 text-right tabular-nums">{scrolls}</td>
-                <td className="py-1.5 text-right tabular-nums">{sidsScroll}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(scrolls)}</td>
+                <td className="py-1.5 text-right tabular-nums">{fmtNum(sidsScroll)}</td>
                 <td className="py-1.5 text-right tabular-nums">{pct(sidsScroll, sidsAdd)}</td>
               </tr>
             </tbody>
@@ -345,30 +498,30 @@ export default async function AnalyticsDashboardPage() {
 
         <Card title="Compare · hot lens combinations">
           <Table
-            rows={compareCombos.data}
+            rows={compareCombosRows}
             columns={[
-              { key: "slugs", label: "Slugs" },
-              { key: "n", label: "Views", align: "right" },
+              { key: "display", label: "Lenses", titleKey: "slugs" },
+              { key: "n", label: "Views", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Filters · most-used snapshots">
           <Table
-            rows={filterUsage.data}
+            rows={filterUsageRows}
             columns={[
-              { key: "filters", label: "Filters JSON" },
-              { key: "n", label: "Applies", align: "right" },
+              { key: "display", label: "Filters", titleKey: "filters" },
+              { key: "n", label: "Applies", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Detail · most-viewed lenses">
           <Table
-            rows={lensViews.data}
+            rows={lensViewsRows}
             columns={[
-              { key: "lens_slug", label: "Lens" },
-              { key: "n", label: "Views", align: "right" },
+              { key: "display", label: "Lens", titleKey: "lens_slug" },
+              { key: "n", label: "Views", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
@@ -387,35 +540,37 @@ export default async function AnalyticsDashboardPage() {
             rows={feedback.data}
             columns={[
               { key: "feedback_type", label: "Type" },
-              { key: "opens", label: "Opens", align: "right" },
-              { key: "submits", label: "Submits", align: "right" },
+              { key: "opens", label: "Opens", align: "right", widthClass: COUNT_WIDTH },
+              { key: "submits", label: "Submits", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Share · method breakdown">
           <Table
-            rows={share.data}
+            rows={shareRows}
             columns={[
-              { key: "method", label: "Method" },
-              { key: "n", label: "Count", align: "right" },
+              { key: "display", label: "Method", titleKey: "method" },
+              { key: "n", label: "Count", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Share · by source page × method">
           <Table
-            rows={shareBySource.data}
+            rows={shareBySourceRows}
             columns={[
               { key: "source_path", label: "Source path" },
-              { key: "method", label: "Method" },
-              { key: "n", label: "Count", align: "right" },
+              { key: "method_display", label: "Method", titleKey: "method" },
+              { key: "n", label: "Count", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Install · PWA accepts">
-          <p className="text-3xl font-bold tabular-nums">{installCount}</p>
+          <p className="font-heading text-3xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
+            {fmtNum(installCount)}
+          </p>
           <p className="mt-1 text-xs text-zinc-500">Accepted install prompts</p>
         </Card>
 
@@ -425,28 +580,28 @@ export default async function AnalyticsDashboardPage() {
             columns={[
               { key: "from_mount", label: "From" },
               { key: "to_mount", label: "To" },
-              { key: "n", label: "Switches", align: "right" },
+              { key: "n", label: "Switches", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Outbound · top destinations">
           <Table
-            rows={outbound.data}
+            rows={outboundRows}
             columns={[
-              { key: "href", label: "Href" },
-              { key: "n", label: "Clicks", align: "right" },
+              { key: "display", label: "Destination", titleKey: "href" },
+              { key: "n", label: "Clicks", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>
 
         <Card title="Outbound · by source page × destination">
           <Table
-            rows={outboundBySource.data}
+            rows={outboundBySourceRows}
             columns={[
               { key: "source_path", label: "Source path" },
-              { key: "href", label: "Destination" },
-              { key: "n", label: "Clicks", align: "right" },
+              { key: "href_display", label: "Destination", titleKey: "href" },
+              { key: "n", label: "Clicks", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />
         </Card>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,9 @@
 // Minimal layout for the admin section. No i18n, no nav — gated by
 // Cloudflare Access in production (see PR description for setup).
+// Shares the main site's font stack (Geist Sans + Source Serif 4) via
+// the exported fontClassName so admin looks of-a-piece with the product.
 
+import { fontClassName } from "../fonts";
 import "../globals.css";
 
 export const metadata = {
@@ -10,8 +13,8 @@ export const metadata = {
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50 antialiased">
+    <html lang="en" className={fontClassName}>
+      <body className="bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">
         {children}
       </body>
     </html>

--- a/src/lib/analytics-format.ts
+++ b/src/lib/analytics-format.ts
@@ -1,0 +1,116 @@
+// Server-only formatters used by the /admin/analytics dashboard to turn
+// the raw rows that come out of Analytics Engine into something a human
+// can actually scan. Keep these functions pure and synchronous so they
+// stay cheap to call inline in JSX cells.
+
+import { getAllLenses } from "@/lib/lens";
+import { lensDisplayName } from "@/lib/lens.format";
+
+// Lazy-built lookup: slug → "Brand Series Model". Resolved once per
+// server process (the analytics route is force-dynamic but the catalog
+// itself never changes between requests within a deploy).
+let lensNameCache: Map<string, string> | null = null;
+
+function lensNameMap(): Map<string, string> {
+  if (lensNameCache) {
+    return lensNameCache;
+  }
+  const map = new Map<string, string>();
+  for (const lens of getAllLenses("en")) {
+    const brandLabel = lens.brand.charAt(0).toUpperCase() + lens.brand.slice(1);
+    map.set(lens.id, lensDisplayName(brandLabel, lens.series, lens.model, lens.brand));
+  }
+  lensNameCache = map;
+  return map;
+}
+
+// Replace one slug with its display name; fall back to the slug if the
+// lens has been removed from the catalog (so the dashboard never breaks
+// on stale events).
+export function formatLensSlug(slug: string): string {
+  return lensNameMap().get(slug) ?? slug;
+}
+
+// Replace a comma-separated slug list (used by compare_view.lens_slugs)
+// with a comma-separated display-name list, suitable for a single cell
+// with `title` set to the original string.
+export function formatLensSlugList(joined: string): string {
+  if (!joined) {
+    return "";
+  }
+  return joined
+    .split(",")
+    .map((s) => formatLensSlug(s.trim()))
+    .join(" · ");
+}
+
+// Compact, human-readable summary of a filter_apply snapshot. Drops
+// any field that is null / empty array / empty string so that the
+// "interesting" parts of the filter stand out.
+//
+// Example input:
+//   {"brands":["sigma"],"typeFilter":"zoom","focusFilter":"auto",
+//    "specialtyTag":null,"focusMotorClass":null,"features":[],
+//    "focalCategories":["standard"]}
+// Becomes:
+//   "Brand: sigma · Zoom · AF · Focal: standard"
+export function formatFilterSnapshot(json: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return json;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return json;
+  }
+  const f = parsed as Record<string, unknown>;
+  const parts: string[] = [];
+
+  const brands = f.brands;
+  if (Array.isArray(brands) && brands.length > 0) {
+    parts.push(`Brand: ${brands.join(",")}`);
+  }
+  if (typeof f.typeFilter === "string" && f.typeFilter) {
+    parts.push(f.typeFilter === "prime" ? "Prime" : "Zoom");
+  }
+  if (typeof f.focusFilter === "string" && f.focusFilter) {
+    parts.push(f.focusFilter === "auto" ? "AF" : "MF");
+  }
+  if (typeof f.specialtyTag === "string" && f.specialtyTag) {
+    parts.push(`Specialty: ${f.specialtyTag}`);
+  }
+  if (typeof f.focusMotorClass === "string" && f.focusMotorClass) {
+    parts.push(`Motor: ${f.focusMotorClass}`);
+  }
+  const features = f.features;
+  if (Array.isArray(features) && features.length > 0) {
+    parts.push(`Features: ${features.join(",")}`);
+  }
+  const focal = f.focalCategories;
+  if (Array.isArray(focal) && focal.length > 0) {
+    parts.push(`Focal: ${focal.join(",")}`);
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : "(no filters)";
+}
+
+// Strip protocol + trailing slash from a URL for compact display.
+// Keeps host + path so it still uniquely identifies the destination.
+export function formatHref(href: string): string {
+  return href
+    .replace(/^https?:\/\//, "")
+    .replace(/\/$/, "");
+}
+
+// Compact share method labels for the dashboard.
+const SHARE_METHOD_LABELS: Record<string, string> = {
+  copy_link: "Copy link",
+  native: "Native share",
+  poster_download: "Poster download",
+  poster_share: "Poster share",
+};
+
+export function formatShareMethod(method: string): string {
+  return SHARE_METHOD_LABELS[method] ?? method;
+}


### PR DESCRIPTION
## Summary

Visual polish on the existing /admin/analytics dashboard + three new high-ROI panels.

### Visual polish (P0)

- **Adopt main-site fonts** — Geist Sans body + Source Serif 4 headings, applied via the existing \`fontClassName\` helper, so /admin/* feels of-a-piece with the product.
- **Map lens slugs to display names** — Compare combos and Detail most-viewed panels now show "Fujifilm XF 100-400mm F4.5-5.6 R LM OIS WR" instead of \`fujifilm-xf-100-400mmf45-56-r-lm-ois-wr-x\`. Raw slug preserved as the cell \`title\` for hover.
- **Pretty-print filter snapshots** — \`{"brands":[],"typeFilter":"zoom",...}\` becomes "Zoom · AF · Focal: standard". JSON noise (nulls, empty arrays) is dropped.
- **Constrain numeric columns** — \`w-20\` + \`table-fixed\` so 1–2 digit counts don't take half the row width.
- **Truncate + tooltip** — long primary strings truncate cleanly with the original value on \`title\` hover.
- **Drop implementation-leak in subtitle** — "Counts are sampling-corrected via \`SUM(_sample_interval)\`" becomes "Last 30 days · numbers adjusted for sampling".

### New panels

| Panel | What it answers | Why now |
|---|---|---|
| **Overview stats bar** (Events / Sessions / Unique queries / Unique lenses viewed) | "What's the overall scale of usage?" | At-a-glance scale; first thing to see when opening the dashboard |
| **Locale · split** | "How does zh vs en behavior differ?" | Drives i18n prioritization decisions |
| **Detail · referrer sources** | "Where do detail-page visits come from?" | Uses the \`lens_view.referrer\` field that was already captured but never surfaced |

All new SQL queries are 30-day window, no schema changes, no write-side changes.

## Files

- \`src/app/admin/layout.tsx\` — apply \`fontClassName\`
- \`src/app/admin/analytics/page.tsx\` — new queries, polished Table, new Stat component, formatter wiring
- \`src/lib/analytics-format.ts\` (new) — \`formatLensSlug\` / \`formatLensSlugList\` / \`formatFilterSnapshot\` / \`formatHref\` / \`formatShareMethod\` helpers

## Verification

- \`npx tsc --noEmit\` — clean
- \`npx eslint\` on changed files — no new errors
- \`npm run build\` — passes; 353 static routes preserved
- Local \`next start\` on port 3001 → "Analytics not configured" placeholder renders with new fonts ✓ (data state can't be verified locally without AE bindings; will appear on prod after merge)

## Test plan

- [ ] Open \`/admin/analytics\` post-merge — header uses Source Serif 4, body uses Geist Sans
- [ ] Top stats bar shows non-zero numbers for Events / Sessions / etc.
- [ ] "Compare · hot lens combinations" shows readable lens names with hover-to-see slug
- [ ] "Filters · most-used snapshots" shows compact summary (no raw JSON)
- [ ] "Locale · split" shows en + zh rows
- [ ] "Detail · referrer sources" shows referrer URLs (will populate as users arrive from external sources)
- [ ] All numeric columns sit in their narrow right-aligned slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)