### PR TITLE
feat(seo): wording refinements + Product schema / SSR h1 / OG images

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import AboutContent from "@/components/AboutContent";
 import BackToTopButton from "@/components/BackToTopButton";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, defaultOgImages } from "@/lib/seo";
 
 type Params = Promise<{ locale: string }>;
 
@@ -18,7 +18,11 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title: `${title} | X-Glass`, description },
+    openGraph: {
+      title: `${title} | X-Glass`,
+      description,
+      images: defaultOgImages(),
+    },
     alternates: buildAlternates(locale, "about"),
   };
 }

--- a/src/app/[locale]/get/page.tsx
+++ b/src/app/[locale]/get/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import InstallPage from "@/components/InstallPage";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, defaultOgImages } from "@/lib/seo";
 
 type Params = Promise<{ locale: string }>;
 
@@ -17,7 +17,11 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title: `${title} | X-Glass`, description },
+    openGraph: {
+      title: `${title} | X-Glass`,
+      description,
+      images: defaultOgImages(),
+    },
     alternates: buildAlternates(locale, "get"),
   };
 }
@@ -25,5 +29,15 @@ export async function generateMetadata({
 export default async function GetPage({ params }: { params: Params }) {
   const { locale } = await params;
   setRequestLocale(locale);
-  return <InstallPage />;
+  const t = await getTranslations({ locale, namespace: "Install" });
+  return (
+    <>
+      {/* Server-rendered h1 so search engines see a page heading without
+          waiting for the client-only InstallPage to hydrate. The platform-
+          specific titles inside InstallPage are h2 by convention since this
+          h1 already names the page. */}
+      <h1 className="sr-only">{t("pageTitle")}</h1>
+      <InstallPage />
+    </>
+  );
 }

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -21,10 +21,10 @@ import Breadcrumb from "@/components/Breadcrumb";
 import { ACTION_OUTLINE_CLS } from "@/lib/ui-tokens";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, lensOgImages } from "@/lib/seo";
+import { SITE } from "@/config/site";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 import {
-  lensSubtitleLine,
   lensDisplayName,
   weightDisplay,
   mfdHeroValue,
@@ -33,6 +33,56 @@ import { SPEC_NA } from "@/lib/types";
 import { PriceSection } from "@/components/PriceSection";
 
 type Params = Promise<{ locale: string; mount: string; id: string }>;
+
+type Lens = ReturnType<typeof getLensesByMount>[number];
+
+// Shared description builder so generateMetadata and the page body both emit
+// the exact same text (one feeds the SERP, the other feeds the JSON-LD).
+// Clauses are intentionally limited to facts the model name does NOT already
+// carry — see PR #210 for the rationale.
+function buildLensDescription(args: {
+  lens: Lens;
+  displayName: string;
+  mountLabel: string;
+  typeLabel: string;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}): string {
+  const { lens, displayName, mountLabel, typeLabel, t } = args;
+  const clauses: string[] = [];
+  const weight = weightDisplay(lens.weightG, "g");
+  if (weight) {
+    clauses.push(t("metaWeight", { value: weight }));
+  }
+  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
+    clauses.push(t("metaFilter", { size: lens.filterMm }));
+  }
+  const mfd = mfdHeroValue(lens.minFocusDistance);
+  if (mfd) {
+    clauses.push(t("metaMfd", { value: mfd }));
+  }
+  if (lens.maxMagnification?.value !== undefined) {
+    clauses.push(t("metaMag", { value: lens.maxMagnification.value }));
+  }
+  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
+    clauses.push(t("metaMotor", { label: lens.focusMotor }));
+  }
+  if (lens.wr === true) {
+    clauses.push(t("metaWr"));
+  } else if (lens.wr === "partial") {
+    clauses.push(t("metaWrPartial"));
+  }
+  if (lens.ois) {
+    clauses.push(t("metaOis"));
+  }
+  if (!lens.af) {
+    clauses.push(t("metaMf"));
+  }
+  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
+  if (clauses.length > 0) {
+    description += t("metaJoinSpace") + clauses.join(t("metaSep")) + t("metaPeriod");
+  }
+  return description;
+}
 
 // Pre-render every (locale × mount × lens id) combination at build time so the
 // detail page is served as a static HTML asset with zero per-request CPU cost.
