### PR TITLE
refactor(context): use React 19 Context-as-JSX syntax consistently

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -30,7 +30,7 @@ function Dialog({
   const mode = responsive && !isDesktop ? "drawer" : "dialog";
 
   return (
-    <DialogModeContext.Provider value={mode}>
+    <DialogModeContext value={mode}>
       {mode === "drawer" ? (
         <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange} swipeDirection="down">
           {children}
@@ -40,7 +40,7 @@ function Dialog({
           {children}
         </DialogPrimitive.Root>
       )}
-    </DialogModeContext.Provider>
+    </DialogModeContext>
   );
 }
 

--- a/src/context/CompareProvider.tsx
+++ b/src/context/CompareProvider.tsx
@@ -30,7 +30,11 @@ export function CompareProvider({ children }: { children: React.ReactNode }) {
   // dispatch from useReducer is reference-stable by contract; only state
   // identity drives value changes here.
   const value = useMemo(() => ({ state, dispatch }), [state]);
-  return <CompareContext value={value}>{children}</CompareContext>;
+  return (
+    <CompareContext value={value}>
+      {children}
+    </CompareContext>
+  );
 }
 
 /**

--- a/src/context/MountPreferenceProvider.tsx
+++ b/src/context/MountPreferenceProvider.tsx
@@ -18,9 +18,9 @@ export function MountPreferenceProvider({ children }: { children: React.ReactNod
   );
 
   return (
-    <MountPreferenceContext.Provider value={value}>
+    <MountPreferenceContext value={value}>
       {children}
-    </MountPreferenceContext.Provider>
+    </MountPreferenceContext>
   );
 }
 

--- a/src/context/ScrollContainerContext.tsx
+++ b/src/context/ScrollContainerContext.tsx
@@ -27,9 +27,9 @@ export function ScrollContainerProvider({
   );
 
   return (
-    <ScrollContainerContext.Provider value={value}>
+    <ScrollContainerContext value={value}>
       {children}
-    </ScrollContainerContext.Provider>
+    </ScrollContainerContext>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace legacy `<Context.Provider value={…}>` with React 19's `<Context value={…}>` across all 4 remaining sites: `MountPreferenceProvider`, `ScrollContainerContext`, `CompareProvider`, `dialog.tsx`

## Test plan
- [ ] Verify mount switching still works (Nav, MountSwitcher, browse/compare pages)
- [ ] Verify compare add/remove/clear/reorder behavior unchanged
- [ ] Verify dialog + drawer rendering on mobile and desktop
- [ ] Verify scroll-lock behavior on compare table phantom header

🤖 Generated with [Claude Code](https://claude.com/claude-code)