### PR TITLE
feat(ui): add price approx label, stop rendering UsedBadge

### DIFF
--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -11,19 +11,17 @@ import { useNavLock } from "@/context/ScrollContainerContext";
 import { usePwa } from "@/lib/usePwa";
 import Image from "next/image";
 import { useTranslations, useLocale } from "next-intl";
-import { ChevronLeft, ChevronRight, Flag, TriangleAlert, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, TriangleAlert, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ICON_CLOSE_BTN_CLS, TEXT_LINK_CLS } from "@/lib/ui-tokens";
+import { ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
 import SpecialtyBadges from "@/components/SpecialtyBadges";
 import { deriveSpecialty } from "@/lib/lens-specialty";
-import FeedbackTrigger from "@/components/FeedbackTrigger";
-import type { FeedbackField } from "@/components/FeedbackDialog";
 import { useCompare } from "@/context/CompareProvider";
 import { useCompareLensSearch } from "@/hooks/useCompareLensSearch";
 import { useCompareUrlSync } from "@/hooks/useCompareUrlSync";
-import { getLensesByMount, getLensUrl, MAX_COMPARE } from "@/lib/lens";
+import { getLensesByMount, MAX_COMPARE } from "@/lib/lens";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import LensSearchDialog from "@/components/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens-image";
@@ -32,10 +30,9 @@ import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens-spec-groups";
 import type { Lens } from "@/lib/types";
 import { PriceCell } from "@/components/PriceCell";
 import { PurchaseLinksCompact, PurchaseDisclosureCaption } from "@/components/PurchaseLinks";
-import { CompareMobileBuyPanel } from "@/components/CompareMobileBuyPanel";
 import { buildPurchaseLinks } from "@/lib/purchase-links";
 import { useCountryCode } from "@/hooks/useCountryCode";
-import { pickPriceEntry, formatPriceForReport } from "@/lib/lens-pricing";
+import { pickPriceEntry } from "@/lib/lens-pricing";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
 
 // --- LensHeaderContent: shared inner card content ---
@@ -192,8 +189,6 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
   const tPurchase = useTranslations("Purchase");
   const locale = useLocale();
   const countryCode = useCountryCode();
-  const priceFieldLabel = tPricing("fieldLabel");
-  const priceGroupLabel = tPricing("groupLabel");
   const { compareIds, reorder, remove, seed } = useCompare();
   const { onSelectLens, getResultState } = useCompareLensSearch();
   // Compare page is the only surface that projects compare state onto the
@@ -345,39 +340,6 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
         .filter((group) => group.rows.length > 0),
     [allGroups, orderedLenses, resolvedPerLens]
   );
-
-  // Per-lens Report Dialog fields — derived from resolved values, identical to
-  // what is rendered in the table cells.
-  const lensFields = useMemo(() => {
-    const map = new Map<string, FeedbackField[]>();
-    const mediaGroupLabel = td("fieldGroupMedia");
-    for (const lens of orderedLenses) {
-      const rowMap = resolvedPerLens.get(lens.id);
-      if (!rowMap) {
-        continue;
-      }
-      const fields: FeedbackField[] = [];
-      for (const group of allGroups) {
-        for (const row of group.rows) {
-          const resolved = rowMap.get(row.label);
-          if (resolved) {
-            fields.push({ label: resolved.label, currentValue: resolved.plainText, group: group.label });
-          }
-        }
-      }
-      const url = getLensUrl(lens, locale);
-      if (url) {
-        fields.push({ label: td("fieldOfficialLink"), currentValue: url, group: mediaGroupLabel });
-      }
-      fields.push({ label: td("fieldLensImage"), currentValue: getLensImageUrl(lens.id), group: mediaGroupLabel, hideCurrentValue: true });
-      const priceSelection = pickPriceEntry(lens.pricing, locale);
-      if (priceSelection) {
-        fields.push({ label: priceFieldLabel, currentValue: formatPriceForReport(priceSelection, locale, tPricing), group: priceGroupLabel });
-      }
-      map.set(lens.id, fields);
-    }
-    return map;
-  }, [resolvedPerLens, allGroups, orderedLenses, td, tPricing, priceFieldLabel, priceGroupLabel, locale]);
 
   const totalColSpan = orderedLenses.length + 1 + emptySlotCount;
   const { lockNav } = useNavLock();

--- a/src/components/PriceCell.tsx
+++ b/src/components/PriceCell.tsx
@@ -2,13 +2,10 @@
 
 // Per-lens price cell used in the compare table.
 //
