### PR TITLE
fix(i18n): shorten Focal Range label so it fits the label column

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -70,7 +70,7 @@
     "allTypes": "All",
     "primes": "Primes",
     "zooms": "Zooms",
-    "focalRange": "Focal Range (Equiv.)",
+    "focalRange": "Focal Range (FF)",
     "category-ultrawide": "Ultra Wide",
     "category-wide": "Wide",
     "category-standard": "Standard",


### PR DESCRIPTION
## Summary

'Focal Range (Equiv.)' renders at ~120px and overflows the sm:w-24 (96px) label slot in the Focal Range filter row, slipping behind the 'All' chip. Shorten the English string to 'Focal Range (FF)' — (FF) is the conventional photographer shorthand for full-frame equivalent, preserving the qualifier without bloating the column.

## Test plan

- [ ] /en/lenses with 'More filters' expanded: 'Focal Range (FF)' label fully visible, does not collide with the 'All' chip
- [ ] Chinese version unaffected (label was already short enough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)