### PR TITLE
fix(analytics): move xg_internal cookie to middleware

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,30 +3,15 @@
 // Shares the main site's font stack (Geist Sans + Source Serif 4) via
 // the exported fontClassName so admin looks of-a-piece with the product.
 
-import { cookies } from "next/headers";
 import { fontClassName } from "../fonts";
 import "../globals.css";
-
-const INTERNAL_COOKIE = "xg_internal";
-const ONE_YEAR = 60 * 60 * 24 * 365;
 
 export const metadata = {
   title: "Admin",
   robots: { index: false, follow: false },
 };
 
-export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const jar = await cookies();
-  if (!jar.has(INTERNAL_COOKIE)) {
-    jar.set(INTERNAL_COOKIE, "1", {
-      path: "/",
-      httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
-      maxAge: ONE_YEAR,
-    });
-  }
-
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={fontClassName}>
       <body className="bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 
-export default createMiddleware(routing);
+const INTERNAL_COOKIE = "xg_internal";
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+const i18nMiddleware = createMiddleware(routing);
+
+export default function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname.startsWith("/admin")) {
+    if (req.cookies.has(INTERNAL_COOKIE)) {
+      return NextResponse.next();
+    }
+    const res = NextResponse.next();
+    res.cookies.set(INTERNAL_COOKIE, "1", {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: ONE_YEAR,
+    });
+    return res;
+  }
+
+  return i18nMiddleware(req);
+}
 
 export const config = {
-  // Exclude static files (.*\\..*), Next.js internals, API routes, and
-  // App Router metadata convention routes that must stay at the root path.
   matcher: [
-    "/((?!_next|_vercel|api|admin|icon|apple-icon|opengraph-image|.*\\..*).*)",
+    "/((?!_next|_vercel|api|icon|apple-icon|opengraph-image|.*\\..*).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- `cookies().set()` throws in Server Components — only Route Handlers and Server Actions can write cookies
- Moves `xg_internal` cookie logic from admin layout to middleware, where `NextResponse.cookies.set()` works correctly
- Removes `admin` from the middleware matcher exclusion so `/admin` requests pass through (handler returns `NextResponse.next()` without running i18n)

Fixes the 500 introduced by #257.

## Test plan

- [ ] Visit `/admin/analytics` — page loads without server error
- [ ] Check Application → Cookies — `xg_internal=1` is present (HttpOnly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)