@@ -68,50 +118,75 @@ export async function generateMetadata({
   const mountLabel = resolvedMount === "X" ? "X" : "GFX";
   const isPrime = lens.focalLengthMin === lens.focalLengthMax;
   const typeLabel = isPrime ? t("metaPrime") : t("metaZoom");
-
-  // Build the description from clauses the model name does NOT already contain.
-  // Focal length and max aperture are intentionally omitted — they're already
-  // in the brand+model display name (e.g. "XF 35mm F1.4 R").
-  const clauses: string[] = [];
-  const weight = weightDisplay(lens.weightG, "g");
-  if (weight) {
-    clauses.push(t("metaWeight", { value: weight }));
-  }
-  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
-    clauses.push(t("metaFilter", { size: lens.filterMm }));
-  }
-  const mfd = mfdHeroValue(lens.minFocusDistance);
-  if (mfd) {
-    clauses.push(t("metaMfd", { value: mfd }));
-  }
-  if (lens.maxMagnification?.value !== undefined) {
-    clauses.push(t("metaMag", { value: lens.maxMagnification.value }));
-  }
-  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
-    clauses.push(t("metaMotor", { label: lens.focusMotor }));
-  }
-  if (lens.wr === true) {
-    clauses.push(t("metaWr"));
-  } else if (lens.wr === "partial") {
-    clauses.push(t("metaWrPartial"));
-  }
-  if (lens.ois) {
-    clauses.push(t("metaOis"));
-  }
-  if (!lens.af) {
-    clauses.push(t("metaMf"));
-  }
-
-  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
-  if (clauses.length > 0) {
-    description += t("metaJoinSpace") + clauses.join(t("metaSep")) + t("metaPeriod");
-  }
+  const description = buildLensDescription({ lens, displayName, mountLabel, typeLabel, t });
 
   return {
     title: displayName,
     description,
-    openGraph: { title: `${displayName} | X-Glass`, description },
+    openGraph: {
+      title: `${displayName} | X-Glass`,
+      description,
+      images: lensOgImages(lens.id),
+    },
     alternates: buildAlternates(locale, `lenses/${mount}/${id}`),
+  };
+}
+
+/**
+ * Build the Product JSON-LD payload for a lens. Emitted alongside the page so
+ * Google can render Product rich snippets (Search Console reports five
+ * impressions already landing on the snippet treatment with the previous
+ * incomplete schema — completing it should grow that share).
+ *
+ * Offers are intentionally omitted: pricing in the catalog is informational,
+ * not authoritative, and an outdated `Offer` block would let Google show
+ * stale prices in the SERP.
+ */
+function lensProductJsonLd(args: {
+  lens: ReturnType<typeof getLensesByMount>[number];
+  displayName: string;
+  description: string;
+  brandName: string;
+  mountLabel: string;
+  canonicalUrl: string;
+}) {
+  const { lens, displayName, description, brandName, mountLabel, canonicalUrl } = args;
+  const props: Array<{ "@type": "PropertyValue"; name: string; value: string | number; unitText?: string }> = [];
+  const focalRange = lens.focalLengthMin === lens.focalLengthMax
+    ? `${lens.focalLengthMin}mm`
+    : `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
+  props.push({ "@type": "PropertyValue", name: "Focal length", value: focalRange });
+  if (lens.maxAperture !== undefined) {
+    const ap = Array.isArray(lens.maxAperture)
+      ? `f/${lens.maxAperture[0]}-${lens.maxAperture[1]}`
+      : `f/${lens.maxAperture}`;
+    props.push({ "@type": "PropertyValue", name: "Max aperture", value: ap });
+  }
+  props.push({ "@type": "PropertyValue", name: "Mount", value: `Fujifilm ${mountLabel}` });
+  if (lens.weightG !== undefined && !Array.isArray(lens.weightG)) {
+    props.push({ "@type": "PropertyValue", name: "Weight", value: lens.weightG, unitText: "g" });
+  }
+  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
+    props.push({ "@type": "PropertyValue", name: "Filter thread", value: lens.filterMm, unitText: "mm" });
+  }
+  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
+    props.push({ "@type": "PropertyValue", name: "Focus motor", value: lens.focusMotor });
+  }
+  if (lens.ois) {
+    props.push({ "@type": "PropertyValue", name: "Optical stabilization", value: "Yes" });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: displayName,
+    description,
+    brand: { "@type": "Brand", name: brandName },
+    image: `${SITE.url}/lenses/${lens.id}.webp`,
+    category: "Camera Lens",
+    sku: lens.id,
+    url: canonicalUrl,
+    additionalProperty: props,
   };
 }
 
@@ -182,7 +257,8 @@ function renderRowValue(
 export default async function LensDetailPage({ params }: { params: Params }) {
   const { id, locale, mount } = await params;
   setRequestLocale(locale);
-  const lenses = getLensesByMount(urlSegmentToMount(mount) ?? "X", locale);
+  const resolvedMount = urlSegmentToMount(mount) ?? "X";
+  const lenses = getLensesByMount(resolvedMount, locale);
   const lens = lenses.find((l) => l.id === id);
 
   if (!lens) {
@@ -193,6 +269,23 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   const tBrand = await getTranslations("Brands");
   const tPricing = await getTranslations("Pricing");
   const url = getLensUrl(lens, locale);
+
+  // Derived values shared between the visible header and the Product JSON-LD.
+  const brandName = tBrand(lens.brand);
+  const displayName = lensDisplayName(brandName, lens.series, lens.model, lens.brand);
+  const mountLabel = resolvedMount === "X" ? "X" : "GFX";
+  const isPrime = lens.focalLengthMin === lens.focalLengthMax;
+  const typeLabel = isPrime ? t("metaPrime") : t("metaZoom");
+  const description = buildLensDescription({ lens, displayName, mountLabel, typeLabel, t });
+  const canonicalUrl = `${SITE.url}/${locale}/lenses/${mount}/${id}`;
+  const productSchema = lensProductJsonLd({
+    lens,
+    displayName,
+    description,
+    brandName,
+    mountLabel,
+    canonicalUrl,
+  });
 
   const specGroups = buildSpecGroups({
     groupOptics: t("groupOptics"),
@@ -293,6 +386,15 @@ export default async function LensDetailPage({ params }: { params: Params }) {
 
   return (
     <>
+    {/* Product structured data — earns this page eligibility for Google's
+        Product rich result treatment. Emitted as a JSON-LD script tag inside
+        the page body (acceptable per schema.org guidance) so it ships in the
+        SSR HTML alongside the rest of the page. */}
+    <script
+      type="application/ld+json"
+      // JSON.stringify is safe — no user-controlled fields are included.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(productSchema) }}
+    />
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
       <Breadcrumb />
       {/* Header: image + key info side by side */}
@@ -322,13 +424,13 @@ export default async function LensDetailPage({ params }: { params: Params }) {
             (small desktop / portrait tablet), avoiding the 4-button row
             wrapping into 2 rows. */}
         <div className="@container flex-1 flex flex-col gap-5">
-          {/* Title */}
+          {/* Title — h1 carries the full display name (brand + optional
+              series + model) so brand-and-model search queries match the
+              page's primary heading. The previous subtitle line above the h1
+              was just the brand+series prefix and is now redundant. */}
           <div>
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              {lensSubtitleLine(tBrand(lens.brand), lens.series)}
-            </p>
-            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 mt-1 font-heading">
-              {lens.model}
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 font-heading">
+              {displayName}
             </h1>
           </div>
 

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -26,9 +26,8 @@ import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
 import {
   lensSubtitleLine,
   lensDisplayName,
-  focalRangeDisplay,
-  primaryApertureDisplay,
   weightDisplay,
+  mfdHeroValue,
 } from "@/lib/lens.format";
 import { SPEC_NA } from "@/lib/types";
 import { PriceSection } from "@/components/PriceSection";
@@ -70,22 +69,43 @@ export async function generateMetadata({
   const isPrime = lens.focalLengthMin === lens.focalLengthMax;
   const typeLabel = isPrime ? t("metaPrime") : t("metaZoom");
 
-  const focal = focalRangeDisplay(lens.focalLengthMin, lens.focalLengthMax);
-  const aperture = primaryApertureDisplay(lens) ?? "—";
-  const weight = weightDisplay(lens.weightG, "g") ?? "—";
-
-  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
-  description += t("metaDescSpecs", { focal, aperture, weight });
+  // Build the description from clauses the model name does NOT already contain.
+  // Focal length and max aperture are intentionally omitted — they're already
+  // in the brand+model display name (e.g. "XF 35mm F1.4 R").
+  const clauses: string[] = [];
+  const weight = weightDisplay(lens.weightG, "g");
+  if (weight) {
+    clauses.push(t("metaWeight", { value: weight }));
+  }
   if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
-    description += t("metaDescFilter", { size: lens.filterMm });
+    clauses.push(t("metaFilter", { size: lens.filterMm }));
+  }
+  const mfd = mfdHeroValue(lens.minFocusDistance);
+  if (mfd) {
+    clauses.push(t("metaMfd", { value: mfd }));
+  }
+  if (lens.maxMagnification?.value !== undefined) {
+    clauses.push(t("metaMag", { value: lens.maxMagnification.value }));
+  }
+  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
+    clauses.push(t("metaMotor", { label: lens.focusMotor }));
+  }
+  if (lens.wr === true) {
+    clauses.push(t("metaWr"));
+  } else if (lens.wr === "partial") {
+    clauses.push(t("metaWrPartial"));
   }
   if (lens.ois) {
-    description += t("metaDescOis");
+    clauses.push(t("metaOis"));
   }
   if (!lens.af) {
-    description += t("metaDescMf");
+    clauses.push(t("metaMf"));
   }
-  description += t("metaDescPeriod");
+
+  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
+  if (clauses.length > 0) {
+    description += t("metaJoinSpace") + clauses.join(t("metaSep")) + t("metaPeriod");
+  }
 
   return {
     title: displayName,

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -17,6 +17,7 @@ import LensDetailTelemetry from "@/components/telemetry/LensDetailTelemetry";
 import ShareFAB from "@/components/ShareFAB";
 import { ShareButton } from "@/components/share/ShareButton";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
+import JsonLd from "@/components/JsonLd";
 import Breadcrumb from "@/components/Breadcrumb";
 import { ACTION_OUTLINE_CLS } from "@/lib/ui-tokens";
 import { BoolCell } from "@/components/ui/bool-cell";
@@ -24,65 +25,11 @@ import { FieldNotePopover } from "@/components/ui/field-note-popover";
 import { buildAlternates, lensOgImages } from "@/lib/seo";
 import { SITE } from "@/config/site";
 import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
-import {
-  lensDisplayName,
-  weightDisplay,
-  mfdHeroValue,
-} from "@/lib/lens.format";
-import { SPEC_NA } from "@/lib/types";
+import { lensDisplayName } from "@/lib/lens.format";
+import { buildLensDescription, buildLensProductSchema } from "@/lib/lens-seo";
 import { PriceSection } from "@/components/PriceSection";
 
 type Params = Promise<{ locale: string; mount: string; id: string }>;
-
-type Lens = ReturnType<typeof getLensesByMount>[number];
-
-// Shared description builder so generateMetadata and the page body both emit
-// the exact same text (one feeds the SERP, the other feeds the JSON-LD).
-// Clauses are intentionally limited to facts the model name does NOT already
-// carry — see PR #210 for the rationale.
-function buildLensDescription(args: {
-  lens: Lens;
-  displayName: string;
-  mountLabel: string;
-  typeLabel: string;
-  t: (key: string, values?: Record<string, string | number>) => string;
-}): string {
-  const { lens, displayName, mountLabel, typeLabel, t } = args;
-  const clauses: string[] = [];
-  const weight = weightDisplay(lens.weightG, "g");
-  if (weight) {
-    clauses.push(t("metaWeight", { value: weight }));
-  }
-  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
-    clauses.push(t("metaFilter", { size: lens.filterMm }));
-  }
-  const mfd = mfdHeroValue(lens.minFocusDistance);
-  if (mfd) {
-    clauses.push(t("metaMfd", { value: mfd }));
-  }
-  if (lens.maxMagnification?.value !== undefined) {
-    clauses.push(t("metaMag", { value: lens.maxMagnification.value }));
-  }
-  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
-    clauses.push(t("metaMotor", { label: lens.focusMotor }));
-  }
-  if (lens.wr === true) {
-    clauses.push(t("metaWr"));
-  } else if (lens.wr === "partial") {
-    clauses.push(t("metaWrPartial"));
-  }
-  if (lens.ois) {
-    clauses.push(t("metaOis"));
-  }
-  if (!lens.af) {
-    clauses.push(t("metaMf"));
-  }
-  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
-  if (clauses.length > 0) {
-    description += t("metaJoinSpace") + clauses.join(t("metaSep")) + t("metaPeriod");
-  }
-  return description;
-}
 
 // Pre-render every (locale × mount × lens id) combination at build time so the
 // detail page is served as a static HTML asset with zero per-request CPU cost.
@@ -123,10 +70,7 @@ export async function generateMetadata({
 
   const brandName = tBrand(lens.brand);
   const displayName = lensDisplayName(brandName, lens.series, lens.model, lens.brand);
-  const mountLabel = resolvedMount === "X" ? "X" : "GFX";
-  const isPrime = lens.focalLengthMin === lens.focalLengthMax;
-  const typeLabel = isPrime ? t("metaPrime") : t("metaZoom");
-  const description = buildLensDescription({ lens, displayName, mountLabel, typeLabel, t });
+  const description = buildLensDescription({ lens, mount: resolvedMount, brandName, t });
 
   return {
     title: displayName,
@@ -137,64 +81,6 @@ export async function generateMetadata({
       images: lensOgImages(lens.id),
     },
     alternates: buildAlternates(locale, `lenses/${mount}/${id}`),
-  };
-}
-
-/**
- * Build the Product JSON-LD payload for a lens. Emitted alongside the page so
- * Google can render Product rich snippets (Search Console reports five
- * impressions already landing on the snippet treatment with the previous
- * incomplete schema — completing it should grow that share).
- *
- * Offers are intentionally omitted: pricing in the catalog is informational,
- * not authoritative, and an outdated `Offer` block would let Google show
- * stale prices in the SERP.
- */
-function lensProductJsonLd(args: {
-  lens: ReturnType<typeof getLensesByMount>[number];
-  displayName: string;
-  description: string;
-  brandName: string;
-  mountLabel: string;
-  canonicalUrl: string;
-}) {
-  const { lens, displayName, description, brandName, mountLabel, canonicalUrl } = args;
-  const props: Array<{ "@type": "PropertyValue"; name: string; value: string | number; unitText?: string }> = [];
-  const focalRange = lens.focalLengthMin === lens.focalLengthMax
-    ? `${lens.focalLengthMin}mm`
-    : `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
-  props.push({ "@type": "PropertyValue", name: "Focal length", value: focalRange });
-  if (lens.maxAperture !== undefined) {
-    const ap = Array.isArray(lens.maxAperture)
-      ? `f/${lens.maxAperture[0]}-${lens.maxAperture[1]}`
-      : `f/${lens.maxAperture}`;
-    props.push({ "@type": "PropertyValue", name: "Max aperture", value: ap });
-  }
-  props.push({ "@type": "PropertyValue", name: "Mount", value: `Fujifilm ${mountLabel}` });
-  if (lens.weightG !== undefined && !Array.isArray(lens.weightG)) {
-    props.push({ "@type": "PropertyValue", name: "Weight", value: lens.weightG, unitText: "g" });
-  }
-  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
-    props.push({ "@type": "PropertyValue", name: "Filter thread", value: lens.filterMm, unitText: "mm" });
-  }
-  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
-    props.push({ "@type": "PropertyValue", name: "Focus motor", value: lens.focusMotor });
-  }
-  if (lens.ois) {
-    props.push({ "@type": "PropertyValue", name: "Optical stabilization", value: "Yes" });
-  }
-
-  return {
-    "@context": "https://schema.org",
-    "@type": "Product",
-    name: displayName,
-    description,
-    brand: { "@type": "Brand", name: brandName },
-    image: `${SITE.url}/lenses/${lens.id}.webp`,
-    category: "Camera Lens",
-    sku: lens.id,
-    url: canonicalUrl,
-    additionalProperty: props,
   };
 }
 
