### PR TITLE
refactor(compare): extract pure reducer, collapse hook, expose dispatch

### DIFF
--- a/src/components/AddToCompareButton.tsx
+++ b/src/components/AddToCompareButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
 
 interface Props {
@@ -10,7 +10,7 @@ interface Props {
 
 export default function AddToCompareButton({ lensId }: Props) {
   const t = useTranslations("LensDetail");
-  const { compareIds, toggleCompare, canToggle } = useMountedCompare();
+  const { compareIds, toggleCompare, canToggle } = useCompare();
 
   const isSelected = compareIds.includes(lensId);
   const isFull = !isSelected && !canToggle(lensId);

--- a/src/components/AddToCompareButton.tsx
+++ b/src/components/AddToCompareButton.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useCompare } from "@/context/CompareProvider";
+import { MAX_COMPARE } from "@/lib/lens";
 import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
 
 interface Props {
@@ -10,14 +11,14 @@ interface Props {
 
 export default function AddToCompareButton({ lensId }: Props) {
   const t = useTranslations("LensDetail");
-  const { compareIds, toggleCompare, canToggle } = useCompare();
+  const { compareIds, toggle } = useCompare();
 
   const isSelected = compareIds.includes(lensId);
-  const isFull = !isSelected && !canToggle(lensId);
+  const isFull = !isSelected && compareIds.length >= MAX_COMPARE;
 
   return (
     <button
-      onClick={() => toggleCompare(lensId)}
+      onClick={() => toggle(lensId)}
       disabled={isFull}
       className={`inline-flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg transition-colors ${
         isSelected

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { MAX_COMPARE } from "@/lib/lens";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import type { Lens } from "@/lib/types";
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 
 export default function CompareAddLensButton({ triggerClassName }: Props) {
   const t = useTranslations("Compare");
-  const { compareIds, addToCompare } = useMountedCompare();
+  const { compareIds, addToCompare } = useCompare();
 
   const canAddMore = compareIds.length < MAX_COMPARE;
 

--- a/src/components/CompareAddLensButton.tsx
+++ b/src/components/CompareAddLensButton.tsx
@@ -14,16 +14,11 @@ interface Props {
 
 export default function CompareAddLensButton({ triggerClassName }: Props) {
   const t = useTranslations("Compare");
-  const { compareIds, addToCompare } = useCompare();
+  const { compareIds, add } = useCompare();
 
   const canAddMore = compareIds.length < MAX_COMPARE;
 
-  const handleSelectLens = useCallback(
-    (lens: Lens) => {
-      addToCompare(lens.id);
-    },
-    [addToCompare]
-  );
+  const handleSelectLens = (lens: Lens) => add(lens.id);
 
   const getResultState = useCallback(
     (candidate: Lens) => ({

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -4,7 +4,7 @@ import { useMemo, useRef, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { getLensesByMount } from "@/lib/lens";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { useClearCompareWithUndo } from "@/hooks/useClearCompareWithUndo";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { buildHorizontalScrollMask, useHorizontalScrollAffordance } from "@/hooks/useHorizontalScrollAffordance";
@@ -28,7 +28,7 @@ export default function CompareBar() {
   const router = useRouter();
   const locale = useLocale();
   const mount = useEffectiveMount();
-  const { compareIds, toggleCompare, addToCompare } = useMountedCompare();
+  const { compareIds, toggleCompare, addToCompare } = useCompare();
   const clearCompareWithUndo = useClearCompareWithUndo();
 
   const handleAddLens = useCallback(

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -28,15 +28,10 @@ export default function CompareBar() {
   const router = useRouter();
   const locale = useLocale();
   const mount = useEffectiveMount();
-  const { compareIds, toggleCompare, addToCompare } = useCompare();
+  const { compareIds, add, remove } = useCompare();
   const clearCompareWithUndo = useClearCompareWithUndo();
 
-  const handleAddLens = useCallback(
-    (lens: Lens) => {
-      addToCompare(lens.id);
-    },
-    [addToCompare]
-  );
+  const handleAddLens = (lens: Lens) => add(lens.id);
 
   const getAddResultState = useCallback(
     (candidate: Lens) => ({
@@ -136,7 +131,7 @@ export default function CompareBar() {
                         </span>
                       </span>
                       <button
-                        onClick={() => toggleCompare(lens.id)}
+                        onClick={() => remove(lens.id)}
                         // Visual size stays compact so the chip itself reads as
                         // the lens identity, but the touch target expands via
                         // a transparent `::before` overlay to ~36px — well

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -5,7 +5,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { ShareButton } from "@/components/share/ShareButton";
 import ShareFAB from "@/components/ShareFAB";
 import CompareAddLensButton from "@/components/CompareAddLensButton";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { useClearCompareWithUndo } from "@/hooks/useClearCompareWithUndo";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { getLensesByMount } from "@/lib/lens";
@@ -21,7 +21,7 @@ interface Props {
 export default function ComparePageHeader({ minColumns = 0 }: Props) {
   const t = useTranslations("Compare");
   const tList = useTranslations("LensList");
-  const { compareIds } = useMountedCompare();
+  const { compareIds } = useCompare();
   const clearCompareWithUndo = useClearCompareWithUndo();
   const mount = useEffectiveMount();
   const locale = useLocale();

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -21,7 +21,7 @@ import SpecialtyBadges from "@/components/SpecialtyBadges";
 import { deriveSpecialty } from "@/lib/lens-specialty";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 import type { FeedbackField } from "@/components/FeedbackDialog";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { useCompareUrlSync } from "@/hooks/useCompareUrlSync";
 import { getLensesByMount, getLensUrl, MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
@@ -300,7 +300,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const priceFieldLabel = tPricing("fieldLabel");
   const priceGroupLabel = tPricing("groupLabel");
   const { compareIds, addToCompare, removeFromCompare, reorderCompare, seedCompare } =
-    useMountedCompare();
+    useCompare();
   // Compare page is the only surface that projects compare state onto the
   // URL. This hook owns that projection so individual write callsites no
   // longer need to know about address-bar bookkeeping.

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -299,8 +299,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const locale = useLocale();
   const priceFieldLabel = tPricing("fieldLabel");
   const priceGroupLabel = tPricing("groupLabel");
-  const { compareIds, addToCompare, removeFromCompare, reorderCompare, seedCompare } =
-    useCompare();
+  const { compareIds, dispatch, add, remove } = useCompare();
   // Compare page is the only surface that projects compare state onto the
   // URL. This hook owns that projection so individual write callsites no
   // longer need to know about address-bar bookkeeping.
@@ -324,8 +323,8 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   // preset link click that re-renders the server component with new
   // searchParams).
   useLayoutEffect(() => {
-    seedCompare(initialLensIds);
-  }, [initialLensIds, seedCompare]);
+    dispatch({ type: "seed", ids: initialLensIds });
+  }, [initialLensIds, dispatch]);
 
   const orderedLenses = compareIds
     .map((id) => getLensesByMount(mount, locale).find((lens) => lens.id === id))
@@ -334,12 +333,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   // Number of empty slot columns to render (search triggers filling up to minColumns)
   const emptySlotCount = Math.max(0, minColumns - orderedLenses.length);
 
-  const handleAddLens = useCallback(
-    (lens: Lens) => {
-      addToCompare(lens.id);
-    },
-    [addToCompare]
-  );
+  const handleAddLens = (lens: Lens) => add(lens.id);
 
   const getAddResultState = useCallback(
     (candidate: Lens) => ({
@@ -363,7 +357,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   };
 
   function handleRemoveLens(lensId: string) {
-    removeFromCompare(lensId);
+    remove(lensId);
   }
 
   function handleShiftLens(lensId: string, direction: -1 | 1) {
@@ -374,7 +368,7 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
     }
     const next = [...compareIds];
     [next[index], next[newIndex]] = [next[newIndex], next[index]];
-    reorderCompare(next);
+    dispatch({ type: "reorder", ids: next });
   }
 
   const allGroups = useMemo(

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -5,7 +5,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { useCompareUrl } from "@/hooks/useCompareUrl";
 import { buildHorizontalScrollMask, useHorizontalScrollAffordance } from "@/hooks/useHorizontalScrollAffordance";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { curatedPresets, type CuratedPreset } from "@/lib/curated-presets";
 import { getAllLenses } from "@/lib/lens";
 import { lensDisplayName } from "@/lib/lens.format";
@@ -69,7 +69,7 @@ export function PresetCard({ preset, onSelect }: { preset: CuratedPreset; onSele
 }
 
 export default function CuratedComparisons() {
-  const { compareIds } = useMountedCompare();
+  const { compareIds } = useCompare();
   const t = useTranslations("Compare");
   const scrollRef = useRef<HTMLDivElement>(null);
   const { canScrollLeft, canScrollRight } = useHorizontalScrollAffordance(scrollRef);

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -12,6 +12,7 @@ import {
   sortLenses,
   defaultFilters,
   getOrderedUniqueBrands,
+  MAX_COMPARE,
   type FilterState,
   type SortKey,
 } from "@/lib/lens";
@@ -48,7 +49,7 @@ export default function LensListClient({ lenses }: Props) {
   const pathname = usePathname();
 
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
-  const { compareIds, toggleCompare, canToggle } = useCompare();
+  const { compareIds, toggle } = useCompare();
 
   const brands = useMemo(() => getOrderedUniqueBrands(lenses), [lenses]);
 
@@ -231,8 +232,11 @@ export default function LensListClient({ lenses }: Props) {
                   key={lens.id}
                   lens={lens}
                   isSelected={compareIds.includes(lens.id)}
-                  selectionDisabled={!canToggle(lens.id)}
-                  onToggle={() => toggleCompare(lens.id)}
+                  selectionDisabled={
+                    !compareIds.includes(lens.id) &&
+                    compareIds.length >= MAX_COMPARE
+                  }
+                  onToggle={() => toggle(lens.id)}
                   priority={i < 8}
                 />
               ))}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -18,7 +18,7 @@ import {
 import { deriveSpecialty } from "@/lib/lens-specialty";
 import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
 import { Z } from "@/config/ui";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
@@ -48,7 +48,7 @@ export default function LensListClient({ lenses }: Props) {
   const pathname = usePathname();
 
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
-  const { compareIds, toggleCompare, canToggle } = useMountedCompare();
+  const { compareIds, toggleCompare, canToggle } = useCompare();
 
   const brands = useMemo(() => getOrderedUniqueBrands(lenses), [lenses]);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -20,7 +20,7 @@ import GitHubMark from "@/components/logos/GitHubMark";
 export default function Nav() {
   const t = useTranslations("Nav");
   const pathname = usePathname();
-  const { compareState } = useCompare();
+  const { compareIds } = useCompare();
   const clearCompareWithUndo = useClearCompareWithUndo();
   const effectiveMount = useEffectiveMount();
   const { navLocked, lockNav } = useNavLock();
@@ -78,7 +78,6 @@ export default function Nav() {
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [mobileMenuOpen]);
 
-  const compareIds = compareState[effectiveMount];
   const seg = mountToUrlSegment(effectiveMount);
   const browseHref = `/lenses/${seg}`;
   const compareHref = compareIds.length > 0

--- a/src/context/CompareProvider.tsx
+++ b/src/context/CompareProvider.tsx
@@ -6,170 +6,159 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
-  useState,
 } from "react";
+import {
+  compareReducer,
+  initialCompareState,
+  type CompareState,
+} from "@/lib/compareReducer";
 import { MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { track } from "@/lib/analytics";
 import type { Mount } from "@/lib/types";
 
-type CompareState = { X: string[]; G: string[] };
-
 interface CompareContextValue {
-  compareState: CompareState;
-  // User-initiated add. Fires `compare_add` exactly once per successful add.
-  // No-ops (and emits no event) when the id is already in the slot or the
-  // slot is at MAX_COMPARE.
+  state: CompareState;
   addToCompare: (id: string, mount: Mount) => void;
-  // User-initiated remove. No-op when the id isn't in the slot.
   removeFromCompare: (id: string, mount: Mount) => void;
-  // Convenience wrapper. Routes to addToCompare or removeFromCompare based
-  // on current membership, so the call site doesn't need to know.
   toggleCompare: (id: string, mount: Mount) => void;
-  // User-initiated reorder (no membership change). Emits no event.
   reorderCompare: (ids: string[], mount: Mount) => void;
   clearCompare: (mount: Mount) => void;
-  // Non-user state transition: URL hydration (shared compare links) and
-  // undo-restore both use this. Distinguished from addToCompare so that
-  // analytics counts user clicks only, not state arriving from outside.
   seedCompare: (ids: string[], mount: Mount) => void;
-  canToggle: (id: string, mount: Mount) => boolean;
 }
 
 const CompareContext = createContext<CompareContextValue | null>(null);
 
 export function CompareProvider({ children }: { children: React.ReactNode }) {
-  const [compareState, setCompareState] = useState<CompareState>({ X: [], G: [] });
-  // Mirror state into a ref so `toggleCompare` can read the latest value
-  // without re-creating the callback on every state change. User event
-  // handlers always run after effects flush, so the ref is up-to-date by
-  // the time toggleCompare reads it.
-  const stateRef = useRef(compareState);
+  const [state, dispatch] = useReducer(compareReducer, initialCompareState);
+
+  // Mutators are invoked from onClick / event handlers, which rules out
+  // useEffectEvent (that hook is restricted to Effects). The classic
+  // ref-sync pattern is the supported way to read latest state inside a
+  // stable event-handler callback.
+  const stateRef = useRef(state);
   useEffect(() => {
-    stateRef.current = compareState;
-  }, [compareState]);
+    stateRef.current = state;
+  }, [state]);
 
   const addToCompare = useCallback((id: string, mount: Mount) => {
-    let didAdd = false;
-    setCompareState((prev) => {
-      const slot = prev[mount];
-      if (slot.includes(id) || slot.length >= MAX_COMPARE) {
-        return prev;
-      }
-      didAdd = true;
-      return { ...prev, [mount]: [...slot, id] };
-    });
-    if (didAdd) {
+    const slot = stateRef.current[mount];
+    if (slot.includes(id) || slot.length >= MAX_COMPARE) return;
+    dispatch({ type: "add", id, mount });
+    track("compare_add", { lens_slug: id });
+  }, []);
+
+  const removeFromCompare = useCallback((id: string, mount: Mount) => {
+    dispatch({ type: "remove", id, mount });
+  }, []);
+
+  const toggleCompare = useCallback((id: string, mount: Mount) => {
+    const slot = stateRef.current[mount];
+    if (slot.includes(id)) {
+      dispatch({ type: "remove", id, mount });
+    } else if (slot.length < MAX_COMPARE) {
+      dispatch({ type: "add", id, mount });
       track("compare_add", { lens_slug: id });
     }
   }, []);
 
-  const removeFromCompare = useCallback((id: string, mount: Mount) => {
-    setCompareState((prev) => {
-      const slot = prev[mount];
-      if (!slot.includes(id)) {
-        return prev;
-      }
-      return { ...prev, [mount]: slot.filter((x) => x !== id) };
-    });
-  }, []);
-
-  const toggleCompare = useCallback(
-    (id: string, mount: Mount) => {
-      if (stateRef.current[mount].includes(id)) {
-        removeFromCompare(id, mount);
-      } else {
-        addToCompare(id, mount);
-      }
-    },
-    [addToCompare, removeFromCompare],
-  );
-
   const reorderCompare = useCallback((ids: string[], mount: Mount) => {
-    setCompareState((prev) => {
-      const slot = prev[mount];
-      if (slot.length === ids.length && slot.every((id, i) => id === ids[i])) {
-        return prev;
-      }
-      return { ...prev, [mount]: ids };
-    });
+    dispatch({ type: "reorder", ids, mount });
   }, []);
 
   const clearCompare = useCallback((mount: Mount) => {
-    setCompareState((prev) => ({ ...prev, [mount]: [] }));
+    dispatch({ type: "clear", mount });
   }, []);
 
   const seedCompare = useCallback((ids: string[], mount: Mount) => {
-    const nextIds = Array.from(new Set(ids)).slice(0, MAX_COMPARE);
-    setCompareState((prev) => {
-      const slot = prev[mount];
-      if (slot.length === nextIds.length && slot.every((id, i) => id === nextIds[i])) {
-        return prev;
-      }
-      return { ...prev, [mount]: nextIds };
-    });
+    dispatch({ type: "seed", ids, mount });
   }, []);
 
-  // canToggle reads compareState directly; using a state ref keeps the function
-  // reference stable across state changes so that consumers (and any useEffect
-  // that depends on it) don't re-run on every mutation.
-  const canToggle = useCallback(
-    (id: string, mount: Mount) => {
-      const slot = compareState[mount];
-      return slot.includes(id) || slot.length < MAX_COMPARE;
-    },
-    [compareState],
-  );
-
-  const value = useMemo(
+  // All mutators are useCallback-stable (deps=[]). Only `state` drives
+  // identity changes of the value object.
+  const value = useMemo<CompareContextValue>(
     () => ({
-      compareState,
+      state,
       addToCompare,
       removeFromCompare,
       toggleCompare,
       reorderCompare,
       clearCompare,
       seedCompare,
-      canToggle,
     }),
     [
-      compareState,
+      state,
       addToCompare,
       removeFromCompare,
       toggleCompare,
       reorderCompare,
       clearCompare,
       seedCompare,
-      canToggle,
     ],
   );
 
   return <CompareContext value={value}>{children}</CompareContext>;
 }
 
+/**
+ * Mount-scoped compare hook. No unscoped variant — every compare surface
+ * lives under `/[locale]/lenses/[mount]/...`, so the URL always supplies
+ * the mount and cross-mount writes are not a real scenario.
+ *
+ * Returned mutators auto-bind to the current mount; reference-stable per
+ * mount, so consumers that put them in useEffect deps don't re-run on
+ * state changes.
+ */
 export function useCompare() {
   const ctx = useContext(CompareContext);
   if (!ctx) {
     throw new Error("useCompare must be used within CompareProvider");
   }
-  return ctx;
-}
-
-// Mount-scoped hook for components inside /lenses/[mount]/...
-// Automatically reads the current mount from URL params.
-//
-// The returned function references are stable across state changes — they
-// only depend on the underlying provider callbacks (which are themselves
-// useCallback-stable) and the current mount. This stability matters because
-// any useEffect with these in its dep array would otherwise re-run after
-// every Context state change, which can clobber state seeded by the effect
-// itself (e.g. seeding compareState from an `initialLensIds` prop).
-export function useMountedCompare() {
-  const ctx = useCompare();
   const mount = useEffectiveMount();
+  const compareIds = ctx.state[mount];
+
+  // Destructure first so deps reference the stable inner mutators, not the
+  // ctx object whose identity changes on every state mutation.
   const {
-    compareState,
+    addToCompare: ctxAdd,
+    removeFromCompare: ctxRemove,
+    toggleCompare: ctxToggle,
+    reorderCompare: ctxReorder,
+    clearCompare: ctxClear,
+    seedCompare: ctxSeed,
+  } = ctx;
+
+  const addToCompare = useCallback(
+    (id: string) => ctxAdd(id, mount),
+    [ctxAdd, mount],
+  );
+  const removeFromCompare = useCallback(
+    (id: string) => ctxRemove(id, mount),
+    [ctxRemove, mount],
+  );
+  const toggleCompare = useCallback(
+    (id: string) => ctxToggle(id, mount),
+    [ctxToggle, mount],
+  );
+  const reorderCompare = useCallback(
+    (ids: string[]) => ctxReorder(ids, mount),
+    [ctxReorder, mount],
+  );
+  const clearCompare = useCallback(() => ctxClear(mount), [ctxClear, mount]);
+  const seedCompare = useCallback(
+    (ids: string[]) => ctxSeed(ids, mount),
+    [ctxSeed, mount],
+  );
+
+  // canToggle is derived state, recomputed each render — used in render
+  // output only, not in any effect dep.
+  const canToggle = (id: string) =>
+    compareIds.includes(id) || compareIds.length < MAX_COMPARE;
+
+  return {
+    compareIds,
     addToCompare,
     removeFromCompare,
     toggleCompare,
@@ -177,44 +166,5 @@ export function useMountedCompare() {
     clearCompare,
     seedCompare,
     canToggle,
-  } = ctx;
-
-  const compareIds = compareState[mount];
-
-  const addScoped = useCallback((id: string) => addToCompare(id, mount), [addToCompare, mount]);
-  const removeScoped = useCallback(
-    (id: string) => removeFromCompare(id, mount),
-    [removeFromCompare, mount],
-  );
-  const toggleScoped = useCallback((id: string) => toggleCompare(id, mount), [toggleCompare, mount]);
-  const reorderScoped = useCallback(
-    (ids: string[]) => reorderCompare(ids, mount),
-    [reorderCompare, mount],
-  );
-  const clearScoped = useCallback(() => clearCompare(mount), [clearCompare, mount]);
-  const seedScoped = useCallback((ids: string[]) => seedCompare(ids, mount), [seedCompare, mount]);
-  const canToggleScoped = useCallback((id: string) => canToggle(id, mount), [canToggle, mount]);
-
-  return useMemo(
-    () => ({
-      compareIds,
-      addToCompare: addScoped,
-      removeFromCompare: removeScoped,
-      toggleCompare: toggleScoped,
-      reorderCompare: reorderScoped,
-      clearCompare: clearScoped,
-      seedCompare: seedScoped,
-      canToggle: canToggleScoped,
-    }),
-    [
-      compareIds,
-      addScoped,
-      removeScoped,
-      toggleScoped,
-      reorderScoped,
-      clearScoped,
-      seedScoped,
-      canToggleScoped,
-    ],
-  );
+  };
 }

--- a/src/context/CompareProvider.tsx
+++ b/src/context/CompareProvider.tsx
@@ -4,112 +4,49 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useReducer,
-  useRef,
 } from "react";
 import {
   compareReducer,
   initialCompareState,
+  type CompareAction,
   type CompareState,
+  type ScopedCompareAction,
 } from "@/lib/compareReducer";
 import { MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { track } from "@/lib/analytics";
-import type { Mount } from "@/lib/types";
 
 interface CompareContextValue {
   state: CompareState;
-  addToCompare: (id: string, mount: Mount) => void;
-  removeFromCompare: (id: string, mount: Mount) => void;
-  toggleCompare: (id: string, mount: Mount) => void;
-  reorderCompare: (ids: string[], mount: Mount) => void;
-  clearCompare: (mount: Mount) => void;
-  seedCompare: (ids: string[], mount: Mount) => void;
+  dispatch: (action: CompareAction) => void;
 }
 
 const CompareContext = createContext<CompareContextValue | null>(null);
 
 export function CompareProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(compareReducer, initialCompareState);
-
-  // Mutators are invoked from onClick / event handlers, which rules out
-  // useEffectEvent (that hook is restricted to Effects). The classic
-  // ref-sync pattern is the supported way to read latest state inside a
-  // stable event-handler callback.
-  const stateRef = useRef(state);
-  useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
-
-  const addToCompare = useCallback((id: string, mount: Mount) => {
-    const slot = stateRef.current[mount];
-    if (slot.includes(id) || slot.length >= MAX_COMPARE) return;
-    dispatch({ type: "add", id, mount });
-    track("compare_add", { lens_slug: id });
-  }, []);
-
-  const removeFromCompare = useCallback((id: string, mount: Mount) => {
-    dispatch({ type: "remove", id, mount });
-  }, []);
-
-  const toggleCompare = useCallback((id: string, mount: Mount) => {
-    const slot = stateRef.current[mount];
-    if (slot.includes(id)) {
-      dispatch({ type: "remove", id, mount });
-    } else if (slot.length < MAX_COMPARE) {
-      dispatch({ type: "add", id, mount });
-      track("compare_add", { lens_slug: id });
-    }
-  }, []);
-
-  const reorderCompare = useCallback((ids: string[], mount: Mount) => {
-    dispatch({ type: "reorder", ids, mount });
-  }, []);
-
-  const clearCompare = useCallback((mount: Mount) => {
-    dispatch({ type: "clear", mount });
-  }, []);
-
-  const seedCompare = useCallback((ids: string[], mount: Mount) => {
-    dispatch({ type: "seed", ids, mount });
-  }, []);
-
-  // All mutators are useCallback-stable (deps=[]). Only `state` drives
-  // identity changes of the value object.
-  const value = useMemo<CompareContextValue>(
-    () => ({
-      state,
-      addToCompare,
-      removeFromCompare,
-      toggleCompare,
-      reorderCompare,
-      clearCompare,
-      seedCompare,
-    }),
-    [
-      state,
-      addToCompare,
-      removeFromCompare,
-      toggleCompare,
-      reorderCompare,
-      clearCompare,
-      seedCompare,
-    ],
-  );
-
+  // dispatch from useReducer is reference-stable by contract; only state
+  // identity drives value changes here.
+  const value = useMemo(() => ({ state, dispatch }), [state]);
   return <CompareContext value={value}>{children}</CompareContext>;
 }
 
 /**
- * Mount-scoped compare hook. No unscoped variant — every compare surface
- * lives under `/[locale]/lenses/[mount]/...`, so the URL always supplies
- * the mount and cross-mount writes are not a real scenario.
+ * Mount-scoped compare hook — the only public API.
  *
- * Returned mutators auto-bind to the current mount; reference-stable per
- * mount, so consumers that put them in useEffect deps don't re-run on
- * state changes.
+ * Returns the current mount's id list plus a mount-injecting `dispatch`,
+ * and three high-level helpers (`add`, `remove`, `toggle`) that bundle the
+ * "read state → dispatch + analytics" pattern so consumers don't repeat it.
+ *
+ * Helpers live here, not in the Provider, so the per-render closure can
+ * read latest state directly — no ref-sync gymnastics, and the Provider
+ * stays a pure state machine.
+ *
+ * Use `dispatch` directly for the lower-frequency actions (`reorder`,
+ * `clear`, `seed`) — they have no analytics gate and no state-dependent
+ * branching, so a dedicated helper would just be a typed alias.
  */
 export function useCompare() {
   const ctx = useContext(CompareContext);
@@ -117,54 +54,46 @@ export function useCompare() {
     throw new Error("useCompare must be used within CompareProvider");
   }
   const mount = useEffectiveMount();
-  const compareIds = ctx.state[mount];
+  const { state, dispatch: rawDispatch } = ctx;
+  const compareIds = state[mount];
 
-  // Destructure first so deps reference the stable inner mutators, not the
-  // ctx object whose identity changes on every state mutation.
-  const {
-    addToCompare: ctxAdd,
-    removeFromCompare: ctxRemove,
-    toggleCompare: ctxToggle,
-    reorderCompare: ctxReorder,
-    clearCompare: ctxClear,
-    seedCompare: ctxSeed,
-  } = ctx;
-
-  const addToCompare = useCallback(
-    (id: string) => ctxAdd(id, mount),
-    [ctxAdd, mount],
-  );
-  const removeFromCompare = useCallback(
-    (id: string) => ctxRemove(id, mount),
-    [ctxRemove, mount],
-  );
-  const toggleCompare = useCallback(
-    (id: string) => ctxToggle(id, mount),
-    [ctxToggle, mount],
-  );
-  const reorderCompare = useCallback(
-    (ids: string[]) => ctxReorder(ids, mount),
-    [ctxReorder, mount],
-  );
-  const clearCompare = useCallback(() => ctxClear(mount), [ctxClear, mount]);
-  const seedCompare = useCallback(
-    (ids: string[]) => ctxSeed(ids, mount),
-    [ctxSeed, mount],
+  // Stable per mount: useReducer's dispatch is reference-stable, mount only
+  // changes on URL navigation. Safe to put in useEffect deps without
+  // triggering re-runs on state mutations.
+  const dispatch = useCallback(
+    (action: ScopedCompareAction) =>
+      rawDispatch({ ...action, mount } as CompareAction),
+    [rawDispatch, mount],
   );
 
-  // canToggle is derived state, recomputed each render — used in render
-  // output only, not in any effect dep.
-  const canToggle = (id: string) =>
-    compareIds.includes(id) || compareIds.length < MAX_COMPARE;
+  // Helpers carry `compareIds` in their deps so they re-read latest state
+  // each render. Identity changes on every mutation — fine for event-handler
+  // usage (onClick), don't put these in useEffect deps.
+  const add = useCallback(
+    (id: string) => {
+      if (compareIds.includes(id) || compareIds.length >= MAX_COMPARE) return;
+      dispatch({ type: "add", id });
+      track("compare_add", { lens_slug: id });
+    },
+    [compareIds, dispatch],
+  );
 
-  return {
-    compareIds,
-    addToCompare,
-    removeFromCompare,
-    toggleCompare,
-    reorderCompare,
-    clearCompare,
-    seedCompare,
-    canToggle,
-  };
+  const remove = useCallback(
+    (id: string) => dispatch({ type: "remove", id }),
+    [dispatch],
+  );
+
+  const toggle = useCallback(
+    (id: string) => {
+      if (compareIds.includes(id)) {
+        dispatch({ type: "remove", id });
+      } else if (compareIds.length < MAX_COMPARE) {
+        dispatch({ type: "add", id });
+        track("compare_add", { lens_slug: id });
+      }
+    },
+    [compareIds, dispatch],
+  );
+
+  return { compareIds, dispatch, add, remove, toggle };
 }

--- a/src/hooks/useClearCompareWithUndo.ts
+++ b/src/hooks/useClearCompareWithUndo.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 
 /**
  * Wraps `clearCompare` with an undo affordance: snapshots the current
@@ -23,7 +23,7 @@ import { useMountedCompare } from "@/context/CompareProvider";
  */
 export function useClearCompareWithUndo() {
   const tCompare = useTranslations("Compare");
-  const { compareIds, clearCompare, seedCompare } = useMountedCompare();
+  const { compareIds, clearCompare, seedCompare } = useCompare();
 
   return useCallback(() => {
     if (compareIds.length === 0) {

--- a/src/hooks/useClearCompareWithUndo.ts
+++ b/src/hooks/useClearCompareWithUndo.ts
@@ -6,36 +6,36 @@ import { useTranslations } from "next-intl";
 import { useCompare } from "@/context/CompareProvider";
 
 /**
- * Wraps `clearCompare` with an undo affordance: snapshots the current
- * compareIds, clears them, then surfaces a sonner toast whose action
- * restores the snapshot via `seedCompare` (not `addToCompare` — those
- * lenses were already tracked when first added; re-counting them on
- * undo would double-fire the `compare_add` event).
+ * Wraps the clear action with an undo affordance: snapshots the current
+ * compareIds, dispatches clear, then surfaces a sonner toast whose action
+ * restores the snapshot via a `seed` action (not `add` — those lenses were
+ * already tracked when first added; re-counting them on undo would double-
+ * fire the `compare_add` event).
  *
- * No-ops when `compareIds` is empty so callers don't need to
- * pre-check before invoking.
+ * No-ops when `compareIds` is empty so callers don't need to pre-check
+ * before invoking.
  *
  * The toast fires synchronously alongside the clear — the mobile
- * `AppToaster` is configured with a fixed bottom offset that sits
- * above the compare bar's resting position, so the two animations
- * (bar exiting downward, toast entering from below into a row above
- * where the bar was) don't share viewport real estate.
+ * `AppToaster` is configured with a fixed bottom offset that sits above
+ * the compare bar's resting position, so the two animations (bar exiting
+ * downward, toast entering from below into a row above where the bar was)
+ * don't share viewport real estate.
  */
 export function useClearCompareWithUndo() {
   const tCompare = useTranslations("Compare");
-  const { compareIds, clearCompare, seedCompare } = useCompare();
+  const { compareIds, dispatch } = useCompare();
 
   return useCallback(() => {
     if (compareIds.length === 0) {
       return;
     }
     const prevIds = [...compareIds];
-    clearCompare();
+    dispatch({ type: "clear" });
     toast(tCompare("clearedToast"), {
       action: {
         label: tCompare("undo"),
-        onClick: () => seedCompare(prevIds),
+        onClick: () => dispatch({ type: "seed", ids: prevIds }),
       },
     });
-  }, [compareIds, clearCompare, seedCompare, tCompare]);
+  }, [compareIds, dispatch, tCompare]);
 }

--- a/src/hooks/useCompareUrlSync.ts
+++ b/src/hooks/useCompareUrlSync.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useLocale } from "next-intl";
-import { useMountedCompare } from "@/context/CompareProvider";
+import { useCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { mountToUrlSegment } from "@/lib/mount";
 
@@ -32,7 +32,7 @@ import { mountToUrlSegment } from "@/lib/mount";
  * via `useLayoutEffect` moments later.
  */
 export function useCompareUrlSync() {
-  const { compareIds } = useMountedCompare();
+  const { compareIds } = useCompare();
   const mount = useEffectiveMount();
   const locale = useLocale();
 

--- a/src/lib/compareReducer.ts
+++ b/src/lib/compareReducer.ts
@@ -1,0 +1,54 @@
+import { MAX_COMPARE } from "./lens";
+import type { Mount } from "./types";
+
+export type CompareState = { X: string[]; G: string[] };
+
+export type CompareAction =
+  | { type: "add"; id: string; mount: Mount }
+  | { type: "remove"; id: string; mount: Mount }
+  | { type: "reorder"; ids: string[]; mount: Mount }
+  | { type: "clear"; mount: Mount }
+  | { type: "seed"; ids: string[]; mount: Mount };
+
+export const initialCompareState: CompareState = { X: [], G: [] };
+
+export function compareReducer(
+  state: CompareState,
+  action: CompareAction,
+): CompareState {
+  switch (action.type) {
+    case "add": {
+      const slot = state[action.mount];
+      if (slot.includes(action.id) || slot.length >= MAX_COMPARE) return state;
+      return { ...state, [action.mount]: [...slot, action.id] };
+    }
+    case "remove": {
+      const slot = state[action.mount];
+      if (!slot.includes(action.id)) return state;
+      return { ...state, [action.mount]: slot.filter((x) => x !== action.id) };
+    }
+    case "reorder": {
+      const slot = state[action.mount];
+      if (
+        slot.length === action.ids.length &&
+        slot.every((id, i) => id === action.ids[i])
+      ) {
+        return state;
+      }
+      return { ...state, [action.mount]: action.ids };
+    }
+    case "clear":
+      return { ...state, [action.mount]: [] };
+    case "seed": {
+      const next = Array.from(new Set(action.ids)).slice(0, MAX_COMPARE);
+      const slot = state[action.mount];
+      if (
+        slot.length === next.length &&
+        slot.every((id, i) => id === next[i])
+      ) {
+        return state;
+      }
+      return { ...state, [action.mount]: next };
+    }
+  }
+}

--- a/src/lib/compareReducer.ts
+++ b/src/lib/compareReducer.ts
@@ -10,6 +10,19 @@ export type CompareAction =
   | { type: "clear"; mount: Mount }
   | { type: "seed"; ids: string[]; mount: Mount };
 
+// Mount-less shape the public useCompare hook accepts. The hook injects
+// `mount` from the URL before forwarding to the reducer, so call sites
+// don't restate something the URL already guarantees.
+//
+// Derived from CompareAction via distributive Omit — the `T extends any`
+// trick forces TypeScript to apply Omit to each member of the union
+// individually instead of merging them into a single intersection.
+export type ScopedCompareAction = CompareAction extends infer A
+  ? A extends { mount: Mount }
+    ? Omit<A, "mount">
+    : never
+  : never;
+
 export const initialCompareState: CompareState = { X: [], G: [] };
 
 export function compareReducer(


### PR DESCRIPTION
## Summary

Two-step refactor of the compare-state plumbing — no behavior change.

- **Step 1 (`34b0063`)** — Split state-transition rules out of `CompareProvider` into a pure reducer (`src/lib/compareReducer.ts`), unit-testable in isolation. Collapse the two-tier `useCompare` / `useMountedCompare` API into a single mount-scoped `useCompare()`.
- **Step 2 (`3261f38`)** — Move the "read state → dispatch + maybe analytics" helpers out of the Provider and into the `useCompare` hook. The hook's per-render closures see latest \`compareIds\` directly, so the old \`stateRef\` + sync-\`useEffect\` workaround is no longer needed anywhere. \`ScopedCompareAction\` now derives from \`CompareAction\` via distributive \`Omit\` — single source of truth at the type level.

Public API now:

\`\`\`ts
const { compareIds, dispatch, add, remove, toggle } = useCompare();
\`\`\`

\`add\` / \`remove\` / \`toggle\` handle the common cases (with analytics gating built in); \`dispatch\` stays as the escape hatch for the lower-frequency \`reorder\` / \`clear\` / \`seed\`.

Net \`-66\` lines across the compare surface.

## Non-obvious traps for reviewers

- **Why \`stateRef\` was needed in the old Provider, why it isn't here**: the Provider's wrappers had \`deps=[]\` so consumers' effects (e.g. \`CompareTable\`'s seed effect with \`seedCompare\` in deps) wouldn't re-run on every state change. With frozen closures, reading latest state required a ref. The new helpers live in \`useCompare\`, are called per-render, and are only used in event handlers — so they can carry \`compareIds\` in their deps without breaking any consumer effect.
- **Why \`useEffectEvent\` is not used**: it can only be called from inside Effects or other Effect Events. All these mutators fire from \`onClick\`, so \`useEffectEvent\` doesn't apply — \`useCallback\` is the right tool here.
- **\`useLayoutEffect\` for seed**: untouched in this PR. It's required because \`Nav\` (in the layout) reads \`compareIds\` from context and would flicker the count badge / compare-link href if the seed landed after first paint.

## Test plan

- [x] List page: add 2 lenses → bar shows correct chips
- [x] List page: toggle (click an already-added card) → removes
- [x] Compare page deep-link \`?ids=A,B\` → seeds correctly, no flicker
- [x] Compare page: remove a column → URL syncs via \`history.replaceState\`
- [x] Compare page: clear → toast undo restores both state and URL
- [x] X / G mount slots independent (state shape verification)
- [x] \`tsc --noEmit\` clean (ignoring pre-existing Cloudflare env errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)