### PR TITLE
feat(analytics): exclude internal traffic from dashboard

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -18,7 +18,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const WINDOW = "INTERVAL '30' DAY";
-const EXCLUDE_INTERNAL = "AND blob6 != '1'";
+const DASHBOARD_FILTER = `timestamp > NOW() - ${WINDOW} AND blob6 != '1'`;
 
 const Q_OVERVIEW = `
   SELECT
@@ -27,7 +27,7 @@ const Q_OVERVIEW = `
     uniqIf(blob4, index1 = 'search') AS unique_queries,
     uniqIf(blob4, index1 = 'lens_view') AS unique_lenses_viewed
   FROM xglass_events
-  WHERE timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+  WHERE ${DASHBOARD_FILTER}
 `;
 
 const Q_LOCALE_SPLIT = `
@@ -36,7 +36,7 @@ const Q_LOCALE_SPLIT = `
     SUM(_sample_interval) AS events,
     uniq(blob1) AS sessions
   FROM xglass_events
-  WHERE timestamp > NOW() - ${WINDOW} AND blob2 != '' ${EXCLUDE_INTERNAL}
+  WHERE ${DASHBOARD_FILTER} AND blob2 != ''
   GROUP BY locale
   ORDER BY events DESC
 `;
@@ -45,7 +45,7 @@ const Q_REFERRER = `
   SELECT blob5 AS referrer, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'lens_view' AND blob5 != ''
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY referrer
   ORDER BY n DESC
   LIMIT 15
@@ -55,7 +55,7 @@ const Q_SEARCH_ZERO = `
   SELECT blob4 AS query, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'search' AND double1 = 0
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY query
   ORDER BY n DESC
   LIMIT 20
@@ -65,7 +65,7 @@ const Q_SEARCH_ALL = `
   SELECT blob4 AS query, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'search'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY query
   ORDER BY n DESC
   LIMIT 20
@@ -75,7 +75,7 @@ const Q_FILTER_USAGE = `
   SELECT blob4 AS filters, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'filter_apply'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY filters
   ORDER BY n DESC
   LIMIT 10
@@ -91,14 +91,14 @@ const Q_COMPARE_FUNNEL = `
     uniqIf(blob1, index1 = 'compare_scroll') AS sids_scroll
   FROM xglass_events
   WHERE index1 IN ('compare_add', 'compare_view', 'compare_scroll')
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
 `;
 
 const Q_COMPARE_COMBOS = `
   SELECT blob5 AS slugs, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'compare_view' AND blob5 != ''
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY slugs
   ORDER BY n DESC
   LIMIT 20
@@ -108,7 +108,7 @@ const Q_LENS_VIEW_TOP = `
   SELECT blob4 AS lens_slug, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'lens_view'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY lens_slug
   ORDER BY n DESC
   LIMIT 20
@@ -121,7 +121,7 @@ const Q_FEEDBACK = `
     sumIf(_sample_interval, index1 = 'feedback_submit') AS submits
   FROM xglass_events
   WHERE index1 IN ('feedback_open', 'feedback_submit')
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY feedback_type
 `;
 
@@ -129,7 +129,7 @@ const Q_SHARE = `
   SELECT blob5 AS method, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'share_action'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY method
   ORDER BY n DESC
 `;
@@ -138,7 +138,7 @@ const Q_INSTALL = `
   SELECT SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'install_action'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
 `;
 
 const Q_MOUNT_SWITCH = `
@@ -148,7 +148,7 @@ const Q_MOUNT_SWITCH = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'mount_switch'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY from_mount, to_mount
   ORDER BY n DESC
 `;
@@ -157,7 +157,7 @@ const Q_OUTBOUND = `
   SELECT blob4 AS href, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'outbound_click'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY href
   ORDER BY n DESC
   LIMIT 20
@@ -170,7 +170,7 @@ const Q_OUTBOUND_BY_SOURCE = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'outbound_click'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY source_path, href
   ORDER BY n DESC
   LIMIT 30
@@ -183,7 +183,7 @@ const Q_SHARE_BY_SOURCE = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'share_action'
-    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
+    AND ${DASHBOARD_FILTER}
   GROUP BY source_path, method
   ORDER BY n DESC
   LIMIT 30

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -18,6 +18,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const WINDOW = "INTERVAL '30' DAY";
+const EXCLUDE_INTERNAL = "AND blob6 != '1'";
 
 const Q_OVERVIEW = `
   SELECT
