### PR TITLE
feat(about): add partial coverage state and unify dash semantics

### DIFF
--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -11,16 +11,27 @@ import { getLensesByMount } from "@/lib/lens";
 import coverageMeta from "@/data/coverage-meta.json";
 import AckCard from "@/components/AckCard";
 
-type CoverageMeta = { active: boolean | "planned"; discontinued: boolean | "planned"; notes: string };
+type CoverageState = boolean | "planned" | "partial";
+type CoverageMeta = { active: CoverageState; discontinued: CoverageState; notes: string };
 
 function Check() {
   return <span className="text-zinc-700 dark:text-zinc-300 text-sm">✓</span>;
+}
+function Partial() {
+  return <span className="text-zinc-600 dark:text-zinc-400 text-sm">◐</span>;
 }
 function Pending() {
   return <span className="text-zinc-400 dark:text-zinc-500 text-sm">○</span>;
 }
 function Dash() {
   return <span className="text-zinc-300 dark:text-zinc-600 text-sm">—</span>;
+}
+
+function StateCell({ state }: { state: CoverageState }) {
+  if (state === true) return <Check />;
+  if (state === "partial") return <Partial />;
+  if (state === "planned") return <Pending />;
+  return <Dash />;
 }
 
 function MountCoverageTable({
@@ -54,9 +65,15 @@ function MountCoverageTable({
               return (
                 <tr key={b}>
                   <td className="px-3 py-2 font-medium text-zinc-800 dark:text-zinc-200 whitespace-nowrap">{brandNames[b] ?? b}</td>
-                  <td className="px-3 py-2 text-center">{m.active === true ? <Check /> : m.active === "planned" ? <Pending /> : <Dash />}</td>
-                  <td className="px-3 py-2 text-center">{m.discontinued === true ? <Check /> : m.discontinued === "planned" ? <Pending /> : <Dash />}</td>
-                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">{m.active === true ? (counts[b] ?? 0) : <Dash />}</td>
+                  <td className="px-3 py-2 text-center"><StateCell state={m.active} /></td>
+                  <td className="px-3 py-2 text-center"><StateCell state={m.discontinued} /></td>
+                  <td className="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">
+                    {m.active === true || m.active === "partial"
+                      ? (counts[b] ?? 0)
+                      : m.active === "planned"
+                        ? <Pending />
+                        : <Dash />}
+                  </td>
                 </tr>
               );
             })}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -352,7 +352,7 @@
     "coverageColActive": "Active",
     "coverageColDiscontinued": "Discontinued",
     "coverageRowTotal": "Total",
-    "coverageLegend": "✓ Covered · ○ Under evaluation · — No plans",
+    "coverageLegend": "✓ Covered · ◐ Partial · ○ Under evaluation · — No plans",
     "coverageSuggest": "Missing a lens you're looking for?",
     "coverageSuggestCta": "Let us know",
     "coverageViewLink": "View lens coverage →",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -352,7 +352,7 @@
     "coverageColActive": "在产",
     "coverageColDiscontinued": "停产",
     "coverageRowTotal": "合计",
-    "coverageLegend": "✓ 已收录 · ○ 评估中 · — 暂无计划",
+    "coverageLegend": "✓ 已收录 · ◐ 部分收录 · ○ 评估中 · — 暂无计划",
     "coverageSuggest": "缺少你要找的镜头？",
     "coverageSuggestCta": "告诉我们",
     "coverageViewLink": "查看收录范围 →",


### PR DESCRIPTION
## Summary
- Adds a new `"partial"` coverage state (◐) to `coverage-meta.json` schema, alongside `true` / `"planned"` / `false`. Useful for brands where we have catalog coverage but not the full lineup (e.g. Sigma contemporary primes without DC DN series).
- Unifies dash (—) semantics: it now consistently means "no plans" across all three columns. Previously the Lenses count column also rendered — for `"planned"` rows, conflicting with the legend.

## Behavior change
- `m.active === "planned"` now renders ○ in the Lenses count column (was —).
- `m.active === "partial"` renders ◐ in Active/Discontinued and the actual lens count in the Lenses column.
- Legend updated in en/zh: `✓ Covered · ◐ Partial · ○ Under evaluation · — No plans`.

No data values were changed in this PR — only schema + rendering. Setting any brand to `"partial"` is a follow-up data edit (out of scope here; the data pipeline is the canonical owner of `coverage-meta.json`).

## Test plan
- [x] Coverage table renders correctly on `/zh/about#coverage` with current data (planned brands now show ○ in Lenses column instead of —)
- [x] Verified ◐ renders correctly by temporarily setting sigma → `"partial"` (reverted before commit)
- [x] Legend reflects all four states in both en and zh
- [ ] Visual check on `/en/about#coverage` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)