### PR TITLE
fix(feedback): prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -297,7 +297,7 @@ export default function FeedbackDialog({
                         onChange={(e) => setSuggestedCorrection(e.target.value)}
                         placeholder={t("suggestedCorrectionPlaceholder")}
                         maxLength={200}
-                        className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600"
+                        className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-base sm:text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600"
                       />
                     </div>
                   </div>
@@ -323,7 +323,7 @@ export default function FeedbackDialog({
               placeholder={t(showFieldPicker ? "descriptionPlaceholder" : "descriptionPlaceholderMain")}
               rows={4}
               maxLength={2000}
-              className="w-full resize-none rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600"
+              className="w-full resize-none rounded-lg border border-zinc-200 bg-white px-3 py-2 text-base sm:text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600"
             />
             <div className="flex flex-col gap-2">
               <label
@@ -351,7 +351,7 @@ export default function FeedbackDialog({
                 placeholder={t("replyContactPlaceholder")}
                 aria-label={t("replyContactLabel")}
                 disabled={!wantsReply}
-                className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 disabled:cursor-not-allowed disabled:bg-zinc-50 disabled:text-zinc-400 disabled:placeholder:text-zinc-300 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600 dark:disabled:bg-zinc-900 dark:disabled:text-zinc-600 dark:disabled:placeholder:text-zinc-700"
+                className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-base sm:text-sm text-zinc-900 placeholder:text-zinc-400 outline-none focus:border-zinc-400 disabled:cursor-not-allowed disabled:bg-zinc-50 disabled:text-zinc-400 disabled:placeholder:text-zinc-300 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:placeholder:text-zinc-600 dark:focus:border-zinc-600 dark:disabled:bg-zinc-900 dark:disabled:text-zinc-600 dark:disabled:placeholder:text-zinc-700"
               />
             </div>
 


### PR DESCRIPTION
## Summary
- iOS Safari force-zooms the viewport when a focused input has `font-size < 16px`, which pushed parts of the feedback dialog off-screen on mobile.
- Bump the three feedback inputs (suggested correction, description textarea, reply contact) to `text-base sm:text-sm` so mobile renders at 16px and the desktop size is unchanged.
- Mirrors the pattern already used by `LensSearchDialog`, which is why search wasn't affected.

## Test plan
- [ ] On iOS Safari (or device-emulation), open the feedback dialog and tap each input — viewport should not zoom.
- [ ] Desktop (≥ sm breakpoint) input sizes are unchanged.