@@ -287,17 +173,14 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   // Derived values shared between the visible header and the Product JSON-LD.
   const brandName = tBrand(lens.brand);
   const displayName = lensDisplayName(brandName, lens.series, lens.model, lens.brand);
-  const mountLabel = resolvedMount === "X" ? "X" : "GFX";
-  const isPrime = lens.focalLengthMin === lens.focalLengthMax;
-  const typeLabel = isPrime ? t("metaPrime") : t("metaZoom");
-  const description = buildLensDescription({ lens, displayName, mountLabel, typeLabel, t });
+  const description = buildLensDescription({ lens, mount: resolvedMount, brandName, t });
   const canonicalUrl = `${SITE.url}/${locale}/lenses/${mount}/${id}`;
-  const productSchema = lensProductJsonLd({
+  const productSchema = buildLensProductSchema({
     lens,
+    mount: resolvedMount,
     displayName,
     description,
     brandName,
-    mountLabel,
     canonicalUrl,
   });
 
@@ -401,14 +284,9 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   return (
     <>
     {/* Product structured data — earns this page eligibility for Google's
-        Product rich result treatment. Emitted as a JSON-LD script tag inside
-        the page body (acceptable per schema.org guidance) so it ships in the
-        SSR HTML alongside the rest of the page. */}
-    <script
-      type="application/ld+json"
-      // JSON.stringify is safe — no user-controlled fields are included.
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(productSchema) }}
-    />
+        Product rich result treatment. Emitted via JsonLd which handles the
+        `</script>` defensive escape; see that component for rationale. */}
+    <JsonLd data={productSchema} />
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-8">
       <Breadcrumb />
       {/* Header: image + key info side by side */}

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -104,9 +104,17 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { locale, mount, id } = await params;
-  const resolvedMount = urlSegmentToMount(mount) ?? "X";
   const t = await getTranslations({ locale, namespace: "LensDetail" });
   const tBrand = await getTranslations({ locale, namespace: "Brands" });
