### PR TITLE
perf(redirects): 308 unprefixed /lenses/* by Accept-Language

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -53,6 +53,20 @@ const nextConfig: NextConfig = {
         destination: "/:locale/lenses/x/compare",
         permanent: false,
       },
+      // Bare /lenses/* (no locale prefix) — 308 so browsers cache the
+      // redirect. Without this, the next-intl middleware returns a 307
+      // per request, which is not cacheable.
+      {
+        source: "/lenses/:path*",
+        has: [{ type: "header", key: "accept-language", value: ".*zh.*" }],
+        destination: "/zh/lenses/:path*",
+        permanent: true,
+      },
+      {
+        source: "/lenses/:path*",
+        destination: "/en/lenses/:path*",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

- Bare `/lenses/*` paths (no locale prefix) currently fall through to `next-intl` middleware, which issues a **307** dynamic redirect — uncacheable, paid per request.
- This adds two entries to `next.config.ts redirects()` that issue **308** instead, routing by `Accept-Language` (zh → `/zh/...`, else → `/en/...`). Browsers cache 308 permanently.
- Targets the hot Bing-China arrival path: Cloudflare Web Analytics shows `/lenses/x` (unprefixed) at 9.9s P75 page-load across 34 sessions, vs `/zh/lenses/x` (prefixed) at 5.7s.

## Test plan

- [x] `curl -I -H "Accept-Language: zh-CN" /lenses/x` → 308 → `/zh/lenses/x`
- [x] `curl -I -H "Accept-Language: en-US" /lenses/x` → 308 → `/en/lenses/x`
- [x] `curl -I /lenses/x/<id>` → 308 with path preserved
- [x] `curl -I /zh/lenses/x` still 200 (no double redirect on already-prefixed paths)
- [x] Existing `/[locale]/lenses` → `/[locale]/lenses/x` redirects unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)