### PR TITLE
style(nav): widen breathing room around the brand/mount slash separator

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -132,7 +132,7 @@ export default function Nav() {
     >
       <nav className="wco-no-drag max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         {/* Left: brand / mount-scope path (GitHub namespace pattern) */}
-        <div className="flex items-center gap-0.5 sm:gap-1.5 shrink-0">
+        <div className="flex items-center gap-1 sm:gap-2 shrink-0">
           <Link
             href="/"
             className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-base sm:text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"


### PR DESCRIPTION
## Summary
- Bump the left nav cluster's flex gap from `gap-0.5 sm:gap-1.5` (2px / 6px) to `gap-1 sm:gap-2` (4px / 8px).
- The "/" separator between the X-Glass brand and the mount switcher now sits with a bit more air on both sides.

## Test plan
- [ ] On mobile (~390px), the X-Glass logo, slash, and X 卡口 switcher still fit comfortably alongside the right-side links.
- [ ] On desktop, the slash looks balanced — not cramped, not floating.