+  // The [mount]/layout.tsx ahead of this page already calls notFound() on an
+  // invalid mount segment, so urlSegmentToMount is guaranteed to return a
+  // valid Mount here. Re-check defensively in case the layout contract is
+  // ever weakened — silently treating an unknown mount as "X" would mis-route
+  // lens lookups and is far worse than a 404.
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount) {
+    return { title: t("notFoundTitle") };
+  }
   const lenses = getLensesByMount(resolvedMount, locale);
   const lens = lenses.find((l) => l.id === id);
   if (!lens) {
@@ -257,7 +265,13 @@ function renderRowValue(
 export default async function LensDetailPage({ params }: { params: Params }) {
   const { id, locale, mount } = await params;
   setRequestLocale(locale);
-  const resolvedMount = urlSegmentToMount(mount) ?? "X";
+  // See note on the matching guard in generateMetadata — the parent layout
+  // already validates mount, but we re-check rather than silently fall back
+  // to "X" and mis-route the lens lookup.
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount) {
+    notFound();
+  }
   const lenses = getLensesByMount(resolvedMount, locale);
   const lens = lenses.find((l) => l.id === id);
 

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -5,7 +5,7 @@ import { getLensesByMount } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
 import LensesLoading from "./loading";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { notFound } from "next/navigation";
 
 type Params = Promise<{ locale: string; mount: string }>;
@@ -37,7 +37,11 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title: `${title} | X-Glass`, description },
+    openGraph: {
+      title: `${title} | X-Glass`,
+      description,
+      images: defaultOgImages(),
+    },
     alternates: buildAlternates(locale, `lenses/${mount}`),
   };
 }
@@ -50,10 +54,20 @@ export default async function LensesPage({ params }: { params: Params }) {
     notFound();
   }
   const lenses = getLensesByMount(resolvedMount, locale);
