### PR TITLE
feat(data): publish lens data 2026.05.23 build 1

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -9490,7 +9490,6 @@
     "brand": "tamron",
     "mount": "X",
     "model": "11-20mm F/2.8 Di III-A RXD",
-    "generation": 3,
     "focalLengthMin": 11,
     "focalLengthMax": 20,
     "maxAperture": 2.8,
@@ -9587,7 +9586,6 @@
     "brand": "tamron",
     "mount": "X",
     "model": "17-70mm F/2.8 Di III-A VC RXD",
-    "generation": 3,
     "focalLengthMin": 17,
     "focalLengthMax": 70,
     "maxAperture": 2.8,
@@ -9683,7 +9681,6 @@
     "brand": "tamron",
     "mount": "X",
     "model": "18-300mm F/3.5-6.3 Di III-A VC VXD",
-    "generation": 3,
     "focalLengthMin": 18,
     "focalLengthMax": 300,
     "maxAperture": [
@@ -9787,7 +9784,6 @@
     "brand": "tamron",
     "mount": "X",
     "model": "150-500mm F/5-6.7 Di III VC VXD",
-    "generation": 3,
     "focalLengthMin": 150,
     "focalLengthMax": 500,
     "maxAperture": [

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.22",
-  "lastUpdated": "2026-05-22T00:56:12.346Z",
+  "version": "2026.05.23",
+  "lastUpdated": "2026-05-23T06:03:17.010Z",
   "lensCount": 196,
   "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.23` build 1
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`