### PR TITLE
feat(mount): show one-time toast when switching to G mount

### DIFF
--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -9,7 +9,10 @@ import { useMountPreference } from "@/context/MountPreferenceProvider";
 import { mountToUrlSegment } from "@/lib/mount";
 import type { Mount } from "@/lib/types";
 import { track } from "@/lib/analytics";
+import { toast } from "sonner";
 import { Select, SelectContent, SelectItem } from "@/components/ui/select";
+
+const GFX_BETA_NOTICED_KEY = "gfx-beta-noticed";
 
 export default function MountSwitcher() {
   const t = useTranslations("MountSwitcher");
@@ -29,6 +32,14 @@ export default function MountSwitcher() {
     }
     if (value !== effectiveMount) {
       track("mount_switch", { from_mount: effectiveMount, to_mount: value });
+    }
+    if (value === "G") {
+      try {
+        if (!localStorage.getItem(GFX_BETA_NOTICED_KEY)) {
+          toast(t("gfxBetaNotice"), { duration: 6000 });
+          localStorage.setItem(GFX_BETA_NOTICED_KEY, "1");
+        }
+      } catch {}
     }
     setPreference(value);
     if (urlMount !== null) {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -47,7 +47,8 @@
     "x": "X Mount",
     "gfx": "G Mount",
     "xCaption": "APS-C",
-    "gfxCaption": "Medium format"
+    "gfxCaption": "Medium format",
+    "gfxBetaNotice": "G Mount coverage is still growing — some lenses and features may be missing."
   },
   "Home": {
     "cta": "Browse Lenses",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -47,7 +47,8 @@
     "x": "X 卡口",
     "gfx": "G 卡口",
     "xCaption": "APS-C",
-    "gfxCaption": "中画幅"
+    "gfxCaption": "中画幅",
+    "gfxBetaNotice": "G 卡口数据仍在完善中，部分镜头和功能暂未覆盖。"
   },
   "Home": {
     "cta": "浏览镜头",


### PR DESCRIPTION
## Summary
- Show a non-blocking Sonner toast the first time a user switches to G mount, setting expectations that lens/feature coverage is still incomplete
- Uses `localStorage` to ensure the notice only appears once per browser
- Adds `gfxBetaNotice` i18n key for both en/zh

## Test plan
- [x] Switch to G mount → toast appears with correct locale text
- [x] Switch back to X, then to G again → no toast (localStorage flag persists)
- [x] Clear `localStorage.removeItem('gfx-beta-noticed')` → toast reappears on next switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)