### PR TITLE
feat(schema): add purchaseChannels to Lens type and Zod schema

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -116,6 +116,11 @@ const lensBaseShape = {
     cn: pricingMarketSchema.optional(),
     global: pricingMarketSchema.optional(),
   }).optional(),
+  purchaseChannels: z.array(z.strictObject({
+    channel: z.enum(['official', 'ebay', 'bhphoto']),
+    url: nonEmptyStringSchema.optional(),
+    affiliate: nonEmptyStringSchema.optional(),
+  })).min(1).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),
   lensMaterial: optionalNonEmptyStringSchema,
@@ -364,7 +369,7 @@ export const KNOWN_DISTINCT_PAIRS = new Set([
 // Identifiers, human-readable labels, links, and freeform notes are excluded;
 // all measurable optical/physical fields are included automatically.
 const SIMILARITY_EXCLUDE = new Set([
-  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations", "searchAliases",
+  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations", "searchAliases", "purchaseChannels",
 ]);
 
 // Threshold above which two same-brand lenses are flagged as suspiciously similar.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -279,6 +279,12 @@ interface LensLocaleTranslations {
   accessories?: string[];
 }
 
+export interface PurchaseChannel {
+  channel: 'official' | 'ebay' | 'bhphoto';
+  url?: string;
+  affiliate?: string;
+}
+
 /**
  * Canonical lens record used by the X-Glass app.
  */
@@ -686,6 +692,8 @@ export interface Lens {
       used?: LensPriceEntry;
     };
   };
+
+  purchaseChannels?: PurchaseChannel[];
 
   /**
    * Mount systems this lens is available for, as stated by the manufacturer.


### PR DESCRIPTION
## Summary
- Add `PurchaseChannel` interface to `types.ts` with `channel`, `url`, and `affiliate` fields
- Add optional `purchaseChannels` array to `Lens` interface and Zod schema
- Exclude `purchaseChannels` from similarity checks

Unblocks pipeline-side `purchaseChannels` generation — pipeline can publish data with this field once this PR merges.

## Test plan
- [x] `tsc --noEmit` passes
- [x] No runtime impact — field is optional, no consumers yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)