### PR TITLE
fix(ui): improve mobile search drawer height and scroll behavior

### DIFF
--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -178,10 +178,10 @@ export default function LensSearchDialog({
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
-          className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
+          className="h-[calc(100dvh-3rem)] max-h-[calc(100dvh-3rem)] w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 sm:h-auto sm:max-h-none dark:border-zinc-800 dark:bg-zinc-950"
           showCloseButton={false}
         >
-          <DialogHeader className="border-b border-zinc-100 pr-5 dark:border-zinc-800">
+          <DialogHeader className="shrink-0 border-b border-zinc-100 pr-5 dark:border-zinc-800">
             <div className="flex items-center justify-between">
               <div>
                 <DialogTitle>{t("title")}</DialogTitle>
@@ -231,7 +231,7 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
-            className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-3 py-3 sm:h-[300px] sm:flex-none [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
             {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
               <div className="flex items-center justify-center py-16">


### PR DESCRIPTION
## Summary

- Make the search drawer near-full-screen on mobile (`calc(100dvh - 3rem)`) with a top peek preserved, so the virtual keyboard doesn't obscure the search input
- Results area uses `flex-1` instead of fixed `h-[300px]` to fill remaining space, reducing dead zones where accidental swipe-to-dismiss can trigger
- Add `overscroll-y-contain` on the scroll container to prevent scroll chaining
- Desktop dialog unchanged (`sm:h-auto sm:flex-none sm:h-[300px]`)

## Test plan

- [ ] Mobile (390px): search drawer opens near-full-screen with visible top peek + rounded corners
- [ ] Mobile: type a query, results fill remaining space and scroll without accidentally dismissing
- [ ] Mobile (zh): Chinese locale renders correctly
- [ ] Desktop (≥640px): search dialog unchanged — centered, 300px results area

🤖 Generated with [Claude Code](https://claude.com/claude-code)