### PR TITLE
fix(filters): order optical-trait chips by canonical sequence

### DIFF
--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -16,7 +16,7 @@ import {
   type SortKey,
 } from "@/lib/lens";
 import { deriveSpecialty } from "@/lib/lens-specialty";
-import type { OpticalTrait } from "@/lib/types";
+import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useMountedCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
@@ -53,9 +53,12 @@ export default function LensListClient({ lenses }: Props) {
   const brands = useMemo(() => getOrderedUniqueBrands(lenses), [lenses]);
 
   const availableOpticalTraits = useMemo<OpticalTrait[]>(
-    () => [
-      ...new Set(lenses.flatMap((l) => deriveSpecialty(l).opticalTraits)),
-    ],
+    () => {
+      const present = new Set(
+        lenses.flatMap((l) => deriveSpecialty(l).opticalTraits),
+      );
+      return OPTICAL_TRAITS.filter((trait) => present.has(trait));
+    },
     [lenses],
   );
 


### PR DESCRIPTION
## Summary
- Optical-trait filter chips were ordered by which lens encountered each trait first (via `Set` over `flatMap`), which could interleave Tilt and Shift with unrelated traits like Fisheye/Probe.
- Filter the canonical `OPTICAL_TRAITS` tuple instead, so the chip order is data-independent and related traits (e.g. 移轴 Tilt / 移轴 Shift) stay adjacent.

## Test plan
- [x] Verify chip order on `/zh/lenses/x` 光学特性 row: 微距 → 移轴 Tilt → 移轴 Shift → 鱼眼

🤖 Generated with [Claude Code](https://claude.com/claude-code)