### PR TITLE
feat(data): publish lens data 2026.05.18 build 6

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -12587,6 +12587,7 @@
       "lensConfiguration": "Includes 1 double-sided aspherical element (two aspherical surfaces on a single element)."
     },
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/18-mm-128-color-skopar/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/18-mm-128-color-skopar/?lang=en"
     },
     "translations": {
@@ -12663,6 +12664,7 @@
     },
     "fieldNotes": {},
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/23-mm-11-2-nokton/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/23-mm-11-2-nokton/?lang=en"
     },
     "translations": {
@@ -12739,6 +12741,7 @@
     },
     "fieldNotes": {},
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/27-mm-12-0-nokton/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/27-mm-12-0-nokton/?lang=en"
     },
     "translations": {
@@ -12816,6 +12819,7 @@
       "lensConfiguration": "Includes 1 GA (Ground Aspherical) element made of high-refractive-index glass — this single element is counted both as aspherical and as high-refractive."
     },
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/35mm-109-nokton/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/35mm-109-nokton/?lang=en"
     },
     "translations": {
@@ -12892,6 +12896,7 @@
     },
     "fieldNotes": {},
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/35-mm-11-2-nokton/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/35-mm-11-2-nokton/?lang=en"
     },
     "translations": {
@@ -12974,6 +12979,7 @@
       "lensConfiguration": "Includes 3 abnormal-partial-dispersion elements forming the apochromatic (APO) design; Voigtländer does not market these as 'ED'."
     },
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/35-mm-12-macro-apo-ultron/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/35-mm-12-macro-apo-ultron/?lang=en"
     },
     "translations": {
@@ -13050,6 +13056,7 @@
     },
     "fieldNotes": {},
     "officialLinks": {
+      "cn": "https://www.voigtlaender.de/lenses/x-mount/50mm-11-2-nokton/?lang=en",
       "global": "https://www.voigtlaender.de/lenses/x-mount/50mm-11-2-nokton/?lang=en"
     },
     "translations": {

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.18",
-  "lastUpdated": "2026-05-18T12:22:05.291Z",
+  "lastUpdated": "2026-05-18T12:34:34.312Z",
   "lensCount": 196,
-  "buildNumber": 5
+  "buildNumber": 6
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.18` build 6
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`