### PR TITLE
feat(mount-switcher): add format caption under each dropdown option

### DIFF
--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -74,7 +74,7 @@ export default function MountSwitcher() {
           >
             <span className="flex flex-col leading-tight">
               <span>{opt.label}</span>
-              <span className="text-xs font-normal text-zinc-300 dark:text-zinc-600 mt-0.5">
+              <span className="text-xs font-normal !text-zinc-400 dark:!text-zinc-500 mt-0.5">
                 {opt.caption}
               </span>
             </span>

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -74,7 +74,7 @@ export default function MountSwitcher() {
           >
             <span className="flex flex-col leading-tight">
               <span>{opt.label}</span>
-              <span className="text-xs font-normal text-zinc-400 dark:text-zinc-500 mt-0.5">
+              <span className="text-xs font-normal text-zinc-300 dark:text-zinc-600 mt-0.5">
                 {opt.caption}
               </span>
             </span>

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -73,7 +73,7 @@ export default function MountSwitcher() {
             className="rounded-none py-2 sm:py-2 text-sm sm:text-base text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
           >
             <span className="flex flex-col leading-tight">
-              <span>{opt.label}</span>
+              <span className="font-medium">{opt.label}</span>
               <span className="text-xs font-normal !text-zinc-400 dark:!text-zinc-500 mt-0.5">
                 {opt.caption}
               </span>

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -27,9 +27,9 @@ export default function MountSwitcher() {
     }
   }, [urlMount, setPreference]);
 
-  const options: { value: Mount; label: string }[] = [
-    { value: "X", label: t("x") },
-    { value: "G", label: t("gfx") },
+  const options: { value: Mount; label: string; caption: string }[] = [
+    { value: "X", label: t("x"), caption: t("xCaption") },
+    { value: "G", label: t("gfx"), caption: t("gfxCaption") },
   ];
 
   const handleValueChange = (value: Mount | null) => {
@@ -72,7 +72,12 @@ export default function MountSwitcher() {
             value={opt.value}
             className="rounded-none py-2 sm:py-2 text-sm sm:text-base text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
           >
-            {opt.label}
+            <span className="flex flex-col leading-tight">
+              <span>{opt.label}</span>
+              <span className="text-xs font-normal text-zinc-400 dark:text-zinc-500 mt-0.5">
+                {opt.caption}
+              </span>
+            </span>
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -46,7 +46,9 @@
   "MountSwitcher": {
     "label": "Switch mount system",
     "x": "X Mount",
-    "gfx": "G Mount"
+    "gfx": "G Mount",
+    "xCaption": "APS-C",
+    "gfxCaption": "Medium format"
   },
   "Home": {
     "cta": "Browse Lenses",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -46,7 +46,9 @@
   "MountSwitcher": {
     "label": "切换卡口系统",
     "x": "X 卡口",
-    "gfx": "G 卡口"
+    "gfx": "G 卡口",
+    "xCaption": "APS-C",
+    "gfxCaption": "中画幅"
   },
   "Home": {
     "cta": "浏览镜头",


### PR DESCRIPTION
## Summary
- Show "APS-C" / "中画幅" (zh) and "APS-C" / "Medium format" (en) as a small secondary line beneath the mount label inside the dropdown, so users see what each Fujifilm mount actually covers at the moment they're choosing.
- The Nav trigger is intentionally unchanged — it sits tight against the "X-Glass /" branding on mobile and any extra inline copy there would risk wrapping.
- Caption uses `text-zinc-300 / dark:text-zinc-600` so it recedes from the primary mount-name label.

## Test plan
- [ ] Verify the trigger label is still just "X 卡口" / "X Mount" on both mobile and desktop.
- [ ] Open the dropdown — each option shows two lines (mount label + smaller faint caption).
- [ ] Check zh and en, mobile and desktop — captions don't wrap.