### PR TITLE
feat(schema): add isCine + opticalTraits, deprecate specialtyTags

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { SPEC_NA, SPECIALTY_TAGS } from "./types.ts";
+import { OPTICAL_TRAITS, SPEC_NA, SPECIALTY_TAGS } from "./types.ts";
 import type { ApertureValue, Lens } from "./types.ts";
 
 const positiveNumberSchema = z.number().positive();
@@ -23,6 +23,7 @@ const minApertureSchema = createApertureSchema("minAperture");
 const maxTStopSchema = createApertureSchema("maxTStop");
 const minTStopSchema = createApertureSchema("minTStop");
 const specialtyTagSchema = z.enum(SPECIALTY_TAGS);
+const opticalTraitSchema = z.enum(OPTICAL_TRAITS);
 export const specNaSchema = z.literal(SPEC_NA);
 const lensPriceEntrySchema = z.strictObject({
   price: z.number().positive(),
@@ -58,6 +59,8 @@ const lensBaseShape = {
   minAperture: minApertureSchema.optional(),
   maxTStop: maxTStopSchema.optional(),
   minTStop: minTStopSchema.optional(),
+  isCine: z.boolean().optional(),
+  opticalTraits: z.array(opticalTraitSchema).min(1).optional(),
   specialtyTags: z.array(specialtyTagSchema).min(1).optional(),
   af: z.boolean(),
   ois: z.boolean(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -202,6 +202,11 @@ export type ApertureValue = number | [number, number];
 /**
  * All valid specialty tag values. Defined as a const tuple so that
  * lens-schema.ts can derive its Zod enum without duplicating the list.
+ *
+ * @deprecated Use {@link Lens.isCine} (cine vs photo) and
+ * {@link Lens.opticalTraits} (flat optical / form-factor traits) instead.
+ * Retained during the dual-write migration window; will be removed in a
+ * follow-up release once the pipeline stops emitting this field.
  */
 export const SPECIALTY_TAGS = [
   "cine",
@@ -214,6 +219,35 @@ export const SPECIALTY_TAGS = [
   "probe",
 ] as const;
 export type SpecialtyTag = (typeof SPECIALTY_TAGS)[number];
+
+/**
+ * Flat optical and form-factor traits, replacing the implicit hierarchy
+ * inside the old `specialtyTags` array. Each trait is independent — no
+ * implicit pairing required.
+ *
+ * Trait definitions (apply when the source or model name explicitly indicates):
+ * - "macro"      — marketed as a macro lens, typically ≥0.5x magnification.
+ *                  Ultra-macro (>1.0x) is derived from {@link Lens.maxMagnification}
+ *                  and is no longer a separate trait.
+ * - "anamorphic" — uses anamorphic optics for cinematic squeeze. In practice
+ *                  always paired with `isCine: true` on the lens, but the trait
+ *                  itself is just "the optics are anamorphic".
+ * - "tilt"       — supports tilt movements (tilt-shift or Lensbaby-style).
+ * - "shift"      — supports shift movements.
+ * - "fisheye"    — fisheye projection (≥180° diagonal or circular).
+ * - "probe"      — probe / periscope form factor (e.g. Laowa Probe). Form-factor
+ *                  trait — orthogonal to macro capability; pair with "macro"
+ *                  when the lens also supports macro focusing.
+ */
+export const OPTICAL_TRAITS = [
+  "macro",
+  "anamorphic",
+  "tilt",
+  "shift",
+  "fisheye",
+  "probe",
+] as const;
+export type OpticalTrait = (typeof OPTICAL_TRAITS)[number];
 
 /**
  * All valid keys for {@link Lens.fieldNotes}. Defined as a const tuple so that
@@ -386,26 +420,47 @@ export interface Lens {
   minTStop?: ApertureValue;
 
   /**
-   * Optional special-purpose capability tags used for filtering and UX badges.
-   * Tags are additive — a lens can carry more than one.
+   * Whether the lens is marketed as a cinema / motion lens (T-stop rated,
+   * geared rings, standardized front diameter, etc.).
    *
-   * Tag definitions (apply when the source or model name explicitly indicates):
+   * Omit the field when the lens is a regular photo lens (do not store `false`).
+   *
+   * @example true
+   */
+  isCine?: boolean;
+
+  /**
+   * Optical / form-factor traits. Flat multi-select — every value in this
+   * array is independent, with no implicit pairing or hierarchy. See
+   * {@link OPTICAL_TRAITS} for the full list and per-trait definitions.
+   *
+   * Omit the field entirely when no traits apply (do not store an empty array).
+   *
+   * @example ["macro"]
+   * @example ["fisheye"]
+   * @example ["anamorphic"]
+   * @example ["macro", "probe"]
+   */
+  opticalTraits?: OpticalTrait[];
+
+  /**
+   * @deprecated Migrating to {@link Lens.isCine} + {@link Lens.opticalTraits}.
+   *
+   * Retained during the dual-write migration window: the pipeline currently
+   * emits both this field and the new fields. Will be removed once the
+   * pipeline stops writing it.
+   *
+   * Legacy tag definitions (kept here so the schema stays self-documenting
+   * until removal):
    * - "macro"       — marketed as a macro lens, typically ≥0.5x magnification.
    * - "ultra_macro" — exceeds 1:1 (>1.0x) magnification at closest focus.
-   *                   Always pair with "macro" (i.e. ["macro", "ultra_macro"]).
-   * - "cine"        — marketed as a cinema / video lens (T-stop rated, geared
-   *                   rings, standardized front diameter, etc.).
+   *                   Always paired with "macro".
+   * - "cine"        — marketed as a cinema / video lens.
    * - "anamorphic"  — uses anamorphic optics for cinematic squeeze.
-   * - "tilt"        — supports tilt movements (tilt-shift or Lensbaby-style).
+   * - "tilt"        — supports tilt movements.
    * - "shift"       — supports shift movements.
    * - "fisheye"     — fisheye projection (≥180° diagonal or circular).
    * - "probe"       — probe / periscope macro lens (e.g. Laowa Probe).
-   *
-   * Omit the field entirely when no tags apply (do not store an empty array).
-   *
-   * @example ["macro"]
-   * @example ["macro", "ultra_macro"]
-   * @example ["cine", "anamorphic"]
    */
   specialtyTags?: SpecialtyTag[];
 


### PR DESCRIPTION
## Summary
Phase 1 of the specialty-tag schema refactor. **Schema-only PR** — no UI, filter, or data changes. Plan archived at `~/X-Glass/plans/2026-05-18-specialty-tag-refactor.md`.

Splits the flat \`specialtyTags\` array into two orthogonal dimensions so the hidden parent-child relationships become explicit:

- **\`isCine?: boolean\`** — product positioning (photo vs cinema). Maps to the upcoming Usage filter (Photo / Cine).
- **\`opticalTraits?: OpticalTrait[]\`** — flat optical / form-factor traits (\`macro\`, \`anamorphic\`, \`tilt\`, \`shift\`, \`fisheye\`, \`probe\`). No implicit pairing.

\`ultra_macro\` drops out — it is fully derivable from \`maxMagnification.value >= 1.0\` and was redundant.

\`specialtyTags\` is kept and marked \`@deprecated\`. Pipeline will dual-write old + new fields during the migration window; this field is removed once pipeline stops emitting it.

## Why now
\`specialtyTags\` mixed three different concerns in one array (product positioning, optical traits, form factor) and relied on doc-comment conventions like "always pair ultra_macro with macro" or "anamorphic example pairs with cine" that the schema didn't enforce. Pipeline had to remember these conventions on write; consumers had to know them on read. Splitting eliminates the implicit rules.

## What this PR does NOT do
- No pipeline changes — that's the next PR in x-glass-pipeline.
- No UI / filter changes — the Usage filter PR depends on pipeline shipping dual-write first.
- No data migration — current \`lenses.json\` continues to validate (new fields are optional, \`specialtyTags\` still accepted).

## Test plan
- [x] \`npx tsc --noEmit\` clean (the compile-time bidirectional \`_LensSchemaCheck\` assertion still passes — types.ts and lens-schema.ts stay in sync)
- [x] \`npm run validate:lenses\` passes against current \`lenses.json\`
- [x] \`npm test\` (251/251 passed)
- [x] \`npx eslint\` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)