### PR TITLE
fix(ui): Sort restructure, action button height, Focal Range label

### DIFF
--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -141,7 +141,7 @@ export default function LensListClient({ lenses }: Props) {
                   <SelectTrigger
                     id="results-sort"
                     hideChevronOnMobile
-                    className="h-9 justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 pl-3 pr-3 text-[12px] shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[12rem]"
+                    className="justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 px-3 text-[12px] shadow-sm shadow-zinc-950/[0.02] data-[size=default]:h-9 dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[12rem]"
                   >
                     <span className="whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
                       {t("sortBy")}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -127,13 +127,7 @@ export default function LensListClient({ lenses }: Props) {
                 ) : null}
               </div>
 
-              <div className="ml-auto inline-flex items-center gap-0.5 rounded-xl border border-zinc-200/70 bg-white/80 p-0.75 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30">
-                <label
-                  htmlFor="results-sort"
-                  className="whitespace-nowrap pl-2.5 text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400"
-                >
-                  {t("sortBy")}
-                </label>
+              <div className="relative ml-auto inline-flex items-center">
                 <Select
                   value={filters.sort}
                   onValueChange={(value) =>
@@ -146,16 +140,17 @@ export default function LensListClient({ lenses }: Props) {
                 >
                   <SelectTrigger
                     id="results-sort"
-                    size="sm"
                     hideChevronOnMobile
-                    className="rounded-lg border-transparent bg-transparent px-2.5 text-[12px] shadow-none dark:bg-transparent sm:min-w-[7.75rem]"
+                    className="h-9 justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 pl-3 pr-10 text-[12px] shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[14rem]"
                   >
+                    <span className="whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
+                      {t("sortBy")}
+                    </span>
                     <SelectValue placeholder={t("sortFocalLength")} />
                   </SelectTrigger>
                   <SelectContent
                     align="end"
-                    alignOffset={-39}
-                    className="min-w-[14rem] overflow-hidden rounded-xl"
+                    className="overflow-hidden rounded-xl"
                   >
                     {sortOptions.map((option) => (
                       <SelectItem
@@ -171,7 +166,7 @@ export default function LensListClient({ lenses }: Props) {
                 <Button
                   size="sm"
                   variant="outline"
-                  className="h-7 rounded-lg border-zinc-200/80 bg-zinc-50/80 px-2 dark:border-zinc-700 dark:bg-zinc-800/70"
+                  className="absolute right-1 top-1/2 z-10 h-7 -translate-y-1/2 rounded-lg border-zinc-200/80 bg-zinc-50/80 px-2 dark:border-zinc-700 dark:bg-zinc-800/70"
                   onClick={() =>
                     updateFilters((current) => ({
                       ...current,

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -127,7 +127,7 @@ export default function LensListClient({ lenses }: Props) {
                 ) : null}
               </div>
 
-              <div className="relative ml-auto inline-flex items-center">
+              <div className="ml-auto inline-flex items-center gap-2">
                 <Select
                   value={filters.sort}
                   onValueChange={(value) =>
@@ -141,7 +141,7 @@ export default function LensListClient({ lenses }: Props) {
                   <SelectTrigger
                     id="results-sort"
                     hideChevronOnMobile
-                    className="h-9 justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 pl-3 pr-10 text-[12px] shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[14rem]"
+                    className="h-9 justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 pl-3 pr-3 text-[12px] shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[12rem]"
                   >
                     <span className="whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
                       {t("sortBy")}
@@ -164,9 +164,8 @@ export default function LensListClient({ lenses }: Props) {
                   </SelectContent>
                 </Select>
                 <Button
-                  size="sm"
                   variant="outline"
-                  className="absolute right-1 top-1/2 z-10 h-7 -translate-y-1/2 rounded-lg border-zinc-200/80 bg-zinc-50/80 px-2 dark:border-zinc-700 dark:bg-zinc-800/70"
+                  className="h-9 rounded-xl border-zinc-200/70 bg-white/80 px-2.5 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30"
                   onClick={() =>
                     updateFilters((current) => ({
                       ...current,

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -64,7 +64,6 @@ export default function MountSwitcher() {
       </SelectPrimitive.Trigger>
       <SelectContent
         align="start"
-        sideOffset={6}
         className="w-auto min-w-[8.5rem] overflow-hidden"
       >
         {options.map((opt) => (

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -65,7 +65,7 @@ function SelectContent({
   portalContainer,
   children,
   side = "bottom",
-  sideOffset = 4,
+  sideOffset = 8,
   align = "center",
   alignOffset = 0,
   alignItemWithTrigger = false,

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -14,7 +14,7 @@ export const ACTION_PRIMARY_CLS =
 
 /** Outline / secondary action button (share, external links, supplementary actions). */
 export const ACTION_OUTLINE_CLS =
-  "inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-800";
+  "inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-800";
 
 /** Selected card border + ring (e.g. lens card added to compare). */
 export const CARD_SELECTED_BORDER_CLS =


### PR DESCRIPTION
## Summary

- **Sort: split asc/desc out of the pill as a sibling button.** The pill bundled the sort selector and the direction toggle into one compound control, which forced two unrelated operations to share a container — the source of every recent design wart (chip-in-chip rounding mismatch, ghost-vs-chevron icon ambiguity, mobile alignment offsets, hardcoded popup width). Treat them as what they are: two independent controls. SelectTrigger *is* the pill now; asc/desc is a sibling button with its own border/bg and 8px gap. Popup anchors to the pill on any viewport with no pixel-tuned offsets.
- **Sort: pill and asc/desc heights now match (36px).** SelectTrigger uses data-attribute selectors for size (data-[size=default]:h-8) which outrank a plain h-9 override via CSS specificity; use the same attribute-scoped utility so both controls render at 36px.
- **Popup-trigger breathing room.** SelectContent default sideOffset 4 → 8. At 4px the popup reads as attached to the trigger and the joined rounded corners look like an unintended concave seam; at 8px it reads as a separate floating layer (Material 3 / Linear / Notion convention).
- **Action button height in wrapped row.** On lens detail, share + feedback buttons go icon-only at narrow container widths. When they wrap to a row of their own no tall sibling exists and they render ~6px shorter. Add min-h-9 to ACTION_OUTLINE_CLS so each button guarantees the standard 36px height on its own.
- **Focal Range label fits the column.** 'Focal Range (Equiv.)' overflowed the 96px label slot and slipped behind the 'All' chip. Shorten to 'Focal Range (FF)' — (FF) is the conventional photographer shorthand for full-frame equivalent, preserving the qualifier without bloating the column.

## Test plan

- [ ] /lenses on desktop >=1280px: Sort pill + asc/desc button as separate siblings, equal height, popup edges align with pill
- [ ] /lenses at mobile 390px viewport: Sort popup edges align with pill (was previously offset left)
- [ ] Sort, MountSwitcher, FeedbackDialog field picker: ~8px gap between trigger and popup, no concave seam illusion
- [ ] Lens detail at container width where action buttons wrap to two rows: second-row button matches first-row height
- [ ] /en/lenses with 'More filters' expanded: 'Focal Range (FF)' label fully visible, does not collide with the 'All' chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)