@@ -26,7 +27,7 @@ const Q_OVERVIEW = `
     uniqIf(blob4, index1 = 'search') AS unique_queries,
     uniqIf(blob4, index1 = 'lens_view') AS unique_lenses_viewed
   FROM xglass_events
-  WHERE timestamp > NOW() - ${WINDOW}
+  WHERE timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
 `;
 
 const Q_LOCALE_SPLIT = `
@@ -35,7 +36,7 @@ const Q_LOCALE_SPLIT = `
     SUM(_sample_interval) AS events,
     uniq(blob1) AS sessions
   FROM xglass_events
-  WHERE timestamp > NOW() - ${WINDOW} AND blob2 != ''
+  WHERE timestamp > NOW() - ${WINDOW} AND blob2 != '' ${EXCLUDE_INTERNAL}
   GROUP BY locale
   ORDER BY events DESC
 `;
@@ -44,7 +45,7 @@ const Q_REFERRER = `
   SELECT blob5 AS referrer, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'lens_view' AND blob5 != ''
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY referrer
   ORDER BY n DESC
   LIMIT 15
@@ -54,7 +55,7 @@ const Q_SEARCH_ZERO = `
   SELECT blob4 AS query, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'search' AND double1 = 0
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY query
   ORDER BY n DESC
   LIMIT 20
@@ -64,7 +65,7 @@ const Q_SEARCH_ALL = `
   SELECT blob4 AS query, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'search'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY query
   ORDER BY n DESC
   LIMIT 20
@@ -74,7 +75,7 @@ const Q_FILTER_USAGE = `
   SELECT blob4 AS filters, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'filter_apply'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY filters
   ORDER BY n DESC
   LIMIT 10
@@ -90,14 +91,14 @@ const Q_COMPARE_FUNNEL = `
     uniqIf(blob1, index1 = 'compare_scroll') AS sids_scroll
   FROM xglass_events
   WHERE index1 IN ('compare_add', 'compare_view', 'compare_scroll')
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
 `;
 
 const Q_COMPARE_COMBOS = `
   SELECT blob5 AS slugs, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'compare_view' AND blob5 != ''
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY slugs
   ORDER BY n DESC
   LIMIT 20
@@ -107,7 +108,7 @@ const Q_LENS_VIEW_TOP = `
   SELECT blob4 AS lens_slug, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'lens_view'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY lens_slug
   ORDER BY n DESC
   LIMIT 20
@@ -120,7 +121,7 @@ const Q_FEEDBACK = `
     sumIf(_sample_interval, index1 = 'feedback_submit') AS submits
   FROM xglass_events
   WHERE index1 IN ('feedback_open', 'feedback_submit')
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY feedback_type
 `;
 
@@ -128,7 +129,7 @@ const Q_SHARE = `
   SELECT blob5 AS method, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'share_action'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY method
   ORDER BY n DESC
 `;
@@ -137,7 +138,7 @@ const Q_INSTALL = `
   SELECT SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'install_action'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
 `;
 
 const Q_MOUNT_SWITCH = `
@@ -147,7 +148,7 @@ const Q_MOUNT_SWITCH = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'mount_switch'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY from_mount, to_mount
   ORDER BY n DESC
 `;
@@ -156,7 +157,7 @@ const Q_OUTBOUND = `
   SELECT blob4 AS href, SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'outbound_click'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY href
   ORDER BY n DESC
   LIMIT 20
@@ -169,7 +170,7 @@ const Q_OUTBOUND_BY_SOURCE = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'outbound_click'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY source_path, href
   ORDER BY n DESC
   LIMIT 30
