### PR TITLE
fix(schema): add searchAliases to Zod strict schema

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -108,6 +108,10 @@ const lensBaseShape = {
   ]).optional(),
   apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
+  searchAliases: z.strictObject({
+    en: nonEmptyStringSchema.optional(),
+    zh: nonEmptyStringSchema.optional(),
+  }).optional(),
   pricing: z.strictObject({
     cn: pricingMarketSchema.optional(),
     global: pricingMarketSchema.optional(),
@@ -360,7 +364,7 @@ export const KNOWN_DISTINCT_PAIRS = new Set([
 // Identifiers, human-readable labels, links, and freeform notes are excluded;
 // all measurable optical/physical fields are included automatically.
 const SIMILARITY_EXCLUDE = new Set([
-  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations",
+  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations", "searchAliases",
 ]);
 
 // Threshold above which two same-brand lenses are flagged as suspiciously similar.


### PR DESCRIPTION
## Summary

- Add `searchAliases` to `lensBaseShape` in `lens-schema.ts` so the Zod strict-object parser accepts the field during pipeline publish
- Add `searchAliases` to `SIMILARITY_EXCLUDE` set (not a measurable spec)
- Unblocks pipeline work that writes `searchAliases` into `lenses.json`

Context: the TypeScript `Lens` interface gained `searchAliases` in #265, but the Zod schema was missed — `z.strictObject` rejects unknown keys, so any lens carrying the field would fail validation.

## Test plan

- [ ] `npx tsc --noEmit` passes (only pre-existing `CloudflareEnv` error remains)
- [ ] `npm run build` passes type check for lens-schema changes
- [ ] Pipeline publish with a lens containing `searchAliases` no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)