### PR TITLE
feat(data): publish lens data 2026.05.24 build 4

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -53,8 +53,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl"
       },
       {
         "channel": "bhphoto"
@@ -139,8 +138,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/25mm-f0-95",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/25mm-f0-95"
       },
       {
         "channel": "bhphoto"
@@ -241,8 +239,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z"
       },
       {
         "channel": "bhphoto"
@@ -332,8 +329,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
       },
       {
         "channel": "bhphoto"
@@ -414,8 +410,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx"
       },
       {
         "channel": "bhphoto"
@@ -491,8 +486,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-35mm-f1-4",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-35mm-f1-4"
       },
       {
         "channel": "bhphoto"
@@ -569,8 +563,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
       },
       {
         "channel": "bhphoto"
@@ -651,8 +644,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
       },
       {
         "channel": "bhphoto"
@@ -733,8 +725,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -817,8 +808,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -899,8 +889,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -982,8 +971,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -1065,8 +1053,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -1148,8 +1135,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10"
       },
       {
         "channel": "bhphoto"
@@ -1225,8 +1211,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43"
       },
       {
         "channel": "bhphoto"
@@ -1311,8 +1296,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43"
       },
       {
         "channel": "bhphoto"
@@ -1404,8 +1388,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii"
       },
       {
         "channel": "bhphoto"
@@ -1494,8 +1477,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43"
       },
       {
         "channel": "bhphoto"
@@ -1578,8 +1560,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z"
       },
       {
         "channel": "bhphoto"
@@ -1663,8 +1644,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z"
       },
       {
         "channel": "bhphoto"
@@ -1833,8 +1813,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/35mm-f1-2",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/35mm-f1-2"
       },
       {
         "channel": "bhphoto"
@@ -1917,8 +1896,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc"
       },
       {
         "channel": "bhphoto"
@@ -2005,8 +1983,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43"
       },
       {
         "channel": "bhphoto"
@@ -2087,8 +2064,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/50mm-f1-8",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/50mm-f1-8"
       },
       {
         "channel": "bhphoto"
@@ -2164,8 +2140,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/55mm-f1-4",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/55mm-f1-4"
       },
       {
         "channel": "bhphoto"
@@ -2247,8 +2222,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://7artisans.store/products/60mm-f2-8",
-        "affiliate": "ref=omwzyqkn"
+        "url": "https://7artisans.store/products/60mm-f2-8"
       },
       {
         "channel": "bhphoto"
@@ -2330,8 +2304,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -2512,8 +2485,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -2605,8 +2577,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -2686,8 +2657,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -2779,8 +2749,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -2872,8 +2841,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount"
       },
       {
         "channel": "bhphoto"
@@ -2962,8 +2930,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -3110,8 +3077,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -3253,8 +3219,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -3330,8 +3295,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -3412,8 +3376,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x"
       },
       {
         "channel": "bhphoto"
@@ -3485,8 +3448,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount",
-        "affiliate": "ref=mffdqyik"
+        "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -11547,8 +11509,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-cine-lens",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-cine-lens"
       }
     ],
     "compatibleMounts": [
@@ -11641,8 +11602,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/100mm-f2-8macro",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/100mm-f2-8macro"
       }
     ],
     "compatibleMounts": [
@@ -11729,8 +11689,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5"
       }
     ],
     "compatibleMounts": [
@@ -11820,8 +11779,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/af-17mm-f1-8-air",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/af-17mm-f1-8-air"
       }
     ],
     "compatibleMounts": [
@@ -11903,8 +11861,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8"
       }
     ],
     "compatibleMounts": [
@@ -11998,8 +11955,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/af27",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/af27"
       }
     ],
     "compatibleMounts": [
@@ -12084,8 +12040,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8"
       }
     ],
     "compatibleMounts": [
@@ -12181,8 +12136,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/56mm",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/56mm"
       }
     ],
     "compatibleMounts": [
@@ -12278,8 +12232,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2"
       }
     ],
     "compatibleMounts": [
@@ -12374,8 +12327,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-7-5mm-f2",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-7-5mm-f2"
       }
     ],
     "compatibleMounts": [
@@ -12467,8 +12419,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/102",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/102"
       }
     ],
     "compatibleMounts": [
@@ -12560,8 +12511,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black"
       }
     ],
     "compatibleMounts": [
@@ -12651,8 +12601,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-25mm-f2",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-25mm-f2"
       }
     ],
     "compatibleMounts": [
@@ -12739,8 +12688,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-35mm-f0-95",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-35mm-f0-95"
       }
     ],
     "compatibleMounts": [
@@ -12823,8 +12771,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-35mm-f1-4",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-35mm-f1-4"
       }
     ],
     "compatibleMounts": [
@@ -12918,8 +12865,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco"
       }
     ],
     "compatibleMounts": [
@@ -13003,8 +12949,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-50mm-f0-95",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/aps-c-50mm-f0-95"
       }
     ],
     "compatibleMounts": [
@@ -13088,8 +13033,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2"
       }
     ],
     "compatibleMounts": [
@@ -13177,8 +13121,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/tilt50mm",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/tilt50mm"
       }
     ],
     "compatibleMounts": [
@@ -13268,8 +13211,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/tilt-35mm-f1-4",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/tilt-35mm-f1-4"
       }
     ],
     "compatibleMounts": [
@@ -13363,8 +13305,7 @@
       },
       {
         "channel": "official",
-        "url": "https://ttartisan.store/products/ts100",
-        "affiliate": "ref=idncwfkb"
+        "url": "https://ttartisan.store/products/ts100"
       }
     ],
     "compatibleMounts": [
@@ -13465,8 +13406,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/af-9mm-f2-8-xf",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/af-9mm-f2-8-xf"
       },
       {
         "channel": "bhphoto"
@@ -13544,8 +13484,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models"
       },
       {
         "channel": "bhphoto"
@@ -13648,8 +13587,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/af-15mm-f1-7-xf",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/af-15mm-f1-7-xf"
       },
       {
         "channel": "bhphoto"
@@ -13731,8 +13669,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount"
       },
       {
         "channel": "bhphoto"
@@ -13831,8 +13768,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/af-25mm-f1-7-x",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/af-25mm-f1-7-x"
       },
       {
         "channel": "bhphoto"
@@ -13912,8 +13848,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount"
       },
       {
         "channel": "bhphoto"
@@ -13998,8 +13933,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/af-28mm-f4-5-x",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/af-28mm-f4-5-x"
       },
       {
         "channel": "bhphoto"
@@ -14088,8 +14022,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens"
       },
       {
         "channel": "bhphoto"
@@ -14172,8 +14105,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount"
       },
       {
         "channel": "bhphoto"
@@ -14250,8 +14182,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/af-56mm-f1-2-xf",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/af-56mm-f1-2-xf"
       },
       {
         "channel": "bhphoto"
@@ -14338,8 +14269,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens"
       },
       {
         "channel": "bhphoto"
@@ -14423,8 +14353,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z"
       },
       {
         "channel": "bhphoto"
@@ -14501,8 +14430,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/75mm-f12-xf-lens",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/75mm-f12-xf-lens"
       },
       {
         "channel": "bhphoto"
@@ -14590,8 +14518,7 @@
     "purchaseChannels": [
       {
         "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount",
-        "affiliate": "ref=owbtcyuk"
+        "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount"
       },
       {
         "channel": "bhphoto"

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.24",
-  "lastUpdated": "2026-05-24T09:31:22.064Z",
+  "lastUpdated": "2026-05-24T12:17:35.012Z",
   "lensCount": 196,
-  "buildNumber": 3
+  "buildNumber": 4
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.24` build 4
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`