### PR TITLE
fix(brand-filter): stop dropdown highlight sticking on touch devices

### DIFF
--- a/src/components/lens-filters/BrandFilterMenu.tsx
+++ b/src/components/lens-filters/BrandFilterMenu.tsx
@@ -64,7 +64,7 @@ export default function BrandFilterMenu({
                 }
               }}
               closeOnClick={false}
-              className="relative flex cursor-pointer items-center gap-2 px-3 py-2 outline-none data-highlighted:bg-zinc-100 dark:data-highlighted:bg-zinc-800"
+              className="relative flex cursor-pointer items-center gap-2 px-3 py-2 outline-none pointer-fine:data-highlighted:bg-zinc-100 dark:pointer-fine:data-highlighted:bg-zinc-800"
             >
               <CheckboxIndicator checked={!hasSelection} />
               <span className="text-zinc-800 dark:text-zinc-200">{allLabel}</span>
@@ -79,7 +79,7 @@ export default function BrandFilterMenu({
                     checked={isChecked}
                     onCheckedChange={() => onToggle(brand)}
                     closeOnClick={false}
-                    className="relative flex cursor-pointer items-center gap-2 px-3 py-2 outline-none data-highlighted:bg-zinc-100 dark:data-highlighted:bg-zinc-800"
+                    className="relative flex cursor-pointer items-center gap-2 px-3 py-2 outline-none pointer-fine:data-highlighted:bg-zinc-100 dark:pointer-fine:data-highlighted:bg-zinc-800"
                   >
                     <CheckboxIndicator checked={isChecked} />
                     <span className="truncate text-zinc-800 dark:text-zinc-200">{brandLabels[brand] ?? brand}</span>


### PR DESCRIPTION
## Summary

Mobile-only bug on the brand filter dropdown: tapping a row left a gray background that stayed there until another row was tapped, because Base UI Menu's `data-highlighted` state has no "leave" trigger on touch.

Gate the highlight background behind `pointer-fine:` so it only applies on mouse / trackpad devices; touch falls through to the default transparent background. The dropdown is `sm:hidden` (desktop uses a chip group), so the practical effect is "no more sticky highlight."

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Desktop sandbox (`pointer: fine`): dropdown still highlights on hover / keyboard nav
- [ ] Manual smoke on a real touch device: tap a brand, highlight does not persist after tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)