### PR TITLE
fix(schema): KNOWN_DISTINCT_PAIRS now also exempts shared officialLinks

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -450,11 +450,17 @@ export const lensCatalogSchema = z.array(lensSchema).superRefine((lenses, ctx) =
     if (lens.officialLinks.cn) {
       const previousCnIndex = seenCnLinks.get(lens.officialLinks.cn);
       if (previousCnIndex !== undefined) {
-        ctx.addIssue({
-          code: "custom",
-          message: `Duplicate officialLinks.cn also appears at index ${previousCnIndex}`,
-          path: [index, "officialLinks", "cn"],
-        });
+        // Honor KNOWN_DISTINCT_PAIRS: pairs that legitimately share a product
+        // page (e.g. Laowa S 17 / TS 17 are two SKUs on the same Tmall listing)
+        // would otherwise need URL data stripped just to pass this gate.
+        const pairKey = makeAllowlistKey(lens.id, lenses[previousCnIndex].id);
+        if (!KNOWN_DISTINCT_PAIRS.has(pairKey)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Duplicate officialLinks.cn also appears at index ${previousCnIndex}`,
+            path: [index, "officialLinks", "cn"],
+          });
+        }
       } else {
         seenCnLinks.set(lens.officialLinks.cn, index);
       }
@@ -463,11 +469,14 @@ export const lensCatalogSchema = z.array(lensSchema).superRefine((lenses, ctx) =
     if (lens.officialLinks.global) {
       const previousGlobalIndex = seenGlobalLinks.get(lens.officialLinks.global);
       if (previousGlobalIndex !== undefined) {
-        ctx.addIssue({
-          code: "custom",
-          message: `Duplicate officialLinks.global also appears at index ${previousGlobalIndex}`,
-          path: [index, "officialLinks", "global"],
-        });
+        const pairKey = makeAllowlistKey(lens.id, lenses[previousGlobalIndex].id);
+        if (!KNOWN_DISTINCT_PAIRS.has(pairKey)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Duplicate officialLinks.global also appears at index ${previousGlobalIndex}`,
+            path: [index, "officialLinks", "global"],
+          });
+        }
       } else {
         seenGlobalLinks.set(lens.officialLinks.global, index);
       }


### PR DESCRIPTION
## Summary
\`KNOWN_DISTINCT_PAIRS\` was only honored by the cross-lens spec-similarity check, not by the \`officialLinks.cn\` / \`officialLinks.global\` duplicate checks. Pairs that legitimately share a product page (e.g. Laowa FF II **S** 17mm F4 and **TS** 17mm F4 — two SKU variants on the same Tmall listing, already allowlisted in #221) still got blocked at publish:

\`\`\`
[publish] BLOCKED — spec similarity gate:
  laowa-ff-ts-17mmf4-c-dreamer-g.officialLinks.cn: Duplicate
    officialLinks.cn also appears at index 121
    (laowa-ff-s-17mmf4-c-dreamer-g)
\`\`\`

Both URL-dedupe paths now consult \`KNOWN_DISTINCT_PAIRS\` the same way the spec-similarity gate does, and skip the diagnostic when the pair is allowlisted. Accidental URL duplicates (e.g. agent miscopying a different lens's page) are still caught because they wouldn't be in the allowlist.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Re-run \`tsx scripts/cli.ts publish\` from the pipeline after this merges — the Laowa S 17 / TS 17 pair should pass; other accidental URL duplicates (if any) should still fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)