### PR TITLE
feat(ui/dialog): responsive bottom drawer on mobile

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -222,7 +222,7 @@ export default function FeedbackDialog({
             </p>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-2">
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-4">
             {lensHeader && (
               <div className="flex flex-col gap-0.5 border-b border-zinc-200 dark:border-zinc-800 pb-3">
                 <span className="text-[11px] font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">

--- a/src/components/FeedbackTrigger.tsx
+++ b/src/components/FeedbackTrigger.tsx
@@ -15,6 +15,7 @@ interface FeedbackTriggerProps {
   className?: string;
   children: ReactNode;
   stopPropagation?: boolean;
+  onBeforeOpen?: () => void;
 }
 
 export default function FeedbackTrigger({
@@ -24,6 +25,7 @@ export default function FeedbackTrigger({
   className,
   children,
   stopPropagation = false,
+  onBeforeOpen,
 }: FeedbackTriggerProps) {
   const [open, setOpen] = useState(false);
 
@@ -35,6 +37,7 @@ export default function FeedbackTrigger({
           if (stopPropagation) {
             e.stopPropagation();
           }
+          onBeforeOpen?.();
           track("feedback_open", { feedback_type: type });
           setOpen(true);
         }}

--- a/src/components/FeedbackTrigger.tsx
+++ b/src/components/FeedbackTrigger.tsx
@@ -15,7 +15,6 @@ interface FeedbackTriggerProps {
   className?: string;
   children: ReactNode;
   stopPropagation?: boolean;
-  onBeforeOpen?: () => void;
 }
 
 export default function FeedbackTrigger({
@@ -25,7 +24,6 @@ export default function FeedbackTrigger({
   className,
   children,
   stopPropagation = false,
-  onBeforeOpen,
 }: FeedbackTriggerProps) {
   const [open, setOpen] = useState(false);
 
@@ -37,7 +35,6 @@ export default function FeedbackTrigger({
           if (stopPropagation) {
             e.stopPropagation();
           }
-          onBeforeOpen?.();
           track("feedback_open", { feedback_type: type });
           setOpen(true);
         }}

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -256,6 +256,7 @@ export default function LensSearchDialog({
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
                     className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                    onBeforeOpen={() => setOpen(false)}
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>
@@ -319,6 +320,7 @@ export default function LensSearchDialog({
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
                     className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                    onBeforeOpen={() => setOpen(false)}
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -242,16 +242,7 @@ export default function LensSearchDialog({
             ref={scrollContainerRef}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
-            {query.trim().length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
-                <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
-                  {t("emptyTitle")}
-                </p>
-                <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-                  {t("emptyDescription")}
-                </p>
-              </div>
-            ) : results.length === 0 ? (
+            {query.trim().length === 0 ? null : results.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
                 <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
                   {t("noResults")}

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -256,7 +256,6 @@ export default function LensSearchDialog({
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
                     className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                    onBeforeOpen={() => setOpen(false)}
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>
@@ -320,7 +319,6 @@ export default function LensSearchDialog({
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
                     className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                    onBeforeOpen={() => setOpen(false)}
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -196,7 +196,7 @@ export default function LensSearchDialog({
                 <DialogTitle>{t("title")}</DialogTitle>
                 <DialogDescription className="sr-only">{t("description")}</DialogDescription>
               </div>
-              <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "h-9 w-9")}>
+              <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "hidden h-9 w-9 sm:inline-flex")}>
                 <X className="h-4 w-4" />
               </DialogClose>
             </div>

--- a/src/components/share/LightboxDialog.tsx
+++ b/src/components/share/LightboxDialog.tsx
@@ -31,6 +31,7 @@ export function LightboxDialog({
           handleClose();
         }
       }}
+      responsive={false}
     >
       <DialogContent
         noDefaultPositioning

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -132,6 +132,7 @@ const DialogContent = React.forwardRef<
             data-slot="dialog-content"
             className={cn(
               `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
+              "transition-[transform,opacity] data-[nested-drawer-open]:scale-[0.94] data-[nested-drawer-open]:opacity-40",
               className,
               "rounded-t-2xl rounded-b-none"
             )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,25 +2,45 @@
 
 import * as React from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { FROSTED_OVERLAY_CHROME_CLS, ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
 import { Z } from "@/config/ui";
+import { useBreakpoint } from "@/hooks/useBreakpoint";
+
+const DialogModeContext = React.createContext<"dialog" | "drawer">("dialog");
+function useDialogMode() {
+  return React.useContext(DialogModeContext);
+}
 
 function Dialog({
   open,
   onOpenChange,
   children,
+  responsive = true,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   children: React.ReactNode;
+  responsive?: boolean;
 }) {
+  const isDesktop = useBreakpoint("sm");
+  const mode = responsive && !isDesktop ? "drawer" : "dialog";
+
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      {children}
-    </DialogPrimitive.Root>
+    <DialogModeContext.Provider value={mode}>
+      {mode === "drawer" ? (
+        <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange} swipeDirection="down">
+          {children}
+        </DrawerPrimitive.Root>
+      ) : (
+        <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+          {children}
+        </DialogPrimitive.Root>
+      )}
+    </DialogModeContext.Provider>
   );
 }
 
@@ -89,10 +109,44 @@ const DialogContent = React.forwardRef<
     showCloseButton = true,
     showOverlayCloseButton = false,
     noDefaultPositioning = false,
+    render: _render,
     ...props
   },
   ref
 ) {
+  const mode = useDialogMode();
+
+  if (mode === "drawer") {
+    return (
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Backdrop
+          data-slot="dialog-backdrop"
+          className={cn(
+            `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+            backdropClassName
+          )}
+        />
+        <DrawerPrimitive.Viewport>
+          <DrawerPrimitive.Popup
+            ref={ref}
+            data-slot="dialog-content"
+            className={cn(
+              `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
+              className,
+              "rounded-t-2xl rounded-b-none"
+            )}
+            {...(props as Omit<typeof props, "style">)}
+          >
+            <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
+              <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
+            </div>
+            {children}
+          </DrawerPrimitive.Popup>
+        </DrawerPrimitive.Viewport>
+      </DrawerPrimitive.Portal>
+    );
+  }
+
   return (
     <DialogPortal>
       <div ref={layerRef} className={cn("fixed inset-0", Z.dialog)}>

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -36,7 +36,7 @@
     "noResultsHint": "试试更短的型号，或者换个品牌名、系列关键词。",
     "suggestLens": "没找到你想要的镜头？",
     "suggestLensLink": "告诉我",
-    "suggestLensResults": "没有你预期的那支镜头？",
+    "suggestLensResults": "没看到你要的镜头？",
     "coverageLink": "查看收录范围 →",
     "results": "搜索结果",
     "clear": "清空",


### PR DESCRIPTION
## Summary

- **Responsive dialog→drawer**: `Dialog` automatically renders as a bottom-sheet drawer on viewports below `sm` (640px). Desktop stays centered dialog. Uses Base UI Drawer primitive with swipe-to-dismiss, drag handle, and slide-up animation.
- **iOS scroll lock fix**: Base UI Drawer correctly locks background scroll on iOS Safari, fixing the scroll-through bug where the page behind the modal could still scroll on mobile.
- **Search empty state cleanup**: removed the dashed-border hint box shown on zero input — the placeholder text already communicates supported search dimensions.
- LightboxDialog opts out of responsive behavior via `responsive={false}`.

## Test plan

- [ ] Desktop: open search dialog — centered modal with zoom animation, unchanged behavior
- [ ] Mobile (~390px): open search dialog — slides up from bottom as drawer, drag handle visible, swipe down to dismiss
- [ ] Mobile: background page does not scroll while drawer is open (iOS Safari regression fixed)
- [ ] Mobile: open feedback dialog — also renders as bottom drawer
- [ ] Mobile: open lightbox (share poster → tap image) — stays as centered fullscreen overlay, not drawer
- [ ] Desktop: search zero-input state shows clean empty area, no dashed hint box

🤖 Generated with [Claude Code](https://claude.com/claude-code)