-// Shows the real captured price, optional Used badge (clickable — explains
-// why a used reference was picked), and persistent source · sampled-date
-// caption below. The unified disclaimer for the whole pricing column lives
-// next to the "Price" field label on the left, not repeated per cell.
+// Shows the captured price with an "approx." qualifier,
+// and persistent source · sampled-date caption below.
 
-import { Popover } from "@base-ui/react/popover";
-import { Calendar, Info } from "lucide-react";
+import { Calendar } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 import {
   pickPriceEntry,
@@ -33,61 +30,26 @@ export function PriceCell({ lens, compact = false }: Props) {
   }
 
   const { entry, condition } = selection;
-  const isUsed = condition === "used";
   const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t.raw("cnyAmount"));
   const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
   return (
     <div className="flex flex-col items-center gap-1 text-center">
-      <div className="inline-flex items-center gap-1.5">
-        {compact && isUsed && (
-          <Popover.Root>
-            <Popover.Trigger
-              className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-            >
-              <span>{t("usedBadge")}</span>
-              <Info className="size-2.5 opacity-70" aria-hidden="true" />
-            </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Positioner side="top" align="center" sideOffset={6}>
-                <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                  {t("usedReason")}
-                </Popover.Popup>
-              </Popover.Positioner>
-            </Popover.Portal>
-          </Popover.Root>
+      <span
+        className={cn(
+          "font-semibold tabular-nums text-zinc-700 dark:text-zinc-200",
+          compact ? "text-sm" : "text-base",
         )}
-        <span
-          className={cn(
-            "font-semibold tabular-nums text-zinc-700 dark:text-zinc-200",
-            compact ? "text-sm" : "text-base",
-          )}
-        >
-          {priceDisplay}
-        </span>
-        {compact && (
-          <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
-            {t("approx")}
-          </span>
-        )}
-        {!compact && isUsed && (
-          <Popover.Root>
-            <Popover.Trigger
-              className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded bg-zinc-100 px-1 py-px text-[10px] font-medium text-zinc-500 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-400 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-            >
-              <span>{t("usedBadge")}</span>
-              <Info className="size-2.5 opacity-70" aria-hidden="true" />
-            </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Positioner side="top" align="center" sideOffset={6}>
-                <Popover.Popup className="max-w-72 origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                  {t("usedReason")}
-                </Popover.Popup>
-              </Popover.Positioner>
-            </Popover.Portal>
-          </Popover.Root>
-        )}
-      </div>
+      >
+        {t.rich("priceApprox", {
+          price: priceDisplay,
+          approx: (chunks) => (
+            <span className={cn("font-normal text-zinc-400 dark:text-zinc-500", compact ? "text-[10px]" : "text-xs")}>
+              {chunks}
+            </span>
+          ),
+        })}
+      </span>
 
       {!compact && (
         <>

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -64,6 +64,7 @@ export function PriceSection({ lens }: Props) {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function UsedBadge({ size, reason, label }: { size: "sm" | "md"; reason: string; label: string }) {
   const padding = size === "md" ? "px-1.5 py-px" : "px-1 py-px";
   const fontSize = size === "md" ? "text-[11px]" : "text-[10px]";

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -2,13 +2,10 @@
 
 // Expanded price display for the lens detail page.
 //
-// Layout (visually bound as a single "price info" card):
-//   ¥1,299  [Used ⓘ]   ← Used badge is clickable; explains why used was picked
+// Layout:
+//   ~¥1,299  (zh) / $999 approx.  (en)
 //   source · Sampled date
 //   ⚠ Disclaimer · …
-//
-// All three rows share a soft background so the disclaimer is
-// unambiguously about THIS price, not the spec table that follows below.
 
 import { Popover } from "@base-ui/react/popover";
 import { Calendar, Info } from "lucide-react";
@@ -35,29 +32,23 @@ export function PriceSection({ lens }: Props) {
   }
 
   const { entry, condition } = selection;
-  const isUsed = condition === "used";
-
   const priceDisplay = formatPrice(entry.price, entry.currency, locale, condition, t.raw("cnyAmount"));
   const sourceDisplay = entry.source;
   const sampledDisplay = formatSampledAt(entry.sampledAt, locale);
 
   return (
-    // No background card — the price block is bound visually by tight inner
-    // gaps (gap-1) while the outer column's gap-5 separates it from title
-    // above and action buttons below. This trades the card's explicit
-    // "unit" boundary for clean left alignment of every text line with the
-    // title and buttons.
     <div className="flex flex-col gap-1">
-      {/* Row 1: Price + used badge (clickable when used) */}
-      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
-        <span className="text-xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
-          {priceDisplay}
-        </span>
-        {isUsed && <UsedBadge size="md" reason={t("usedReason")} label={t("conditionUsed")} />}
-      </div>
+      {/* Row 1: Price + approx */}
+      <span className="text-xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
+        {t.rich("priceApprox", {
+          price: priceDisplay,
+          approx: (chunks) => (
+            <span className="text-sm font-normal text-zinc-400 dark:text-zinc-500">{chunks}</span>
+          ),
+        })}
+      </span>
 
-      {/* Row 2: Source + sampled date — calendar icon makes the date read
-          as data, not prose. */}
+      {/* Row 2: Source + sampled date */}
       <div className="inline-flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
         <span data-redact-hook="priceSource">{sourceDisplay}</span>
         <span className="opacity-30">|</span>
@@ -73,9 +64,6 @@ export function PriceSection({ lens }: Props) {
   );
 }
 
-// Inline-defined so the click affordance (cursor + hover background + trailing
-// info icon) stays paired with the badge's visual treatment. If a second
-// surface ever needs the same clickable badge, hoist this to its own file.
 function UsedBadge({ size, reason, label }: { size: "sm" | "md"; reason: string; label: string }) {
   const padding = size === "md" ? "px-1.5 py-px" : "px-1 py-px";
   const fontSize = size === "md" ? "text-[11px]" : "text-[10px]";

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -638,7 +638,6 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
                   </div>
                 );
               }
-              const isUsed = sel.condition === "used";
               const priceDisplay = formatPrice(
                 sel.entry.price,
                 sel.entry.currency,

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -649,16 +649,8 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
               const sampledDisplay = formatSampledAt(sel.entry.sampledAt, labels.locale);
               return (
                 <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
-                  {/* Value + Used badge */}
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
-                    <span className={cn("font-semibold tabular-nums text-zinc-700 leading-none", statSize)}>
-                      {priceDisplay}
-                    </span>
-                    {isUsed && (
-                      <span className="rounded bg-zinc-200 px-1 py-px text-zinc-500" style={{ fontSize: 8, fontWeight: 500 }}>
-                        {labels.usedBadge}
-                      </span>
-                    )}
+                  <span className={cn("font-semibold tabular-nums text-zinc-700 leading-none", statSize)}>
+                    {priceDisplay}
                   </span>
                   {/* Caption row 1: source */}
                   <span data-redact-hook="priceSource" className="tabular-nums text-zinc-400 leading-tight text-center" style={{ fontSize: 9, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>

--- a/src/hooks/useCountryCode.ts
+++ b/src/hooks/useCountryCode.ts
@@ -14,7 +14,7 @@ function getServerSnapshot(): string {
   return DEFAULT_COUNTRY;
 }
 
-function subscribe(_cb: () => void): () => void {
+function subscribe(/* cb */): () => void {
   return () => {};
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -489,7 +489,7 @@
     "rowWarn": "please do verify the latest price",
     "usedReason": "No new-price listing was found in official channels; showing a used-market reference instead.",
     "sampledAt": "Sampled {date}",
-    "approx": "approx."
+    "priceApprox": "{price} <approx>approx.</approx>"
   },
   "Purchase": {
     "whereToBuy": "Where to buy",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -489,7 +489,7 @@
     "rowWarn": "请务必核实最新价格",
     "usedReason": "官方渠道未采集到该镜头的新品价格，此处展示二手市场参考价。",
     "sampledAt": "采样于 {date}",
-    "approx": "约"
+    "priceApprox": "<approx>~</approx>{price}"
   },
   "Purchase": {
     "whereToBuy": "购买渠道",


### PR DESCRIPTION
## Summary
- Add "approx." / "~" qualifier to all price displays using `t.rich()` i18n template — locale controls prefix vs suffix positioning with zero locale checks in components
- Stop rendering UsedBadge in all surfaces (detail page, compare table, share poster) — component definition retained in `PriceSection.tsx` for future use
- Remove compact-mode UsedBadge code from PriceCell entirely

## Test plan
- [ ] Lens detail: price shows `$999 approx.` (en) / `~¥1,299` (zh)
- [ ] Compare table: same approx label renders correctly
- [ ] Share poster: no Used badge on price
- [ ] No Used badge visible anywhere in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)