### PR TITLE
feat(api): add BFF edge data layer for lens list and search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "19.2.4",
         "shadcn": "^4.1.0",
         "sonner": "^2.0.7",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6"
@@ -8517,6 +8518,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -14621,6 +14631,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tagged-tag": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.2.4",
     "shadcn": "^4.1.0",
     "sonner": "^2.0.7",
+    "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getLensesByMount } from "@/lib/lens";
-import { urlSegmentToMount } from "@/lib/mount";
+import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
 import LensesLoading from "./loading";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
@@ -53,7 +53,6 @@ export default async function LensesPage({ params }: { params: Params }) {
   if (!resolvedMount) {
     notFound();
   }
-  const lenses = getLensesByMount(resolvedMount, locale);
   const t = await getTranslations({ locale, namespace: "LensList" });
   const h1Title = resolvedMount === "X" ? t("metaTitleX") : t("metaTitleG");
 
@@ -66,7 +65,7 @@ export default async function LensesPage({ params }: { params: Params }) {
           anchor. */}
       <h1 className="sr-only">{h1Title}</h1>
       <Suspense fallback={<LensesLoading />}>
-        <LensListClient lenses={lenses} />
+        <LensListClient mount={mount as MountSegment} />
       </Suspense>
     </>
   );

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getLensesByMount } from "@/lib/lens";
-import { urlSegmentToMount, mountToUrlSegment } from "@/lib/mount";
+import { urlSegmentToMount } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
 import LensesLoading from "./loading";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
@@ -65,7 +65,7 @@ export default async function LensesPage({ params }: { params: Params }) {
           anchor. */}
       <h1 className="sr-only">{h1Title}</h1>
       <Suspense fallback={<LensesLoading />}>
-        <LensListClient mount={mountToUrlSegment(resolvedMount)} />
+        <LensListClient />
       </Suspense>
     </>
   );

--- a/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getLensesByMount } from "@/lib/lens";
-import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
+import { urlSegmentToMount, mountToUrlSegment } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
 import LensesLoading from "./loading";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
@@ -65,7 +65,7 @@ export default async function LensesPage({ params }: { params: Params }) {
           anchor. */}
       <h1 className="sr-only">{h1Title}</h1>
       <Suspense fallback={<LensesLoading />}>
-        <LensListClient mount={mount as MountSegment} />
+        <LensListClient mount={mountToUrlSegment(resolvedMount)} />
       </Suspense>
     </>
   );

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
 type FeedbackType = "data_issue" | "general";
 
@@ -18,32 +19,8 @@ interface FeedbackPayload {
 }
 
 const MAX_DESCRIPTION_LENGTH = 2000;
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 5;
 
