### PR TITLE
refactor(context): move URL→preference sync into MountPreferenceProvider

### DIFF
--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown } from "lucide-react";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
@@ -18,14 +17,6 @@ export default function MountSwitcher() {
   const urlMount = useMountParam();
   const effectiveMount = useEffectiveMount();
   const { setPreference } = useMountPreference();
-
-  // Sync URL mount → preference so navigating to /lenses/gfx
-  // keeps the badge on GFX after navigating away.
-  useEffect(() => {
-    if (urlMount) {
-      setPreference(urlMount);
-    }
-  }, [urlMount, setPreference]);
 
   const options: { value: Mount; label: string; caption: string }[] = [
     { value: "X", label: t("x"), caption: t("xCaption") },

--- a/src/context/MountPreferenceProvider.tsx
+++ b/src/context/MountPreferenceProvider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useParams } from "next/navigation";
 import { createContext, useContext, useMemo, useState } from "react";
 import type { Mount } from "@/lib/types";
+import { urlSegmentToMount } from "@/lib/mount";
 
 interface MountPreferenceContextValue {
   preference: Mount;
@@ -12,6 +14,13 @@ const MountPreferenceContext = createContext<MountPreferenceContextValue | null>
 
 export function MountPreferenceProvider({ children }: { children: React.ReactNode }) {
   const [preference, setPreference] = useState<Mount>("X");
+  const params = useParams<{ mount?: string }>();
+  const mount = urlSegmentToMount(params.mount);
+
+  if (mount && mount !== preference) {
+    setPreference(mount);
+  }
+
   const value = useMemo(
     () => ({ preference, setPreference }),
     [preference]


### PR DESCRIPTION
## Summary
- Move URL mount → preference sync from MountSwitcher into MountPreferenceProvider, where it belongs as a state concern
- Use render-time setState with guard (`if (mount && mount !== preference)`) instead of useEffect — eliminates one-frame flash of stale preference

## Test plan
- [ ] Navigate to `/lenses/gfx`, then go to homepage — Nav links should still point to GFX
- [ ] Use MountSwitcher dropdown on homepage and on lens pages — both directions work
- [ ] Direct URL `/lenses/gfx/some-lens` → homepage → verify GFX context retained
- [ ] Refresh on homepage — defaults to X-mount as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)