### PR TITLE
fix(compare): remove non-existent LensHeader props from bad merge

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -524,10 +524,6 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
               <LensHeader
                 key={lens.id}
                 lens={lens}
-                url={getLensUrl(lens, locale)}
-                officialSiteLabel={t("officialSite")}
-                reportIssueLabel={t("reportIssue")}
-                feedbackFields={lensFields.get(lens.id)}
                 removeLabel={t("removeLens", { model: lensDisplayName(tBrand(lens.brand), lens.series, lens.model) })}
                 shiftLeftLabel={t("shiftLeft")}
                 shiftRightLabel={t("shiftRight")}


### PR DESCRIPTION
## Summary
- The merge conflict resolution in #277 incorrectly kept four props (`url`, `officialSiteLabel`, `reportIssueLabel`, `feedbackFields`) that `LensHeader` does not accept, causing a typecheck failure on main
- This removes those four lines

## Test plan
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)