### PR TITLE
feat(about): add Cinema column to Coverage table

### DIFF
--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -11,7 +11,7 @@ import { getLensesByMount } from "@/lib/lens";
 import coverageMeta from "@/data/coverage-meta.json";
 import AckCard from "@/components/AckCard";
 
-type CoverageMeta = { active: boolean | "planned"; discontinued: boolean | "planned"; notes: string };
+type CoverageMeta = { active: boolean | "planned"; discontinued: boolean | "planned"; cinema: boolean | "planned"; notes: string };
 
 function Check() {
   return <span className="text-zinc-700 dark:text-zinc-300 text-sm">✓</span>;
@@ -31,7 +31,7 @@ function MountCoverageTable({
   counts: Record<string, number>;
   meta: Record<string, CoverageMeta>;
   brandNames: Record<string, string>;
-  col: { brand: string; count: string; active: string; discontinued: string };
+  col: { brand: string; count: string; active: string; discontinued: string; cinema: string };
   rowTotal: string;
 }) {
   const total = brands.reduce((s, b) => s + (counts[b] ?? 0), 0);
@@ -45,17 +45,19 @@ function MountCoverageTable({
               <th className="px-3 py-2 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 w-28">{col.brand}</th>
               <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.active}</th>
               <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.discontinued}</th>
+              <th className="px-3 py-2 text-center text-xs font-medium text-zinc-500 dark:text-zinc-400 w-14">{col.cinema}</th>
               <th className="px-3 py-2 text-right text-xs font-medium text-zinc-500 dark:text-zinc-400 whitespace-nowrap">{col.count}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/60">
             {brands.map((b) => {
-              const m: CoverageMeta = (meta as Record<string, CoverageMeta>)[b] ?? { active: false, discontinued: false, notes: "" };
+              const m: CoverageMeta = (meta as Record<string, CoverageMeta>)[b] ?? { active: false, discontinued: false, cinema: false, notes: "" };
               return (
                 <tr key={b}>
                   <td className="px-3 py-2 font-medium text-zinc-800 dark:text-zinc-200 whitespace-nowrap">{brandNames[b] ?? b}</td>
                   <td className="px-3 py-2 text-center">{m.active === true ? <Check /> : m.active === "planned" ? <Pending /> : <Dash />}</td>
                   <td className="px-3 py-2 text-center">{m.discontinued === true ? <Check /> : m.discontinued === "planned" ? <Pending /> : <Dash />}</td>
+                  <td className="px-3 py-2 text-center">{m.cinema === true ? <Check /> : m.cinema === "planned" ? <Pending /> : <Dash />}</td>
                   <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">{m.active === true ? (counts[b] ?? 0) : <Dash />}</td>
                 </tr>
               );
@@ -64,7 +66,7 @@ function MountCoverageTable({
           <tfoot>
             <tr className="border-t border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
               <td className="px-3 py-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">{rowTotal}</td>
-              <td colSpan={2} />
+              <td colSpan={3} />
               <td className="px-3 py-2 text-right tabular-nums text-xs font-semibold text-zinc-700 dark:text-zinc-300">{total}</td>
             </tr>
           </tfoot>
@@ -190,7 +192,7 @@ export default async function AboutContent() {
                 counts={counts}
                 meta={meta as Record<string, CoverageMeta>}
                 brandNames={Object.fromEntries(brands.map((b) => [b, tBrand(b as Parameters<typeof tBrand>[0])]))}
-                col={{ brand: t("coverageColBrand"), count: t("coverageColCount"), active: t("coverageColActive"), discontinued: t("coverageColDiscontinued") }}
+                col={{ brand: t("coverageColBrand"), count: t("coverageColCount"), active: t("coverageColActive"), discontinued: t("coverageColDiscontinued"), cinema: t("coverageColCinema") }}
                 rowTotal={t("coverageRowTotal")}
               />
               <p className="text-xs text-zinc-400 dark:text-zinc-600">

--- a/src/data/coverage-meta.json
+++ b/src/data/coverage-meta.json
@@ -1,19 +1,19 @@
 {
   "x": {
-    "fujifilm":    { "active": true,  "discontinued": true,  "notes": "" },
-    "sigma":       { "active": true,  "discontinued": "planned", "notes": "" },
-    "tamron":      { "active": true,  "discontinued": "planned", "notes": "" },
-    "viltrox":     { "active": true,  "discontinued": false, "notes": "" },
-    "7artisans":   { "active": true,  "discontinued": false, "notes": "" },
-    "ttartisan":   { "active": true,  "discontinued": false, "notes": "" },
-    "brightinstar":{ "active": true,  "discontinued": false, "notes": "" },
-    "sgimage":     { "active": true,  "discontinued": false, "notes": "" },
-    "laowa":       { "active": "planned", "discontinued": false, "notes": "" },
-    "meike":       { "active": "planned", "discontinued": false, "notes": "" },
-    "sirui":       { "active": "planned", "discontinued": false, "notes": "" },
-    "voigtlander": { "active": "planned", "discontinued": false, "notes": "" }
+    "fujifilm":    { "active": true,  "discontinued": true,      "cinema": false, "notes": "" },
+    "sigma":       { "active": true,  "discontinued": "planned", "cinema": false, "notes": "" },
+    "tamron":      { "active": true,  "discontinued": "planned", "cinema": false, "notes": "" },
+    "viltrox":     { "active": true,  "discontinued": false,     "cinema": false, "notes": "" },
+    "7artisans":   { "active": true,  "discontinued": false,     "cinema": false, "notes": "" },
+    "ttartisan":   { "active": true,  "discontinued": false,     "cinema": false, "notes": "" },
+    "brightinstar":{ "active": true,  "discontinued": false,     "cinema": false, "notes": "" },
+    "sgimage":     { "active": true,  "discontinued": false,     "cinema": false, "notes": "" },
+    "laowa":       { "active": "planned", "discontinued": false, "cinema": false, "notes": "" },
+    "meike":       { "active": "planned", "discontinued": false, "cinema": false, "notes": "" },
+    "sirui":       { "active": "planned", "discontinued": false, "cinema": false, "notes": "" },
+    "voigtlander": { "active": "planned", "discontinued": false, "cinema": false, "notes": "" }
   },
   "g": {
-    "fujifilm":    { "active": true,  "discontinued": false, "notes": "" }
+    "fujifilm":    { "active": true,  "discontinued": false, "cinema": false, "notes": "" }
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -351,6 +351,7 @@
     "coverageColCount": "Lenses",
     "coverageColActive": "Active",
     "coverageColDiscontinued": "Discontinued",
+    "coverageColCinema": "Cinema",
     "coverageRowTotal": "Total",
     "coverageLegend": "✓ Covered · ○ Under evaluation · — No plans",
     "coverageSuggest": "Missing a lens you're looking for?",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -351,6 +351,7 @@
     "coverageColCount": "镜头总数",
     "coverageColActive": "在产",
     "coverageColDiscontinued": "停产",
+    "coverageColCinema": "电影",
     "coverageRowTotal": "合计",
     "coverageLegend": "✓ 已收录 · ○ 评估中 · — 暂无计划",
     "coverageSuggest": "缺少你要找的镜头？",


### PR DESCRIPTION
## Summary
- Adds a tri-state Cinema column to the brand coverage tables on the About page, sitting between Discontinued and the Lenses count.
- `coverage-meta.json` gains a `cinema` field per brand entry; all values default to `false` (— "No plans" / "暂无计划") for now. Real status will be backfilled manually per brand as cine coverage matures.
- Mirrors a new `coverage.cinema` field added on the pipeline side (private repo) so future agents/scripts can query indexing intent there. Public table here is decoupled — UI authors edit `coverage-meta.json` directly.

## Why now
Several recently-added brands (Laowa, Meike, Sirui) have substantial cine lineups that are intentionally out of scope for the current indexing pass. Without a column to show that, the table reads as "this brand has X lenses" which understates what the brand actually makes.

## Test plan
- [x] `tsc --noEmit` (no new errors)
- [x] Local render verified at `/en/about#coverage` and `/zh/about#coverage` (Cinema column renders, all values "—", footer total correct)
- [x] Chinese label "电影" sits naturally next to "在产/停产" (matching two-char column width)

## Screenshots
EN and ZH renders captured locally; column layout matches existing visual conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)