### PR TITLE
feat(types): allow fieldNotes for lengthMm and diameterMm

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -226,6 +226,8 @@ export type SpecialtyTag = (typeof SPECIALTY_TAGS)[number];
 export const FIELD_NOTE_KEYS = [
   "wr",
   "weightG",
+  "lengthMm",
+  "diameterMm",
   "filterMm",
   "minFocusDistance",
   "maxMagnification",


### PR DESCRIPTION
## Summary
- Extends `FIELD_NOTE_KEYS` enum to allow per-field notes on `lengthMm` and `diameterMm`.
- Third-party multi-mount lenses commonly list dimensions for only one mount (mount flange depth differs across systems → physical length/diameter varies slightly). Currently this caveat had to be jammed into `weightG`'s note or dropped.
- Pattern mirrors the existing `weightG` fieldNote convention.

## Why now
Unblocks the x-glass-pipeline publish step for records carrying `fieldNotes.lengthMm` / `fieldNotes.diameterMm`. The proximate driver is Laowa 4.5-10mm Fisheye Zoom where the spec table gives Ø68.9 × 59.3 mm explicitly only for Sony E mount.

## Test plan
- [x] `tsc --noEmit` (no new errors; pre-existing Cloudflare module errors unchanged)
- [ ] Lens-schema Zod validation accepts new keys (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)