### PR TITLE
fix(ui): Used badge order, dropdown item height, disclosure font

### DIFF
--- a/src/components/PriceCell.tsx
+++ b/src/components/PriceCell.tsx
@@ -40,6 +40,23 @@ export function PriceCell({ lens, compact = false }: Props) {
   return (
     <div className="flex flex-col items-center gap-1 text-center">
       <div className="inline-flex items-center gap-1.5">
+        {compact && isUsed && (
+          <Popover.Root>
+            <Popover.Trigger
+              className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+            >
+              <span>{t("usedBadge")}</span>
+              <Info className="size-2.5 opacity-70" aria-hidden="true" />
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Positioner side="top" align="center" sideOffset={6}>
+                <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                  {t("usedReason")}
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        )}
         <span
           className={cn(
             "font-semibold tabular-nums text-zinc-700 dark:text-zinc-200",
@@ -53,7 +70,7 @@ export function PriceCell({ lens, compact = false }: Props) {
             {t("approx")}
           </span>
         )}
-        {isUsed && (
+        {!compact && isUsed && (
           <Popover.Root>
             <Popover.Trigger
               className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"

--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -53,7 +53,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
               <DropdownItem key={link.channel} link={link} lensId={lens.id} customId={customId} />
             ))}
             {hasAffiliate && (
-              <div className="mt-1 flex items-start gap-2 border-t border-zinc-100 px-3 py-2 text-[11px] leading-relaxed text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+              <div className="mt-1 flex items-start gap-2 border-t border-zinc-100 px-3 py-2 text-[10px] leading-relaxed text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
                 <Info size={11} className="shrink-0 mt-0.5 text-zinc-400 dark:text-zinc-500" aria-hidden="true" />
                 <span>{t("disclosureDetail")}</span>
               </div>
@@ -77,7 +77,7 @@ function DropdownItem({ link, lensId, customId }: { link: PurchaseLink; lensId: 
         source: customId ?? "unknown",
         is_affiliate: link.isAffiliate,
       })}
-      className="flex items-center justify-between px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
+      className="flex items-center justify-between px-3 py-2.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
     >
       <span>{link.label}</span>
       <ArrowUpRight size={12} className="text-zinc-400" />


### PR DESCRIPTION
## Summary
- Move "Used" badge before the price amount in compact PriceCell (mobile compare buy panel)
- Increase RetailersDropdown item padding from py-2 to py-2.5 so items match the popup shadow height
- Shrink RetailersDropdown disclosure text from 11px to 10px on desktop

## Test plan
- [ ] Mobile compare "Where to Buy": Used badge appears before the price
- [ ] Desktop detail page: dropdown items are taller, disclosure text is smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)