### PR TITLE
fix(schema): allowlist laowa S 17 / TS 17 as distinct in similarity gate

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -328,6 +328,13 @@ export const KNOWN_DISTINCT_PAIRS = new Set([
   makeAllowlistKey(
     "fujifilm-xc-50-230mmf45-67-ois-ii-x",
     "fujifilm-xc-50-230mmf45-67-ois-x"),
+  // S 17mm is shift-only; TS 17mm adds an internal tilt mechanism (+40g).
+  // Laowa sells them as separate SKUs sharing the same product page and
+  // outer housing (same length/diameter, same optical formula). The diff
+  // is opticalTraits ["shift"] vs ["tilt","shift"] and weight 770g vs 810g.
+  makeAllowlistKey(
+    "laowa-ff-s-17mmf4-c-dreamer-g",
+    "laowa-ff-ts-17mmf4-c-dreamer-g"),
 ]);
 
 // Fields excluded from the spec similarity comparison.


### PR DESCRIPTION
## Summary
- Laowa sells FF II **S** 17mm F4 (shift-only) and FF II **TS** 17mm F4 (tilt + shift) as separate SKUs on the same Tmall product page (id=995024947971) sharing the same outer housing.
- Confirmed distinct by direct Tmall detail-page check during pricing collection: two 镜头型号 sub-SKUs sell at different prices on GFX (¥6969 vs ¥8469).
- Diff: opticalTraits `["shift"]` vs `["tilt","shift"]`; weight 770g vs 810g (+40g for the internal tilt mechanism). Length, diameter, optical formula, cn product link are identical by design.

## Test plan
- [x] Confirmed both products exist as separately purchasable Tmall SKUs at different prices
- [ ] Re-run publish gate after merge to verify the spec-similarity check no longer blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)