### PR TITLE
style(detail): reduce collection chip title font weight

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -429,7 +429,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
                 href={`/lenses/${mount}/collections/${c.slug}`}
                 className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
               >
-                <span className="font-medium text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
+                <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
                   {locale === "zh" ? c.title.zh : c.title.en}
                 </span>
                 <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">


### PR DESCRIPTION
## Summary
- Reduce font weight of collection chip titles in the "Featured In" section from `font-medium` (500) to `font-normal` (400)

## Test plan
- [x] Visit any lens detail page with collections (e.g. XF 16mm F1.4) and verify chip titles appear lighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)