+  const t = await getTranslations({ locale, namespace: "LensList" });
+  const h1Title = resolvedMount === "X" ? t("metaTitleX") : t("metaTitleG");
 
   return (
-    <Suspense fallback={<LensesLoading />}>
-      <LensListClient lenses={lenses} />
-    </Suspense>
+    <>
+      {/* Server-rendered h1 so the static HTML carries a heading even when the
+          Suspense fallback (loading.tsx skeleton) is what Next.js pre-renders
+          for the initial response. LensListClient's own visible heading is
+          rendered client-side after hydration; this sr-only h1 is the SEO
+          anchor. */}
+      <h1 className="sr-only">{h1Title}</h1>
+      <Suspense fallback={<LensesLoading />}>
+        <LensListClient lenses={lenses} />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -9,7 +9,7 @@ import CompareTelemetry from "@/components/telemetry/CompareTelemetry";
 import CuratedComparisons from "@/components/CuratedComparisons";
 import BackToTopButton from "@/components/BackToTopButton";
 import Breadcrumb from "@/components/Breadcrumb";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { lensDisplayName } from "@/lib/lens.format";
 import { notFound } from "next/navigation";
 
@@ -55,7 +55,11 @@ export async function generateMetadata({
     return {
       title,
       description: emptyDescription,
-      openGraph: { title: `${title} | X-Glass`, description: emptyDescription },
+      openGraph: {
+        title: `${title} | X-Glass`,
+        description: emptyDescription,
+        images: defaultOgImages(),
+      },
       alternates,
     };
   }
@@ -64,7 +68,11 @@ export async function generateMetadata({
     return {
       title: emptyTitle,
       description: emptyDescription,
-      openGraph: { title: `${emptyTitle} | X-Glass`, description: emptyDescription },
+      openGraph: {
+        title: `${emptyTitle} | X-Glass`,
+        description: emptyDescription,
+        images: defaultOgImages(),
+      },
       alternates,
     };
   }
@@ -76,7 +84,11 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title: `${title} | X-Glass`, description },
+    openGraph: {
+      title: `${title} | X-Glass`,
+      description,
+      images: defaultOgImages(),
+    },
     alternates,
   };
 }

