### PR TITLE
fix(search): hit zoom lenses when range is typed without a hyphen

### DIFF
--- a/src/lib/__tests__/lens-search.test.ts
+++ b/src/lib/__tests__/lens-search.test.ts
@@ -244,6 +244,31 @@ describe("searchLenses — focal & aperture tokens", () => {
     expect(results[0]?.id).toBe("sigma-18-50-28");
   });
 
+  it("'1850' (no-hyphen zoom range) matches the 18-50 zoom", () => {
+    const results = searchLenses(lenses, "1850");
+    expect(results[0]?.id).toBe("sigma-18-50-28");
+  });
+
+  it("'100400' (no-hyphen zoom range) matches both 100-400 zooms", () => {
+    const ids = searchLenses(lenses, "100400").map((l) => l.id);
+    expect(ids).toContain("fuji-xf100-400");
+    expect(ids).toContain("sigma-100-400");
+  });
+
+  it("'185' (prefix of no-hyphen zoom range) matches the 18-50 zoom", () => {
+    const ids = searchLenses(lenses, "185").map((l) => l.id);
+    expect(ids).toContain("sigma-18-50-28");
+  });
+
+  it("synthetic focal range does not steal the top slot from prime focal matches", () => {
+    // "50" should still rank the 50mm-side of the prime/zoom universe by
+    // its real model token, not via the new synthetic "1850" includes hit.
+    const results = searchLenses(lenses, "50");
+    // sigma-18-50 has "50mm" word-prefix match (450); should rank above any
+    // includes-only hit on the synthetic token, and not below unrelated lenses.
+    expect(results[0]?.id).toBe("sigma-18-50-28");
+  });
+
   it("'f2.8' matches lenses with maxAperture 2.8", () => {
     const results = searchLenses(lenses, "f2.8");
     const ids = results.map((l) => l.id);

--- a/src/lib/lens-search.ts
+++ b/src/lib/lens-search.ts
@@ -121,6 +121,20 @@ function formatApertureNum(n: number): string {
   return n % 1 === 0 ? String(n) : n.toFixed(1).replace(/\.?0+$/, "");
 }
 
+/**
+ * Synthetic "no-hyphen focal range" token for zoom lenses (e.g. an 18-50mm
+ * lens emits "1850"). Users commonly type zoom ranges without the hyphen,
+ * but the model string normalises "18-50mm" into separate "18" and "50mm"
+ * tokens, so the joined form is otherwise unreachable. Skipped for primes
+ * since the single focal length is already an exact token.
+ */
+function focalRangeTokens(lens: Lens): string[] {
+  if (lens.focalLengthMin === lens.focalLengthMax) {
+    return [];
+  }
+  return [`${lens.focalLengthMin}${lens.focalLengthMax}`];
+}
+
 function apertureTokens(lens: Lens): string[] {
   const tokens: string[] = [];
   if (lens.maxAperture === undefined) {
@@ -168,7 +182,7 @@ function createSearchableLensEntry(lens: Lens): SearchableLensEntry {
     brand: normTokens(lens.brand),
     alias: aliasTokens,
     series: normTokens(lens.series ?? ""),
-    model: normTokens(lens.model),
+    model: [...normTokens(lens.model), ...focalRangeTokens(lens)],
     aperture: apertureTokens(lens).map((t) => normalizeLensSearchText(t)),
   };
 


### PR DESCRIPTION
## Summary
- Users typing `1850` / `100400` / `2470` now find the matching zoom (Sigma 18-50, 100-400 pair, etc.) — previously 0 results.
- Implemented by emitting a synthetic joined-range token (`\${min}\${max}`) into each zoom lens's model bucket at index time. Mirrors the existing no-dot aperture variants (`f28` for f/2.8).
- Primes skip the token (focal already exact-matches as its own token).

## Why index-side, not query-side
Query-side splitting of a pure-digit string is ambiguous (`70200` = 70+200? 7+0200? 702+00?) and risks regressions via AND semantics. Index-side synthesis is 1:1 literal matching against canonical data and matches the pattern already validated for aperture tokens.

## Seesaw checks
- `50` query still ranks 50mm primes top (synthetic `1850` only adds a weaker includes-hit, not the best).
- `100` / `400` against 100-400 zoom keep their original boundaryPrefix best; synthetic `100400` only adds weaker wordPrefix.
- `18-50` still works (existing tokens untouched).
- `185` now reasonably surfaces all 18-XXX zooms (18-50, 18-55, 18-120, 18-135, 18-300) — intentional, user hasn't specified the long end.

## Test plan
- [x] `npx vitest run src/lib/__tests__/lens-search.test.ts` — 38/38 pass (33 existing + 5 new)
- [ ] Manual: search `1850`, `185`, `1855`, `100400` in the lens search dialog at localhost