@@ -182,7 +183,7 @@ const Q_SHARE_BY_SOURCE = `
     SUM(_sample_interval) AS n
   FROM xglass_events
   WHERE index1 = 'share_action'
-    AND timestamp > NOW() - ${WINDOW}
+    AND timestamp > NOW() - ${WINDOW} ${EXCLUDE_INTERNAL}
   GROUP BY source_path, method
   ORDER BY n DESC
   LIMIT 30

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,15 +3,30 @@
 // Shares the main site's font stack (Geist Sans + Source Serif 4) via
 // the exported fontClassName so admin looks of-a-piece with the product.
 
+import { cookies } from "next/headers";
 import { fontClassName } from "../fonts";
 import "../globals.css";
+
+const INTERNAL_COOKIE = "xg_internal";
+const ONE_YEAR = 60 * 60 * 24 * 365;
 
 export const metadata = {
   title: "Admin",
   robots: { index: false, follow: false },
 };
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const jar = await cookies();
+  if (!jar.has(INTERNAL_COOKIE)) {
+    jar.set(INTERNAL_COOKIE, "1", {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: ONE_YEAR,
+    });
+  }
+
   return (
     <html lang="en" className={fontClassName}>
       <body className="bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -67,6 +67,19 @@ function parseSid(cookieHeader: string | null): string | null {
   return null;
 }
 
+function parseInternal(cookieHeader: string | null): boolean {
+  if (!cookieHeader) {
+    return false;
+  }
+  for (const part of cookieHeader.split(";")) {
+    const [k, v] = part.trim().split("=");
+    if (k === "xg_internal" && v === "1") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function sanitizeProps(raw: unknown): EventProps {
   if (!raw || typeof raw !== "object") {
     return {};
@@ -107,13 +120,15 @@ export async function POST(req: Request): Promise<NextResponse> {
   const locale = (parsed.locale ?? "").slice(0, 8);
   const props = sanitizeProps(parsed.props);
 
-  const sid = parseSid(req.headers.get("cookie")) ?? crypto.randomUUID();
+  const cookieHeader = req.headers.get("cookie");
+  const sid = parseSid(cookieHeader) ?? crypto.randomUUID();
+  const internal = parseInternal(cookieHeader);
 
   try {
     const { env } = getCloudflareContext();
     const ae = (env as CloudflareEnv).ANALYTICS;
     if (ae) {
-      ae.writeDataPoint(toDataPoint(event, sid, locale, props));
+      ae.writeDataPoint(toDataPoint(event, sid, locale, props, internal));
     }
   } catch {
     // Binding may be unavailable (e.g. `next dev` without initOpenNext bound).

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -70,7 +70,7 @@ export const EVENT_NAME_SET: ReadonlySet<string> = new Set<string>(EVENT_NAMES);
 
 interface AnalyticsEnginePoint {
   indexes: [string];
-  blobs: [string, string, string, string, string];
+  blobs: [string, string, string, string, string, string];
   doubles: [number];
 }
 
@@ -79,6 +79,7 @@ export function toDataPoint(
   sid: string,
   locale: string,
   props: EventProps,
+  internal: boolean,
 ): AnalyticsEnginePoint {
   const primaryString =
     props.query ??
@@ -102,7 +103,7 @@ export function toDataPoint(
 
   return {
     indexes: [event],
-    blobs: [sid, locale, props.path ?? "", primaryString, secondaryString],
+    blobs: [sid, locale, props.path ?? "", primaryString, secondaryString, internal ? "1" : ""],
     doubles: [primaryNumber],
   };
 }


### PR DESCRIPTION
## Summary

- Admin layout sets a long-lived `HttpOnly` `xg_internal` cookie on first visit (gated by Cloudflare Access, so only authorized users trigger it)
- `/api/track` reads the cookie and writes `blob6 = "1"` to Analytics Engine for internal sessions
- All 16 dashboard SQL queries now include `AND blob6 != '1'` to filter out internal traffic
- Data is still written (not dropped), so removing the filter condition recovers full visibility

## Test plan

- [ ] Deploy to preview, visit `/admin/analytics` — verify cookie `xg_internal=1` appears (HttpOnly, 1-year expiry)
- [ ] Browse the site in the same browser, trigger a few events (search, lens view)
- [ ] Query AE directly to confirm those events have `blob6 = '1'`
- [ ] Open the dashboard — internal events should be excluded from all panels
- [ ] In a fresh incognito window (no admin visit), trigger events — confirm `blob6` is empty and events appear in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)