### PR TITLE
feat(data): publish lens data 2026.05.18 build 5

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -7023,7 +7023,7 @@
     "id": "laowa-cf-4mmf28-210-circular-fisheye-x",
     "brand": "laowa",
     "mount": "X",
-    "model": "CF 4mm F2.8 210° Circular Fisheye",
+    "model": "CF 4mm F2.8 Circular Fisheye",
     "focalLengthMin": 4,
     "focalLengthMax": 4,
     "maxAperture": 2.8,

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.18",
-  "lastUpdated": "2026-05-18T12:08:33.647Z",
+  "lastUpdated": "2026-05-18T12:22:05.291Z",
   "lensCount": 196,
-  "buildNumber": 4
+  "buildNumber": 5
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.18` build 5
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`