### PR TITLE
feat(data): publish lens data 2026.05.24 build 3

### DIFF
--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -60,6 +60,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-82",
       "Rear lens cap RLCP-002",
@@ -150,6 +158,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -235,6 +251,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -308,6 +332,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-77",
       "Rear lens cap RLCP-002",
@@ -416,6 +448,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -501,6 +541,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap",
       "Rear lens cap",
@@ -596,6 +644,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-62 II",
       "Lens rear cap RLCP-002",
@@ -693,6 +749,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -778,6 +842,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -864,6 +936,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-62II",
       "Rear lens cap RLCP-002",
@@ -950,6 +1030,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-77",
       "Rear lens cap RLCP-002",
@@ -1034,6 +1122,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -1118,6 +1214,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -1211,6 +1315,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-67II",
       "Lens rear cap RLCP-002",
@@ -1298,6 +1410,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -1387,6 +1507,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-72 II",
       "Rear lens cap RLCP-002",
@@ -1474,6 +1602,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-72II",
       "Rear lens cap RLCP-002",
@@ -1558,6 +1694,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -1643,6 +1787,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-95",
       "Rear lens cap RLCP-002",
@@ -1731,6 +1883,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-8-15mm-f-2-8-ff-zoom-fisheye-2/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1813,6 +1974,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1891,6 +2061,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1970,6 +2149,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/the-laowa-35mm-f-2-8-zero-d-tilt-shift-0-5x-macro/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2048,6 +2236,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-55mm-f-2-8-tilt-shift-1x-macro/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2126,6 +2323,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-100mm-f-2-8-tilt-shift-1x-macro/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2199,6 +2405,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-gfx-zero-d/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "filterMm": 86,
     "lensConfiguration": {
       "groups": 14,
@@ -2264,6 +2479,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-19mm-f-2-8-zero-d/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm G",
       "Hasselblad XCD"

--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -50,6 +50,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -126,6 +136,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/25mm-f0-95",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -218,6 +238,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -299,6 +329,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -371,6 +411,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Aluminum alloy",
     "filterMm": 39,
     "lensConfiguration": {
@@ -438,6 +488,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-35mm-f1-4",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Metal+polymer plastic",
     "filterMm": 62,
     "lensConfiguration": {
@@ -506,6 +566,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -578,6 +648,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -650,6 +730,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -724,6 +814,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -796,6 +896,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -869,6 +979,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -942,6 +1062,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1015,6 +1145,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1082,6 +1222,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1158,6 +1308,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1241,6 +1401,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -1321,6 +1491,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1395,6 +1575,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1470,6 +1660,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1551,6 +1751,11 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1625,6 +1830,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/35mm-f1-2",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1699,6 +1914,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1777,6 +2002,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1849,6 +2084,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/50mm-f1-8",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1916,6 +2161,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/55mm-f1-4",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1989,6 +2244,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://7artisans.store/products/60mm-f2-8",
+        "affiliate": "ref=omwzyqkn"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -2062,6 +2327,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2148,6 +2423,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.amazon.com/Brightin-XF-Mount-Mirrorless-Fit/dp/B0D3KV8TLL"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon EF-M",
@@ -2225,6 +2509,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -2308,6 +2602,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -2379,6 +2683,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2462,6 +2776,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -2545,6 +2869,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2625,6 +2959,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 9,
@@ -2688,6 +3032,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.amazon.com/Brightin-Fujifilm-Aperture-Portrait-X-Pro1-3/dp/B07Z4B95KM"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon EF-M",
@@ -2754,6 +3107,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2816,6 +3179,11 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": 43,
     "lensConfiguration": {
@@ -2882,6 +3250,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": 43,
     "lensConfiguration": {
@@ -2949,6 +3327,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -3021,6 +3409,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "filterMm": 55,
     "lensConfiguration": {
       "groups": 5,
@@ -3084,6 +3482,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount",
+        "affiliate": "ref=mffdqyik"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -3158,6 +3566,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Tripod collar foot",
       "Support foot",
@@ -3255,6 +3671,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Tripod collar foot",
       "Support foot",
@@ -3367,6 +3791,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-49",
       "Rear lens cap"
@@ -3467,6 +3899,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-52II",
       "Lens rear cap"
@@ -3564,6 +4004,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -3635,6 +4083,14 @@
       "en": "Fujifilm XC 16-50mm OIS II",
       "zh": "富士 XC 16-50mm OIS II"
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -3708,6 +4164,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-43"
     ],
@@ -3790,6 +4254,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -3881,6 +4353,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Lens hood"
@@ -3976,6 +4456,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-8-16",
       "Lens rear cap RLCP-001",
@@ -4064,6 +4552,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-62 II",
       "Rear lens cap RLCP-001",
@@ -4157,6 +4653,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -4239,6 +4743,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 72,
     "lensConfiguration": {
       "groups": 10,
@@ -4319,6 +4831,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 7,
@@ -4397,6 +4917,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-58 II",
       "Rear lens cap RLCP-001",
@@ -4500,6 +5028,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 12,
@@ -4581,6 +5117,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-72 II",
       "Rear lens cap RLCP-001",
@@ -4682,6 +5226,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-72II",
       "Rear lens cap RLCP-001",
@@ -4768,6 +5320,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens hood LH-XF16"
     ],
@@ -4848,6 +5408,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-49",
       "Lens rear cap RLCP-001",
@@ -4955,6 +5523,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -5034,6 +5610,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 72,
     "lensConfiguration": {
       "groups": 12,
@@ -5123,6 +5707,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 67,
     "lensConfiguration": {
       "groups": 12,
@@ -5193,6 +5785,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens hood LH-XF18"
     ],
@@ -5266,6 +5866,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 52,
     "lensConfiguration": {
       "groups": 7,
@@ -5328,6 +5936,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -5400,6 +6016,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -5470,6 +6094,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-43",
       "Lens rear cap RLCP-001",
@@ -5553,6 +6185,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-39 II",
       "Rear lens cap RLCP-001",
@@ -5641,6 +6281,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -5711,6 +6359,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 39,
     "lensConfiguration": {
       "groups": 5,
@@ -5783,6 +6439,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 43,
     "lensConfiguration": {
       "groups": 9,
@@ -5853,6 +6517,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -5924,6 +6596,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -6009,6 +6689,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-43",
       "Lens rear cap RLCP-001",
@@ -6103,6 +6791,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Lens rear cap",
@@ -6191,6 +6887,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 9,
@@ -6261,6 +6965,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-46",
       "Lens rear cap RLCP-001",
@@ -6363,6 +7075,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 10,
@@ -6432,6 +7152,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -6503,6 +7231,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -6585,6 +7321,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-67 II",
       "Rear lens cap RLCP-001",
@@ -6675,6 +7419,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 39,
     "lensConfiguration": {
       "groups": 8,
@@ -6761,6 +7513,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 67,
     "lensConfiguration": {
       "groups": 12,
@@ -6835,6 +7595,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -6923,6 +7691,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 8,
@@ -7008,6 +7784,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 14,
@@ -7091,6 +7875,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-82",
       "Rear lens cap RLCP-001",
@@ -7182,6 +7974,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap FLCP-105",
       "Lens rear cap RLCP-001",
@@ -7270,6 +8070,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Front lens cap FLCP-95",
       "Rear lens cap RLCP-001",
@@ -7359,6 +8167,11 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -7448,6 +8261,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-4mm-f-2-8-mft/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -7539,6 +8361,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-8-16mm-f3-5-5-zoom-cf/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -7617,6 +8448,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/9mm/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -7699,6 +8539,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-10mm-f-4-cookie/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Sony E",
@@ -7785,6 +8634,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-12-24mm-f-5-6-zoom-shift-cf/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -7861,6 +8719,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-argus-25mm-f-0-95-apsc-apo/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -7943,6 +8810,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-argus-33mm-f-0-95-cf-apo/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8028,6 +8904,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://www.venuslens.net/product/laowa-65mm-f-2-8-2x-ultra-macro-apo/"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8098,6 +8983,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-12mm-f2-8-aps-c-ultra-wide-lens-copy"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": "N/A",
     "lensConfiguration": {
@@ -8171,6 +9065,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-24mm-f6-3-full-frame-ultra-slim-pancake-lens"
+      }
+    ],
     "compatibleMounts": [
       "Leica L",
       "Sony E",
@@ -8253,6 +9156,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/aps-c-25mm-f1-8-%E8%87%AA%E5%8A%A8%E5%AF%B9%E7%84%A6%E9%95%9C%E5%A4%B4"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8329,6 +9241,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/af-55mm-f1-8"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": 58,
     "lensConfiguration": {
@@ -8400,6 +9321,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-7-5mm-f2-8-aps-c-fisheye-lens"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8482,6 +9412,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8563,6 +9502,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens-copy"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8640,6 +9588,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-35mm-f0-95-ultra-bright-aps-c-lens"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8716,6 +9673,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-35mm-f1-2-aps-c-lens"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8793,6 +9759,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/mf-25mm-f2-8-aps-c-lens-copy"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -8869,6 +9844,15 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "official",
+        "url": "https://www.sg-image.com/products/50mm-f1-8-mf-full-frame-lens-with-shaped-aperture"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -8967,6 +9951,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -9057,6 +10049,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Canon RF",
       "Fujifilm X",
@@ -9152,6 +10152,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Canon RF",
       "Fujifilm X",
@@ -9267,6 +10275,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -9364,6 +10380,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -9465,6 +10489,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -9572,6 +10604,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -9660,6 +10700,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -9748,6 +10796,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -9837,6 +10893,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -9939,6 +11003,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "L-Mount",
       "Fujifilm X",
@@ -10042,6 +11114,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -10142,6 +11222,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -10247,6 +11335,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -10354,6 +11450,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Round-shaped hood",
       "Front cap",
@@ -10437,6 +11541,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-cine-lens",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -10521,6 +11635,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/100mm-f2-8macro",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -10599,6 +11723,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -10680,6 +11814,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/af-17mm-f1-8-air",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Sony E",
@@ -10753,6 +11897,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -10838,6 +11992,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/af27",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -10914,6 +12078,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11001,6 +12175,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/56mm",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11088,6 +12272,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -11174,6 +12368,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-7-5mm-f2",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11257,6 +12461,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/102",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11340,6 +12554,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11421,6 +12645,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-25mm-f2",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11499,6 +12733,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-35mm-f0-95",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11573,6 +12817,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-35mm-f1-4",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11658,6 +12912,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11733,6 +12997,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/aps-c-50mm-f0-95",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11808,6 +13082,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11887,6 +13171,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/tilt50mm",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11968,6 +13262,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/tilt-35mm-f1-4",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12053,6 +13357,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "official",
+        "url": "https://ttartisan.store/products/ts100",
+        "affiliate": "ref=idncwfkb"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -12148,6 +13462,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/af-9mm-f2-8-xf",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12217,6 +13541,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12311,6 +13645,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/af-15mm-f1-7-xf",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12384,6 +13728,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12474,6 +13828,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/af-25mm-f1-7-x",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12545,6 +13909,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12621,6 +13995,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/af-28mm-f4-5-x",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": "N/A",
     "lensConfiguration": {
@@ -12701,6 +14085,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12775,6 +14169,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12843,6 +14247,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/af-56mm-f1-2-xf",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -12921,6 +14335,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12996,6 +14420,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Nikon Z"
@@ -13064,6 +14498,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/75mm-f12-xf-lens",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -13143,6 +14587,16 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "official",
+        "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount",
+        "affiliate": "ref=owbtcyuk"
+      },
+      {
+        "channel": "bhphoto"
+      }
+    ],
     "lensMaterial": "Metal",
     "filterMm": 72,
     "lensConfiguration": {
@@ -13219,6 +14673,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13303,6 +14765,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13384,6 +14854,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13462,6 +14940,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13547,6 +15033,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13631,6 +15125,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -13715,6 +15217,14 @@
         }
       }
     },
+    "purchaseChannels": [
+      {
+        "channel": "bhphoto"
+      },
+      {
+        "channel": "ebay"
+      }
+    ],
     "accessories": [
       "Lens cap",
       "Rear cap",

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.24",
-  "lastUpdated": "2026-05-24T07:23:32.314Z",
+  "lastUpdated": "2026-05-24T09:31:22.064Z",
   "lensCount": 196,
-  "buildNumber": 2
+  "buildNumber": 3
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.24` build 3
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`