### PR TITLE
feat(pwa): add ref=pwa query param to start_url for usage tracking

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -8,7 +8,7 @@ export default function manifest(): MetadataRoute.Manifest {
     description: SITE.pwaDescription,
     // Explicit app ID — prevents DevTools warning about falling back to start_url.
     id: "/",
-    start_url: "/",
+    start_url: "/?ref=pwa",
     scope: "/",
     display: SITE.display,
     // Prefer WCO on capable desktop browsers so the Nav background extends


### PR DESCRIPTION
## Summary

- Adds `?ref=pwa` to the manifest `start_url` so PWA launches are distinguishable from regular browser visits
- Cloudflare Web Analytics Paths dimension will show `/?ref=pwa` entries automatically
- Custom dashboard `blob3` (path) also captures it — no analytics code changes needed

## Test plan

- [ ] Verify `/manifest.webmanifest` contains `"start_url": "/?ref=pwa"`
- [ ] On an installed PWA, confirm the app opens with `/?ref=pwa` in the address bar (or check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)