### PR TITLE
feat(schema): add searchAliases field to Lens type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -658,6 +658,18 @@ export interface Lens {
   releaseYear?: number;
 
   /**
+   * Locale-keyed search terms optimised for marketplace search engines
+   * (eBay, B&H, MPB, etc.). Pipeline generates these by normalising
+   * brand/model names to match how sellers actually list products.
+   *
+   * Front-end uses the value for the current locale to build affiliate
+   * search URLs. Falls back to `brand + " " + model` when absent.
+   *
+   * @example { en: "7Artisans 50mm f0.95", zh: "七工匠 50mm f0.95" }
+   */
+  searchAliases?: Partial<Record<"en" | "zh", string>>;
+
+  /**
    * Sampled prices per market. Each market holds independent `new` (official
    * store) and `used` (secondary market) price entries — both may be present
    * and the UI renders them as separate data points.


### PR DESCRIPTION
## Summary
- Add optional `searchAliases` field to `Lens` interface, keyed by locale (`en` / `zh`)
- Pipeline will populate this with marketplace-optimised search terms (e.g. `"7Artisans 50mm f0.95"` instead of `"七工匠 50mm f/0.95 II"`)
- Front-end will use these to build affiliate search URLs for eBay, MPB, B&H etc.

Unblocks pipeline-side work to generate the field values.

## Test plan
- [ ] Type-only change — `npm run build` passes with no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)