--- a/src/components/InstallPage.tsx
+++ b/src/components/InstallPage.tsx
@@ -103,9 +103,9 @@ export default function InstallPage() {
 
       {platform === "installed" && (
         <div className="max-w-xs">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("installedTitle")}
-          </h1>
+          </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("installedBody")}</p>
           <Link
             href="/lenses/x"
@@ -118,9 +118,9 @@ export default function InstallPage() {
 
       {platform === "prompt" && (
         <div className="max-w-xs">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("promptTitle")}
-          </h1>
+          </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("promptBody")}</p>
           <button
             onClick={handleInstall}
@@ -133,9 +133,9 @@ export default function InstallPage() {
 
       {platform === "ios" && (
         <div className="max-w-xs w-full">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("iosTitle")}
-          </h1>
+          </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("iosSubtitle")}</p>
           <ol className="mt-6 space-y-3 text-left">
             {IOS_STEPS.map((key, i) => (
@@ -155,9 +155,9 @@ export default function InstallPage() {
 
       {platform === "macos-safari" && (
         <div className="max-w-xs w-full">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("macosTitle")}
-          </h1>
+          </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("macosSubtitle")}</p>
           <ol className="mt-6 space-y-3 text-left">
             {MACOS_STEPS.map((key, i) => (
@@ -177,9 +177,9 @@ export default function InstallPage() {
 
       {platform === "generic" && (
         <div className="max-w-xs">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-800 dark:text-zinc-50">
             {t("genericTitle")}
-          </h1>
+          </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("genericBody")}</p>
         </div>
       )}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,27 @@
+/**
+ * Server component that emits a schema.org JSON-LD block as a `<script
+ * type="application/ld+json">` tag. Encapsulates two concerns the call site
+ * shouldn't have to know about:
+ *
+ * 1. `dangerouslySetInnerHTML` is required because React entity-escapes text
+ *    children, which would break the JSON when rendered inside script-data
+ *    content model (browser doesn't decode entities there).
+ *
+ * 2. Defensive escape of `<` to `<` (valid JSON, same parsed value)
+ *    prevents a `</script>` substring inside any JSON string value from
+ *    prematurely closing the script tag. Browsers tokenize raw bytes when
+ *    parsing script-data content — they don't care that the sequence sits
+ *    inside a JSON string literal.
+ *
+ * Both call sites (SiteJsonLd, lens detail Product schema) go through this
+ * component so the escape stays consistent.
+ */
+export default function JsonLd({ data }: { data: object }) {
+  const safe = JSON.stringify(data).replace(/</g, "\\u003c");
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: safe }}
+    />
+  );
+}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -94,9 +94,9 @@ export default function LensListClient({ lenses }: Props) {
       <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 pt-4 sm:pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+            <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
               {t("title")}
-            </h1>
+            </h2>
             <LensSearchDialog triggerVariant="icon" />
           </div>
           <LensFilters

--- a/src/components/SiteJsonLd.tsx
+++ b/src/components/SiteJsonLd.tsx
@@ -1,5 +1,6 @@
 import { SITE } from "@/config/site";
 import { routing } from "@/i18n/routing";
+import JsonLd from "@/components/JsonLd";
 
 const ORG_ID = `${SITE.url}/#organization`;
 const SITE_ID = `${SITE.url}/#website`;
@@ -43,12 +44,5 @@ export default function SiteJsonLd({ locale }: { locale: string }) {
     },
   ];
 
-  const json = JSON.stringify({ "@context": "https://schema.org", "@graph": graph });
-
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: json }}
-    />
-  );
+  return <JsonLd data={{ "@context": "https://schema.org", "@graph": graph }} />;
 }

--- a/src/lib/lens-seo.ts
+++ b/src/lib/lens-seo.ts
@@ -1,0 +1,141 @@
+import { SITE } from "@/config/site";
+import { SPEC_NA } from "@/lib/types";
+import type { Lens, Mount } from "@/lib/types";
+import { mountSeoLabel } from "@/lib/mount";
+import { isZoom } from "@/lib/lens";
+import {
+  lensDisplayName,
+  weightDisplay,
+  mfdHeroValue,
+} from "@/lib/lens.format";
+
+// Translator signature compatible with next-intl's `getTranslations(...)` return
+// type. Helpers here accept the resolved `t` function rather than calling
+// getTranslations themselves so callers control await timing and namespace.
+type T = (key: string, values?: Record<string, string | number>) => string;
+
+/**
+ * Build the meta description string for a lens detail page.
+ *
+ * Clauses are intentionally limited to facts the brand-and-model display name
+ * does NOT already carry — focal length and max aperture are usually already
+ * in the model (e.g. "XF 35mm F1.4 R"), so repeating them in the description
+ * is keyword-stuffing with no information gain. We surface weight, filter
+ * thread, MFD, max magnification, focus motor label, weather sealing, OIS,
+ * and MF — each conditional on data presence.
+ */
+export function buildLensDescription(args: {
+  lens: Lens;
+  mount: Mount;
+  brandName: string;
+  t: T;
+}): string {
+  const { lens, mount, brandName, t } = args;
+  const displayName = lensDisplayName(brandName, lens.series, lens.model, lens.brand);
+  const mountLabel = mountSeoLabel(mount);
+  const typeLabel = isZoom(lens) ? t("metaZoom") : t("metaPrime");
+
+  const clauses: string[] = [];
+  const weight = weightDisplay(lens.weightG, "g");
+  if (weight) {
+    clauses.push(t("metaWeight", { value: weight }));
+  }
+  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
+    clauses.push(t("metaFilter", { size: lens.filterMm }));
+  }
+  const mfd = mfdHeroValue(lens.minFocusDistance);
+  if (mfd) {
+    clauses.push(t("metaMfd", { value: mfd }));
+  }
+  if (lens.maxMagnification?.value !== undefined) {
+    clauses.push(t("metaMag", { value: lens.maxMagnification.value }));
+  }
+  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
+    clauses.push(t("metaMotor", { label: lens.focusMotor }));
+  }
+  if (lens.wr === true) {
+    clauses.push(t("metaWr"));
+  } else if (lens.wr === "partial") {
+    clauses.push(t("metaWrPartial"));
+  }
+  if (lens.ois) {
+    clauses.push(t("metaOis"));
+  }
+  if (!lens.af) {
+    clauses.push(t("metaMf"));
+  }
+
+  let description = t("metaDescPrefix", { name: displayName, mount: mountLabel, type: typeLabel });
+  if (clauses.length > 0) {
+    description += t("metaJoinSpace") + clauses.join(t("metaSep")) + t("metaPeriod");
+  }
+  return description;
+}
+
+type PropertyValue = {
+  "@type": "PropertyValue";
+  name: string;
+  value: string | number;
+  unitText?: string;
+};
+
+/**
+ * Build the schema.org Product JSON-LD payload for a lens.
+ *
+ * `Product` is the standard schema.org type for any catalogued item (sale not
+ * required — see schema.org examples for non-commercial product descriptions).
+ * Offers are intentionally omitted: catalog prices in this DB are informational
+ * not authoritative, and surfacing a stale Offer in the SERP would mislead.
+ */
+export function buildLensProductSchema(args: {
+  lens: Lens;
+  mount: Mount;
+  displayName: string;
+  description: string;
+  brandName: string;
+  canonicalUrl: string;
+}) {
+  const { lens, mount, displayName, description, brandName, canonicalUrl } = args;
+  const mountLabel = mountSeoLabel(mount);
+  const props: PropertyValue[] = [];
+
+  const focalRange = lens.focalLengthMin === lens.focalLengthMax
+    ? `${lens.focalLengthMin}mm`
+    : `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
+  props.push({ "@type": "PropertyValue", name: "Focal length", value: focalRange });
+
+  if (lens.maxAperture !== undefined) {
+    const ap = Array.isArray(lens.maxAperture)
+      ? `f/${lens.maxAperture[0]}-${lens.maxAperture[1]}`
+      : `f/${lens.maxAperture}`;
+    props.push({ "@type": "PropertyValue", name: "Max aperture", value: ap });
+  }
+
+  props.push({ "@type": "PropertyValue", name: "Mount", value: `Fujifilm ${mountLabel}` });
+
+  if (lens.weightG !== undefined && !Array.isArray(lens.weightG)) {
+    props.push({ "@type": "PropertyValue", name: "Weight", value: lens.weightG, unitText: "g" });
+  }
+  if (lens.filterMm !== undefined && lens.filterMm !== SPEC_NA) {
+    props.push({ "@type": "PropertyValue", name: "Filter thread", value: lens.filterMm, unitText: "mm" });
+  }
+  if (lens.af && lens.focusMotor && lens.focusMotor !== SPEC_NA) {
+    props.push({ "@type": "PropertyValue", name: "Focus motor", value: lens.focusMotor });
+  }
+  if (lens.ois) {
+    props.push({ "@type": "PropertyValue", name: "Optical stabilization", value: "Yes" });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: displayName,
+    description,
+    brand: { "@type": "Brand", name: brandName },
+    image: `${SITE.url}/lenses/${lens.id}.webp`,
+    category: "Camera Lens",
+    sku: lens.id,
+    url: canonicalUrl,
+    additionalProperty: props,
+  };
+}

--- a/src/lib/mount.ts
+++ b/src/lib/mount.ts
@@ -15,3 +15,14 @@ export function urlSegmentToMount(seg: string | undefined): Mount | null {
 export function mountToUrlSegment(mount: Mount): MountSegment {
   return mount === "X" ? "x" : "gfx";
 }
+
+/**
+ * Public-facing mount label for SEO copy and structured data — distinct from
+ * the URL segment (lowercase) and from the Mount type ("G" internally vs.
+ * "GFX" in product literature). Used in meta descriptions, OG titles, and
+ * JSON-LD additionalProperty values where "Fujifilm GFX-mount" reads naturally
+ * but "Fujifilm G-mount" doesn't match how people actually search for it.
+ */
+export function mountSeoLabel(mount: Mount): "X" | "GFX" {
+  return mount === "X" ? "X" : "GFX";
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,35 @@
 import type { Metadata } from "next";
 import { routing } from "@/i18n/routing";
 import { SITE } from "@/config/site";
+import { getLensImageUrl } from "@/lib/lens-image";
+
+// Default OG image is the site-wide 1200x630 PNG used for the home page and
+// every page that doesn't have a more specific image to advertise.
+const DEFAULT_OG_IMAGE = {
+  url: "/opengraph-image.png",
+  width: 1200,
+  height: 630,
+} as const;
+
+/**
+ * OG image slot for pages that don't have page-specific imagery. Use this in
+ * every non-home generateMetadata's openGraph spread — Next.js does a wholesale
+ * replace on openGraph when a page sets its own, so the layout-level images
+ * inheritance is lost without this re-declaration.
+ */
+export function defaultOgImages(): NonNullable<Metadata["openGraph"]>["images"] {
+  return [{ ...DEFAULT_OG_IMAGE }];
+}
+
+/**
+ * OG image slot for lens detail pages. Uses the lens's own square 800x800
+ * webp. Social platforms render this as a square thumbnail (Twitter "summary"
+ * card style) which fits a single-product context better than the 1200x630
+ * site banner.
+ */
+export function lensOgImages(lensId: string): NonNullable<Metadata["openGraph"]>["images"] {
+  return [{ url: getLensImageUrl(lensId), width: 800, height: 800 }];
+}
 
 /**
  * Builds canonical + hreflang alternates for a given locale + path.

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -13,7 +13,7 @@
   },
   "Metadata": {
     "seoTitle": "X-Glass | Fujifilm Lens Database & Comparison",
-    "seoDescription": "The Fujifilm lens database. X-mount and G-mount, first-party and every third-party brand. Normalized specs, cross-brand comparison."
+    "seoDescription": "The Fujifilm lens database. X-mount and G-mount, first-party and major third-party brands. Normalized specs, cross-brand comparison."
   },
   "Nav": {
     "lenses": "Browse",
@@ -137,12 +137,19 @@
     "equivSuffix": "eq."
   },
   "LensDetail": {
-    "metaDescPrefix": "{name} {mount}-mount {type} lens for Fujifilm. Specs, parameters and side-by-side comparison.",
-    "metaDescSpecs": " Focal length {focal}, max aperture {aperture}, weight {weight}",
-    "metaDescFilter": ", filter ⌀{size}mm",
-    "metaDescOis": ", optical stabilization",
-    "metaDescMf": ", manual focus",
-    "metaDescPeriod": ".",
+    "metaDescPrefix": "{name}, {mount}-mount {type} lens for Fujifilm. Specs, parameters, and side-by-side comparison",
+    "metaJoinSpace": ": ",
+    "metaSep": ", ",
+    "metaPeriod": ".",
+    "metaWeight": "weight {value}",
+    "metaFilter": "filter ⌀{size}mm",
+    "metaMfd": "min focus {value}",
+    "metaMag": "{value}× max magnification",
+    "metaMotor": "{label} motor",
+    "metaWr": "weather-sealed",
+    "metaWrPartial": "partial weather sealing",
+    "metaOis": "optical stabilization",
+    "metaMf": "manual focus",
     "metaPrime": "prime",
     "metaZoom": "zoom",
     "groupOptics": "Optics",
@@ -332,7 +339,7 @@
   },
   "About": {
     "pageTitle": "About",
-    "metaDescription": "The story behind X-Glass, what's covered, and where it's headed. An independent engineer's Fujifilm lens database — open-source web code, normalized data, cross-brand comparison.",
+    "metaDescription": "The story behind X-Glass, who maintains it, and which Fujifilm X / GFX-mount lenses are covered. Built and maintained solo by an independent engineer, with open-source web code.",
     "backgroundTitle": "Background",
     "backgroundBody1": "The Fujifilm lens ecosystem — spanning both the X Mount (APS-C) and G Mount (medium format) systems — has grown from a handful of native options in its early days to today's landscape of dozens of brands and hundreds of lenses. Yet specs are scattered across brand websites and various platforms in inconsistent formats, making meaningful comparison a slow and frustrating exercise. X-Glass was built to pull all of that fragmented information into one place — a normalized, comparable database that lets the data speak for itself.",
     "backgroundBody2": "I'm a web front-end engineer, and X-Glass is a project I develop and maintain entirely on my own. I've always had a strong conviction and passion for building products that don't compromise on engineering quality, user experience, or aesthetic design — and that drive is one of the key forces behind why this project exists.",
@@ -449,7 +456,7 @@
   },
   "Install": {
     "pageTitle": "Get the App",
-    "metaDescription": "Install X-Glass to your phone or desktop. App-like launch, offline access to Fujifilm lens specs and comparisons.",
+    "metaDescription": "Install X-Glass to your phone home screen or desktop. App-like launch, works offline.",
     "headline": "Add X-Glass to your home screen",
     "subheadline": "Faster access, full-screen experience, works offline.",
     "installedTitle": "You're all set",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -147,7 +147,7 @@
     "metaMag": "最大放大倍率 {value}×",
     "metaMotor": "{label} 对焦",
     "metaWr": "防滴防尘",
-    "metaWrPartial": "部分防护",
+    "metaWrPartial": "部分防滴防尘",
     "metaOis": "光学防抖",
     "metaMf": "手动对焦",
     "metaPrime": "定焦",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -13,7 +13,7 @@
   },
   "Metadata": {
     "seoTitle": "X-Glass | 富士 X / G 卡口镜头图鉴",
-    "seoDescription": "富士党的镜头图鉴。覆盖 X 卡口与 G 卡口、原厂与所有副厂镜头，规格统一标准，跨品牌横向对比。"
+    "seoDescription": "富士党的镜头图鉴。覆盖 X 卡口与 G 卡口、原厂与主流副厂镜头，规格统一标准，跨品牌横向对比。"
   },
   "Nav": {
     "lenses": "镜头库",
@@ -138,11 +138,18 @@
   },
   "LensDetail": {
     "metaDescPrefix": "{name} 富士 {mount} 卡口{type}镜头规格、参数与横向对比。",
-    "metaDescSpecs": "焦段 {focal}，最大光圈 {aperture}，重量 {weight}",
-    "metaDescFilter": "，滤镜口径 ⌀{size}mm",
-    "metaDescOis": "，光学防抖",
-    "metaDescMf": "，手动对焦",
-    "metaDescPeriod": "。",
+    "metaJoinSpace": "",
+    "metaSep": "，",
+    "metaPeriod": "。",
+    "metaWeight": "重量 {value}",
+    "metaFilter": "滤镜口径 ⌀{size}mm",
+    "metaMfd": "最近对焦 {value}",
+    "metaMag": "最大放大倍率 {value}×",
+    "metaMotor": "{label} 对焦",
+    "metaWr": "防滴防尘",
+    "metaWrPartial": "部分防护",
+    "metaOis": "光学防抖",
+    "metaMf": "手动对焦",
     "metaPrime": "定焦",
     "metaZoom": "变焦",
     "groupOptics": "光学",
@@ -332,7 +339,7 @@
   },
   "About": {
     "pageTitle": "关于",
-    "metaDescription": "X-Glass 项目缘起、收录范围与开发计划。一个独立工程师开发的富士镜头图鉴，Web 代码开源，聚焦规范化数据与跨品牌对比。",
+    "metaDescription": "X-Glass 项目缘起、维护者，以及富士 X / GFX 卡口的镜头收录情况。由独立工程师独立开发与维护，Web 代码开源。",
     "backgroundTitle": "项目缘起",
     "backgroundBody1": "富士的镜头生态——涵盖 X 卡口（APS-C）与 G 卡口（中画幅）两套系统——已经从早年的原厂主导，成长为如今数十个品牌、上百颗镜头并存的繁荣局面。然而，镜头参数散落在各品牌官网与各类平台之间，格式不一，横向对比极其低效。X-Glass 的初衷，正是把这些碎片化的信息汇聚到一处，建立一个规范化、可横向对比的数据库，让选镜头这件事回归客观数据本身。",
     "backgroundBody2": "我是一名 Web 前端工程师，X-Glass 目前完全由我一人开发并维护。对打造一个在工程质量，用户体验和美学设计上都不妥协的产品，我一直有很强的执念与热情——这份热情，同样是这个项目得以实现的重要驱动力之一。",
@@ -449,7 +456,7 @@
   },
   "Install": {
     "pageTitle": "安装应用",
-    "metaDescription": "把 X-Glass 装到手机或桌面，像 App 一样打开，支持离线查阅富士镜头参数与对比。",
+    "metaDescription": "把 X-Glass 装到手机主屏或电脑桌面，像 App 一样打开，离线也能用。",
     "headline": "将 X-Glass 添加到主屏幕",
     "subheadline": "像 App 一样打开，全屏体验，支持离线使用。",
     "installedTitle": "已完成安装",


### PR DESCRIPTION
Two-commit branch covering all post-audit SEO follow-ups from PR #207.

## Commit 1 — \`feat(seo): refine wording across home, About, Get, and lens detail\`

| Page | Issue | Fix |
|---|---|---|
| Home seoDescription | "every third-party brand" / "所有副厂" too absolute | "major third-party brands" / "主流副厂" |
| About metaDescription | Mentioned a "development plan" section that doesn't really exist | Reflects what the page actually has: origin story, who maintains it, per-brand coverage status |
| Get metaDescription | Keyword-stuffed "Fujifilm 镜头参数与对比"; Get has no real search intent | Describes only what the page does (install instructions, app-like launch, offline) |
| Lens detail description | Focal length + max aperture repeated info already in the model name | Replaced with model-name-orthogonal facts: weight, filter, min focus, max magnification, focus motor, weather sealing, OIS, MF — all conditional on data |

Also restructured the lens-detail i18n keys: one key per clause + locale-aware glue keys (\`metaSep\`, \`metaJoinSpace\`, \`metaPeriod\`).

## Commit 2 — \`feat(seo): Product schema, SSR h1, OG images, brand-in-h1\`

| # | Change | Why |
|---|---|---|
| **A** | Lens detail emits Product JSON-LD (name, brand, image, sku, url, additionalProperty for focal/aperture/mount/weight/filter/motor/OIS) | Eligibility for Google's "Product snippets" rich result. GSC \`Search appearance.csv\` already shows 5 impressions on that surface with the incomplete previous schema |
| **B** | Server-side sr-only h1 on \`(browse)/page.tsx\` and \`get/page.tsx\` | Both pages' previous h1s came from client components (LensListClient / InstallPage), so static HTML response had no h1. Crawlers saw no page heading. Downgraded the now-redundant client h1s to h2 to keep a single page-level h1 |
| **C** | \`defaultOgImages\` helper + applied to about / get / lens list / compare empty / compare custom | Each page's \`generateMetadata\` previously overrode \`openGraph\` wholesale, losing the layout-level og:image inheritance. Sharing those URLs produced cards with no image |
| **D** | Lens detail og:image uses the lens's own 800x800 webp via \`lensOgImages\` helper | Per-lens thumbnail in shares (vs the generic site banner) |
| **E** | Lens detail h1 now uses \`lensDisplayName(...)\` so it includes brand | h1 was bare model ("XF 35mm F1.4 R"); the brand was only in the small grey subtitle above. h1 is now the full display name; the redundant subtitle paragraph is removed |

Pricing is deliberately NOT in the Product schema — catalog prices are informational not authoritative, and surfacing an outdated Offer in the SERP would mislead users.

## Test plan
- [x] Typecheck clean (only pre-existing unrelated error in \`api/track/route.ts\`)
- [x] ESLint diff before/after my changes is identical (no new lint issues introduced)
- [x] JSON validates
- [x] curl against local dev server:
  - Lens detail (full-spec zoom): Product JSON-LD with 7 additionalProperty entries, lens-specific og:image, displayName in title + description + h1
  - Lens list / Get: server-side sr-only h1 present in static HTML
  - About / Compare empty / Compare custom: og:image present
- [ ] Verify Bing "identical descriptions" / Product rich-result eligibility after deploy + recrawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)