### PR TITLE
fix(search): hide generation badge due to data quality issues

### DIFF
--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -308,7 +308,6 @@ export default function LensSearchDialog({
                       <div className="min-w-0">
                         <p className="truncate text-xs uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
                           {lensSubtitleLine(tBrand(lens.brand), lens.series)}
-                          {lens.generation ? ` · ${t("generation", { value: lens.generation })}` : ""}
                         </p>
                         <p className="mt-0.5 truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
                           {lens.model}

--- a/src/lib/__tests__/lens-search.test.ts
+++ b/src/lib/__tests__/lens-search.test.ts
@@ -37,7 +37,6 @@ const lenses = [
     focalLengthMax: 23,
     maxAperture: 2,
     minAperture: 16,
-    generation: 2,
   },
   {
     id: "fuji-xf40-28",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -40,8 +40,7 @@
     "coverageLink": "View lens coverage →",
     "results": "Lens search results",
     "clear": "Clear search",
-    "view": "Open",
-    "generation": "Gen {value}"
+    "view": "Open"
   },
   "MountSwitcher": {
     "label": "Switch mount system",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -40,8 +40,7 @@
     "coverageLink": "查看收录范围 →",
     "results": "搜索结果",
     "clear": "清空",
-    "view": "查看",
-    "generation": "第 {value} 代"
+    "view": "查看"
   },
   "MountSwitcher": {
     "label": "切换卡口系统",


### PR DESCRIPTION
## Summary
- Remove generation badge rendering from lens search dialog
- Remove associated i18n keys (`generation`) from en/zh locale files
- Clean up test fixture

Type definitions and Zod schema are intentionally kept — the field still exists in data, and display can be restored once pipeline data quality is fixed.

## Test plan
- [ ] Open lens search, verify no "Gen X" / "第 X 代" badge appears for multi-generation lenses
- [ ] Confirm search still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)