-const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const bucket = rateLimitBuckets.get(ip);
-  if (!bucket || bucket.resetAt < now) {
-    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-  if (bucket.count >= RATE_LIMIT_MAX) {
-    return false;
-  }
-  bucket.count += 1;
-  return true;
-}
-
-function getClientIp(req: Request): string {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    return forwarded.split(",")[0].trim();
-  }
-  return req.headers.get("x-real-ip") ?? "unknown";
-}
+const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 5 });
 
 function buildIssue(payload: FeedbackPayload): {
   title: string;
@@ -132,12 +109,8 @@ export function GET() {
 }
 
 export async function POST(req: Request) {
-  const ip = getClientIp(req);
-  if (!checkRateLimit(ip)) {
-    return NextResponse.json(
-      { error: "rate_limited" },
-      { status: 429 }
-    );
+  if (!checkRateLimit(req)) {
+    return RATE_LIMITED_RESPONSE;
   }
 
   let payload: FeedbackPayload;

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -10,33 +10,9 @@ import { parseFilters } from "@/lib/filter-params";
 import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
 import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { routing } from "@/i18n/routing";
+import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 120;
-
-const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const bucket = rateLimitBuckets.get(ip);
-  if (!bucket || bucket.resetAt < now) {
-    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-  if (bucket.count >= RATE_LIMIT_MAX) {
-    return false;
-  }
-  bucket.count += 1;
-  return true;
-}
-
-function getClientIp(req: Request): string {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    return forwarded.split(",")[0].trim();
-  }
-  return req.headers.get("x-real-ip") ?? "unknown";
-}
+const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
 const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
 
@@ -48,9 +24,8 @@ function computeAvailableOpticalTraits(lenses: { isCine?: boolean; opticalTraits
 }
 
 export function GET(req: Request) {
-  const ip = getClientIp(req);
-  if (!checkRateLimit(ip)) {
-    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  if (!checkRateLimit(req)) {
+    return RATE_LIMITED_RESPONSE;
   }
 
   const { searchParams } = new URL(req.url);

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import {
+  filterLenses,
+  sortLenses,
+  getLensesByMount,
+  getOrderedUniqueBrands,
+} from "@/lib/lens";
+import { deriveSpecialty } from "@/lib/lens-specialty";
+import { parseFilters } from "@/lib/filter-params";
+import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
+import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
+import { routing } from "@/i18n/routing";
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 120;
+
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  bucket.count += 1;
+  return true;
+}
+
+function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
+
+function computeAvailableOpticalTraits(lenses: { isCine?: boolean; opticalTraits?: OpticalTrait[] }[]): OpticalTrait[] {
+  const present = new Set(
+    lenses.flatMap((l) => deriveSpecialty(l).opticalTraits),
+  );
+  return OPTICAL_TRAITS.filter((trait) => present.has(trait));
+}
+
+export function GET(req: Request) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  }
+
+  const { searchParams } = new URL(req.url);
+
+  const mountParam = searchParams.get("mount");
+  const locale = searchParams.get("locale");
+
+  if (!mountParam || !VALID_MOUNTS.includes(mountParam)) {
+    return NextResponse.json(
+      { error: "invalid or missing 'mount' param (expected 'x' or 'gfx')" },
+      { status: 400 },
+    );
+  }
+  if (!locale || !(routing.locales as readonly string[]).includes(locale)) {
+    return NextResponse.json(
+      { error: `invalid or missing 'locale' param (expected ${routing.locales.join(" or ")})` },
+      { status: 400 },
+    );
+  }
+
+  const mount = urlSegmentToMount(mountParam as MountSegment)!;
+  const allLenses = getLensesByMount(mount, locale);
+
+  const filters = parseFilters(searchParams);
+  const filtered = filterLenses(allLenses, filters);
+  const sorted = sortLenses(filtered, filters.sort, filters.sortDir);
+
+  let result = sorted;
+  const pageParam = searchParams.get("page");
+  const limitParam = searchParams.get("limit");
+  if (pageParam && limitParam) {
+    const page = Math.max(1, parseInt(pageParam, 10) || 1);
+    const limit = Math.max(1, Math.min(200, parseInt(limitParam, 10) || 50));
+    const start = (page - 1) * limit;
+    result = sorted.slice(start, start + limit);
+  }
+
+  const brands = getOrderedUniqueBrands(allLenses);
+  const availableOpticalTraits = computeAvailableOpticalTraits(allLenses);
+
+  return NextResponse.json(
+    {
+      lenses: result,
+      total: sorted.length,
+      brands,
+      availableOpticalTraits,
+    },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { getLensesByMount } from "@/lib/lens";
+import { buildLensSearchIndex, searchLensIndex, type LensSearchIndex } from "@/lib/lens-search";
+import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
+import { routing } from "@/i18n/routing";
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 120;
+
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  bucket.count += 1;
+  return true;
+}
+
+function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
+const MAX_QUERY_LENGTH = 200;
+const DEFAULT_LIMIT = 8;
+const MAX_LIMIT = 30;
+
+const indexCache = new Map<string, LensSearchIndex>();
+
+function getCachedIndex(mount: string, locale: string): LensSearchIndex {
+  const key = `${mount}:${locale}`;
+  let index = indexCache.get(key);
+  if (!index) {
+    const resolvedMount = urlSegmentToMount(mount as MountSegment)!;
+    index = buildLensSearchIndex(getLensesByMount(resolvedMount, locale));
+    indexCache.set(key, index);
+  }
+  return index;
+}
+
+export function GET(req: Request) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  }
+
+  const { searchParams } = new URL(req.url);
+
+  const mountParam = searchParams.get("mount");
+  const locale = searchParams.get("locale");
+  const query = searchParams.get("q");
+
+  if (!mountParam || !VALID_MOUNTS.includes(mountParam)) {
+    return NextResponse.json(
+      { error: "invalid or missing 'mount' param (expected 'x' or 'gfx')" },
+      { status: 400 },
+    );
+  }
+  if (!locale || !(routing.locales as readonly string[]).includes(locale)) {
+    return NextResponse.json(
+      { error: `invalid or missing 'locale' param (expected ${routing.locales.join(" or ")})` },
+      { status: 400 },
+    );
+  }
+  if (!query || query.trim().length === 0) {
+    return NextResponse.json(
+      { error: "missing or empty 'q' param" },
+      { status: 400 },
+    );
+  }
+  if (query.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json(
+      { error: `query too long (max ${MAX_QUERY_LENGTH} chars)` },
+      { status: 400 },
+    );
+  }
+
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam
+    ? Math.max(1, Math.min(MAX_LIMIT, parseInt(limitParam, 10) || DEFAULT_LIMIT))
+    : DEFAULT_LIMIT;
+
+  const index = getCachedIndex(mountParam, locale);
+  const results = searchLensIndex(index, query.trim(), limit);
+
+  return NextResponse.json(
+    { results, query: query.trim() },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -3,33 +3,9 @@ import { getLensesByMount } from "@/lib/lens";
 import { buildLensSearchIndex, searchLensIndex, type LensSearchIndex } from "@/lib/lens-search";
 import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
+import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 120;
-
-const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const bucket = rateLimitBuckets.get(ip);
-  if (!bucket || bucket.resetAt < now) {
-    rateLimitBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-  if (bucket.count >= RATE_LIMIT_MAX) {
-    return false;
-  }
-  bucket.count += 1;
-  return true;
-}
-
-function getClientIp(req: Request): string {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    return forwarded.split(",")[0].trim();
-  }
-  return req.headers.get("x-real-ip") ?? "unknown";
-}
+const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
 const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
 const MAX_QUERY_LENGTH = 200;
@@ -50,9 +26,8 @@ function getCachedIndex(mount: string, locale: string): LensSearchIndex {
 }
 
 export function GET(req: Request) {
-  const ip = getClientIp(req);
-  if (!checkRateLimit(ip)) {
-    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  if (!checkRateLimit(req)) {
+    return RATE_LIMITED_RESPONSE;
   }
 
   const { searchParams } = new URL(req.url);

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -19,7 +19,8 @@ import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
 import { useLensesApi } from "@/hooks/useLensesApi";
-import type { MountSegment } from "@/lib/mount";
+import { mountToUrlSegment } from "@/lib/mount";
+import { useEffectiveMount } from "@/hooks/useMountParam";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
 import { Button } from "@/components/ui/button";
@@ -36,22 +37,19 @@ import LensSearchDialog from "./LensSearchDialog";
 import LensesLoading from "@/app/[locale]/lenses/[mount]/(browse)/loading";
 import FeedbackTrigger from "./FeedbackTrigger";
 
-interface Props {
-  mount: MountSegment;
-}
-
-export default function LensListClient({ mount }: Props) {
+export default function LensListClient() {
   const t = useTranslations("LensList");
   const tSearch = useTranslations("Search");
   const hookAttr = useUiHookAttr();
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const locale = useLocale();
+  const mount = useEffectiveMount();
 
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
 
-  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mount, locale);
+  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mountToUrlSegment(mount), locale);
 
   const displayed = useMemo(
     () =>

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -2,25 +2,24 @@
 
 import { useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
+import { useLocale } from "next-intl";
 import { usePathname, Link } from "@/i18n/navigation";
 import { motion, AnimatePresence } from "motion/react";
 import { useTranslations } from "next-intl";
-import type { Lens } from "@/lib/types";
 import { TEXT_LINK_CLS } from "@/lib/ui-tokens";
 import {
   filterLenses,
   sortLenses,
   defaultFilters,
-  getOrderedUniqueBrands,
   MAX_COMPARE,
   type FilterState,
   type SortKey,
 } from "@/lib/lens";
-import { deriveSpecialty } from "@/lib/lens-specialty";
-import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
+import { useLensesApi } from "@/hooks/useLensesApi";
+import type { MountSegment } from "@/lib/mount";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
 import { Button } from "@/components/ui/button";
@@ -34,39 +33,35 @@ import {
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
 import LensSearchDialog from "./LensSearchDialog";
+import LensesLoading from "@/app/[locale]/lenses/[mount]/(browse)/loading";
 import FeedbackTrigger from "./FeedbackTrigger";
 
 interface Props {
-  lenses: Lens[];
+  mount: MountSegment;
 }
 
-export default function LensListClient({ lenses }: Props) {
+export default function LensListClient({ mount }: Props) {
   const t = useTranslations("LensList");
   const tSearch = useTranslations("Search");
   const hookAttr = useUiHookAttr();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const locale = useLocale();
 
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
 
-  const brands = useMemo(() => getOrderedUniqueBrands(lenses), [lenses]);
-
-  const availableOpticalTraits = useMemo<OpticalTrait[]>(
-    () => {
-      const present = new Set(
-        lenses.flatMap((l) => deriveSpecialty(l).opticalTraits),
-      );
-      return OPTICAL_TRAITS.filter((trait) => present.has(trait));
-    },
-    [lenses],
-  );
+  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mount, locale);
 
   const displayed = useMemo(
     () =>
       sortLenses(filterLenses(lenses, filters), filters.sort, filters.sortDir),
     [lenses, filters]
   );
+
+  if (isLoading && lenses.length === 0) {
+    return <LensesLoading />;
+  }
 
   const hasActiveFilters =
     filters.brands.length > 0 ||

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { useLocale } from "next-intl";
 import { usePathname, Link } from "@/i18n/navigation";
 import { motion, AnimatePresence } from "motion/react";
 import { useTranslations } from "next-intl";
@@ -19,7 +18,6 @@ import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
 import { useLensesApi } from "@/hooks/useLensesApi";
-import { useEffectiveMount } from "@/hooks/useMountParam";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
 import { Button } from "@/components/ui/button";
@@ -42,13 +40,10 @@ export default function LensListClient() {
   const hookAttr = useUiHookAttr();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const locale = useLocale();
-  const mount = useEffectiveMount();
-
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
 
-  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mount, locale);
+  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi();
 
   const displayed = useMemo(
     () =>

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -19,7 +19,6 @@ import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
 import { useLensesApi } from "@/hooks/useLensesApi";
-import { mountToUrlSegment } from "@/lib/mount";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
@@ -49,7 +48,7 @@ export default function LensListClient() {
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
 
-  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mountToUrlSegment(mount), locale);
+  const { lenses, brands, availableOpticalTraits, isLoading } = useLensesApi(mount, locale);
 
   const displayed = useMemo(
     () =>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -5,7 +5,6 @@ import {
   useDeferredValue,
   useEffect,
   useId,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -13,10 +12,9 @@ import type { LucideIcon } from "lucide-react";
 import { Search, X } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
-import { getLensesByMount } from "@/lib/lens";
 import { mountToUrlSegment } from "@/lib/mount";
 import { useEffectiveMount } from "@/hooks/useMountParam";
-import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens-search";
+import { useLensSearchApi } from "@/hooks/useLensSearchApi";
 import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { lensSubtitleLine } from "@/lib/lens.format";
@@ -60,7 +58,6 @@ export default function LensSearchDialog({
   const router = useRouter();
   const locale = useLocale();
   const mount = useEffectiveMount();
-  const lensSearchIndex = useMemo(() => buildLensSearchIndex(getLensesByMount(mount, locale)), [mount, locale]);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
@@ -101,9 +98,10 @@ export default function LensSearchDialog({
     }
   }, [activeIndex]);
 
-  const results = useMemo(
-    () => searchLensIndex(lensSearchIndex, deferredQuery),
-    [lensSearchIndex, deferredQuery]
+  const { results, isLoading: isSearching } = useLensSearchApi(
+    mountToUrlSegment(mount),
+    locale,
+    deferredQuery,
   );
 
   useSearchTelemetry({ query: deferredQuery, resultsCount: results.length, isOpen: open });
@@ -240,7 +238,11 @@ export default function LensSearchDialog({
             ref={scrollContainerRef}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
-            {query.trim().length === 0 ? null : results.length === 0 ? (
+            {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-700 dark:border-t-zinc-400" />
+              </div>
+            ) : results.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
                 <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
                   {t("noResults")}

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Search, X } from "lucide-react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
 import { useEffectiveMount } from "@/hooks/useMountParam";
@@ -56,7 +56,6 @@ export default function LensSearchDialog({
   const t = useTranslations("Search");
   const tBrand = useTranslations("Brands");
   const router = useRouter();
-  const locale = useLocale();
   const mount = useEffectiveMount();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -98,11 +97,7 @@ export default function LensSearchDialog({
     }
   }, [activeIndex]);
 
-  const { results, isLoading: isSearching } = useLensSearchApi(
-    mountToUrlSegment(mount),
-    locale,
-    deferredQuery,
-  );
+  const { results, isLoading: isSearching } = useLensSearchApi(deferredQuery);
 
   useSearchTelemetry({ query: deferredQuery, resultsCount: results.length, isOpen: open });
 

--- a/src/hooks/useLensSearchApi.ts
+++ b/src/hooks/useLensSearchApi.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import useSWR from "swr";
+import { useLocale } from "next-intl";
 import type { Lens } from "@/lib/types";
-import type { MountSegment } from "@/lib/mount";
+import { mountToUrlSegment } from "@/lib/mount";
+import { useEffectiveMount } from "@/hooks/useMountParam";
 import { jsonFetcher, buildSearchUrl } from "@/lib/api";
 
 interface SearchResponse {
@@ -12,14 +14,11 @@ interface SearchResponse {
 
 const EMPTY_RESULTS: Lens[] = [];
 
-export function useLensSearchApi(
-  mount: MountSegment,
-  locale: string,
-  query: string,
-  limit = 8,
-) {
+export function useLensSearchApi(query: string, limit = 8) {
+  const mount = useEffectiveMount();
+  const locale = useLocale();
   const trimmed = query.trim();
-  const url = trimmed ? buildSearchUrl(mount, locale, trimmed, limit) : null;
+  const url = trimmed ? buildSearchUrl(mountToUrlSegment(mount), locale, trimmed, limit) : null;
   const { data, error, isLoading } = useSWR<SearchResponse>(url, jsonFetcher, {
     keepPreviousData: true,
     dedupingInterval: 300,

--- a/src/hooks/useLensSearchApi.ts
+++ b/src/hooks/useLensSearchApi.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import useSWR from "swr";
+import type { Lens } from "@/lib/types";
+import type { MountSegment } from "@/lib/mount";
+import { jsonFetcher, buildSearchUrl } from "@/lib/api";
+
+interface SearchResponse {
+  results: Lens[];
+  query: string;
+}
+
+const EMPTY_RESULTS: Lens[] = [];
+
+export function useLensSearchApi(
+  mount: MountSegment,
+  locale: string,
+  query: string,
+  limit = 8,
+) {
+  const trimmed = query.trim();
+  const url = trimmed ? buildSearchUrl(mount, locale, trimmed, limit) : null;
+  const { data, error, isLoading } = useSWR<SearchResponse>(url, jsonFetcher, {
+    keepPreviousData: true,
+    dedupingInterval: 300,
+  });
+
+  return {
+    results: data?.results ?? EMPTY_RESULTS,
+    isLoading,
+    error,
+  };
+}

--- a/src/hooks/useLensesApi.ts
+++ b/src/hooks/useLensesApi.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import useSWR from "swr";
-import type { Lens, OpticalTrait } from "@/lib/types";
-import type { MountSegment } from "@/lib/mount";
+import type { Lens, Mount, OpticalTrait } from "@/lib/types";
+import { mountToUrlSegment } from "@/lib/mount";
 import { jsonFetcher, buildLensListUrl } from "@/lib/api";
 
 interface LensListResponse {
@@ -16,8 +16,8 @@ const EMPTY_LENSES: Lens[] = [];
 const EMPTY_BRANDS: string[] = [];
 const EMPTY_TRAITS: OpticalTrait[] = [];
 
-export function useLensesApi(mount: MountSegment, locale: string) {
-  const url = buildLensListUrl(mount, locale);
+export function useLensesApi(mount: Mount, locale: string) {
+  const url = buildLensListUrl(mountToUrlSegment(mount), locale);
   const { data, error, isLoading } = useSWR<LensListResponse>(url, jsonFetcher, {
     keepPreviousData: true,
     revalidateOnFocus: false,

--- a/src/hooks/useLensesApi.ts
+++ b/src/hooks/useLensesApi.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import useSWR from "swr";
-import type { Lens, Mount, OpticalTrait } from "@/lib/types";
+import { useLocale } from "next-intl";
+import type { Lens, OpticalTrait } from "@/lib/types";
 import { mountToUrlSegment } from "@/lib/mount";
+import { useEffectiveMount } from "@/hooks/useMountParam";
 import { jsonFetcher, buildLensListUrl } from "@/lib/api";
 
 interface LensListResponse {
@@ -16,7 +18,9 @@ const EMPTY_LENSES: Lens[] = [];
 const EMPTY_BRANDS: string[] = [];
 const EMPTY_TRAITS: OpticalTrait[] = [];
 
-export function useLensesApi(mount: Mount, locale: string) {
+export function useLensesApi() {
+  const mount = useEffectiveMount();
+  const locale = useLocale();
   const url = buildLensListUrl(mountToUrlSegment(mount), locale);
   const { data, error, isLoading } = useSWR<LensListResponse>(url, jsonFetcher, {
     keepPreviousData: true,

--- a/src/hooks/useLensesApi.ts
+++ b/src/hooks/useLensesApi.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import useSWR from "swr";
+import type { Lens, OpticalTrait } from "@/lib/types";
+import type { MountSegment } from "@/lib/mount";
+import { jsonFetcher, buildLensListUrl } from "@/lib/api";
+
+interface LensListResponse {
+  lenses: Lens[];
+  total: number;
+  brands: string[];
+  availableOpticalTraits: OpticalTrait[];
+}
+
+const EMPTY_LENSES: Lens[] = [];
+const EMPTY_BRANDS: string[] = [];
+const EMPTY_TRAITS: OpticalTrait[] = [];
+
+export function useLensesApi(mount: MountSegment, locale: string) {
+  const url = buildLensListUrl(mount, locale);
+  const { data, error, isLoading } = useSWR<LensListResponse>(url, jsonFetcher, {
+    keepPreviousData: true,
+    revalidateOnFocus: false,
+    dedupingInterval: 2000,
+  });
+
+  return {
+    lenses: data?.lenses ?? EMPTY_LENSES,
+    brands: data?.brands ?? EMPTY_BRANDS,
+    availableOpticalTraits: data?.availableOpticalTraits ?? EMPTY_TRAITS,
+    total: data?.total ?? 0,
+    isLoading,
+    error,
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,26 @@
+import type { MountSegment } from "./mount";
+
+export async function jsonFetcher<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`API ${res.status}: ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function buildLensListUrl(mount: MountSegment, locale: string): string {
+  return `/api/lenses?mount=${mount}&locale=${locale}`;
+}
+
+export function buildSearchUrl(
+  mount: MountSegment,
+  locale: string,
+  query: string,
+  limit?: number,
+): string {
+  const params = new URLSearchParams({ mount, locale, q: query });
+  if (limit) {
+    params.set("limit", String(limit));
+  }
+  return `/api/lenses/search?${params.toString()}`;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+interface RateLimiterOptions {
+  windowMs: number;
+  max: number;
+}
+
+function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+export function createRateLimiter({ windowMs, max }: RateLimiterOptions) {
+  const buckets = new Map<string, Bucket>();
+
+  return function checkRateLimit(req: Request): boolean {
+    const ip = getClientIp(req);
+    const now = Date.now();
+    const bucket = buckets.get(ip);
+    if (!bucket || bucket.resetAt < now) {
+      buckets.set(ip, { count: 1, resetAt: now + windowMs });
+      return true;
+    }
+    if (bucket.count >= max) {
+      return false;
+    }
+    bucket.count += 1;
+    return true;
+  };
+}
+
+export const RATE_LIMITED_RESPONSE = NextResponse.json(
+  { error: "rate_limited" },
+  { status: 429 },
+);


### PR DESCRIPTION
## Summary

- Add two API route handlers (`/api/lenses`, `/api/lenses/search`) that serve lens data from in-memory JSON with rate limiting
- Migrate `LensListClient` and `LensSearchDialog` to fetch data via SWR hooks instead of static imports
- API supports full filter/sort/pagination params — client currently fetches all data once and filters locally (Phase 1)

## Design

Phase 1 of a progressive BFF layer. The API is complete (server-side filtering + pagination ready), but the client uses the simplest integration: fetch all → cache in SWR → filter locally. This preserves instant filter switching while moving data delivery behind an API endpoint.

Upgrade path to server-side filtering (Phase 2) requires changing hook params + removing ~5 lines of local filter logic — no API changes, no structural rewrite.

## What's NOT migrated

Compare-related components (`CompareBar`, `CompareTable`, `CuratedComparisons`) still call `getLensesByMount()` directly. They resolve 1-4 lenses by ID — different use case, separate follow-up.

## Test plan

- [ ] Lens list page loads, shows correct count, filters/sorts instantly
- [ ] Search dialog returns results via API
- [ ] Network tab shows `/api/lenses` and `/api/lenses/search` calls
- [ ] Filter switching does NOT trigger new API requests (client-side filtering)
- [ ] Compare page unaffected
- [ ] GFX mount (`/lenses/gfx`) works correctly
- [ ] Both locales (zh/en) return correctly translated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)