### PR TITLE
feat(data): publish lens data 2026.05.18 build 4

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -12607,7 +12607,7 @@
     "brand": "voigtlander",
     "mount": "X",
     "series": "Nokton",
-    "model": "23mm F1.2",
+    "model": "23mm F1.2 aspherical",
     "focalLengthMin": 23,
     "focalLengthMax": 23,
     "maxAperture": 1.2,

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.18",
-  "lastUpdated": "2026-05-18T12:02:08.380Z",
+  "lastUpdated": "2026-05-18T12:08:33.647Z",
   "lensCount": 196,
-  "buildNumber": 3
+  "buildNumber": 4
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.18` build 4
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`