### PR TITLE
style(nav): tighten gap between Compare and mobile overflow menu

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -197,7 +197,7 @@ export default function Nav() {
           <div ref={menuRef} className="relative">
             <button
               onClick={() => setMobileMenuOpen((v) => !v)}
-              className="p-2 -mr-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+              className="pl-1 pr-2 py-2 -mr-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
               aria-label="Menu"
               aria-expanded={mobileMenuOpen}
             >


### PR DESCRIPTION
## Summary
- The hamburger button used symmetric `p-2`, leaving ~12px between the "Compare" link and the three-dot icon.
- Switch to `pl-1 pr-2` so the left padding shrinks by 4px; the icon visibly sits closer to "Compare" and the right-edge alignment is unchanged (still anchored by `-mr-2`).
- Frees up a touch more breathing room in the middle of the bar between the left brand cluster and the right links.

## Test plan
- [ ] On mobile, the three-dot menu sits closer to "Compare" than before but doesn't touch it.
- [ ] The icon is still right-edge-aligned with the rest of the nav.
- [ ] Tapping the icon still works comfortably (hit area unchanged vertically, only slightly narrower horizontally).