### PR TITLE
fix(ui): adjust count/sort row spacing and unify border-radius

### DIFF
--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -139,7 +139,8 @@ export default function LensListClient() {
                 </SelectTrigger>
                 <SelectContent
                   align="end"
-                  className="overflow-hidden rounded-xl"
+                  sideOffset={0}
+                  className="overflow-hidden rounded-lg"
                 >
                   {sortOptions.map((option) => (
                     <SelectItem

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -85,7 +85,7 @@ export default function LensListClient() {
 
   return (
     <>
-      <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 pt-4 sm:pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col gap-6">
+      <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 pt-4 sm:pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col">
         <div className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
@@ -99,77 +99,78 @@ export default function LensListClient() {
             availableOpticalTraits={availableOpticalTraits}
             onFiltersChange={updateFilters}
           />
-          <div>
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-center gap-3 text-sm text-zinc-500 dark:text-zinc-400">
-                <p className="whitespace-nowrap">{t("resultsCount", { count: displayed.length })}</p>
-                {hasActiveFilters ? (
-                  <button
-                    type="button"
-                    className={`whitespace-nowrap text-[11px] font-medium uppercase tracking-[0.08em] ${TEXT_LINK_CLS}`}
-                    onClick={clearAllFilters}
-                  >
-                    {t("clearFilters")}
-                  </button>
-                ) : null}
-              </div>
+        </div>
 
-              <div className="ml-auto inline-flex items-center gap-2">
-                <Select
-                  value={filters.sort}
-                  onValueChange={(value) =>
-                    updateFilters((current) => ({
-                      ...current,
-                      sort: (value ?? "focalLength") as SortKey,
-                    }))
-                  }
-                  items={sortOptions.map((option) => ({ ...option }))}
+        <div className="mt-6 mb-2 sm:mt-5 sm:mb-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-3 text-sm text-zinc-500 dark:text-zinc-400">
+              <p className="whitespace-nowrap">{t("resultsCount", { count: displayed.length })}</p>
+              {hasActiveFilters ? (
+                <button
+                  type="button"
+                  className={`whitespace-nowrap text-[11px] font-medium uppercase tracking-[0.08em] ${TEXT_LINK_CLS}`}
+                  onClick={clearAllFilters}
                 >
-                  <SelectTrigger
-                    id="results-sort"
-                    hideChevronOnMobile
-                    className="justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 px-3 text-[12px] shadow-sm shadow-zinc-950/[0.02] data-[size=default]:h-9 dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[12rem]"
-                  >
-                    <span className="whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
-                      {t("sortBy")}
-                    </span>
-                    <SelectValue placeholder={t("sortFocalLength")} />
-                  </SelectTrigger>
-                  <SelectContent
-                    align="end"
-                    className="overflow-hidden rounded-xl"
-                  >
-                    {sortOptions.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        className="rounded-none py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
-                      >
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="outline"
-                  className="h-9 rounded-xl border-zinc-200/70 bg-white/80 px-2.5 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30"
-                  onClick={() =>
-                    updateFilters((current) => ({
-                      ...current,
-                      sortDir: current.sortDir === "asc" ? "desc" : "asc",
-                    }))
-                  }
-                  aria-label={
-                    filters.sortDir === "asc" ? t("sortAsc") : t("sortDesc")
-                  }
+                  {t("clearFilters")}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="ml-auto inline-flex items-center gap-2">
+              <Select
+                value={filters.sort}
+                onValueChange={(value) =>
+                  updateFilters((current) => ({
+                    ...current,
+                    sort: (value ?? "focalLength") as SortKey,
+                  }))
+                }
+                items={sortOptions.map((option) => ({ ...option }))}
+              >
+                <SelectTrigger
+                  id="results-sort"
+                  hideChevronOnMobile
+                  className="justify-start gap-2 rounded-xl border-zinc-200/70 bg-white/80 px-3 text-[12px] shadow-sm shadow-zinc-950/[0.02] data-[size=default]:h-9 dark:border-zinc-800 dark:bg-zinc-900/30 sm:min-w-[12rem]"
                 >
-                  {filters.sortDir === "asc" ? (
-                    <ArrowUpNarrowWide />
-                  ) : (
-                    <ArrowDownNarrowWide />
-                  )}
-                </Button>
-              </div>
+                  <span className="whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
+                    {t("sortBy")}
+                  </span>
+                  <SelectValue placeholder={t("sortFocalLength")} />
+                </SelectTrigger>
+                <SelectContent
+                  align="end"
+                  className="overflow-hidden rounded-xl"
+                >
+                  {sortOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      className="rounded-none py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                variant="outline"
+                className="h-9 rounded-xl border-zinc-200/70 bg-white/80 px-2.5 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30"
+                onClick={() =>
+                  updateFilters((current) => ({
+                    ...current,
+                    sortDir: current.sortDir === "asc" ? "desc" : "asc",
+                  }))
+                }
+                aria-label={
+                  filters.sortDir === "asc" ? t("sortAsc") : t("sortDesc")
+                }
+              >
+                {filters.sortDir === "asc" ? (
+                  <ArrowUpNarrowWide />
+                ) : (
+                  <ArrowDownNarrowWide />
+                )}
+              </Button>
             </div>
           </div>
         </div>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -152,7 +152,7 @@ export default function LensSearchDialog({
           triggerVariant === "icon"
             ? "inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200 bg-white text-zinc-600 transition-colors hover:border-zinc-300 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:text-zinc-50"
             : triggerVariant === "button"
-              ? "inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 transition-colors hover:border-zinc-300 hover:text-zinc-950 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:text-zinc-50"
+              ? "inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 transition-colors hover:border-zinc-300 hover:text-zinc-950 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:text-zinc-50"
               : "group flex w-full flex-col items-center justify-center gap-2 rounded-[28px] border border-dashed border-zinc-300 bg-zinc-50/60 text-center text-zinc-500 transition-colors hover:border-zinc-400 hover:bg-zinc-100/70 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950/60 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:bg-zinc-900 dark:hover:text-zinc-50",
           triggerClassName
         )}

--- a/src/components/lens-filters/TypeSegmentedControl.tsx
+++ b/src/components/lens-filters/TypeSegmentedControl.tsx
@@ -29,7 +29,7 @@ export default function TypeSegmentedControl<T>({
       role="radiogroup"
       aria-label={ariaLabel}
       className={cn(
-        "rounded-lg bg-zinc-100 dark:bg-zinc-800 p-1",
+        "rounded-xl bg-zinc-100 dark:bg-zinc-800 p-1",
         compact
           ? "flex min-w-0 flex-1"
           : cn("w-full sm:w-fit", wrap ? "flex flex-wrap" : "flex sm:inline-flex"),
@@ -45,7 +45,7 @@ export default function TypeSegmentedControl<T>({
             role="radio"
             aria-checked={selected}
             className={cn(
-              "h-8 rounded-md text-[12px] font-medium transition-colors sm:h-7",
+              "h-8 rounded-lg text-[12px] font-medium transition-colors sm:h-7",
               compact ? "flex-1 px-2.5" : "flex-1 px-4 sm:flex-none",
               selected
                 ? "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-50 dark:shadow-none"


### PR DESCRIPTION
## Summary
- Move the count + sort row out of the filter container so its spacing can be controlled independently
- `mt-6 mb-2` on mobile, `sm:mt-5 sm:mb-3` on desktop — visually groups the row with the lens grid rather than the filters
- Unify border-radius across controls: segmented container `rounded-lg` → `rounded-xl`, inner buttons `rounded-md` → `rounded-lg`, search button `rounded-2xl` → `rounded-xl`
- Sort dropdown popup downgraded to `rounded-lg` to visually distinguish from lens cards; `sideOffset` reduced to 0

## Test plan
- [x] Desktop (1440px): spacing and radius verified
- [x] Mobile (390px): spacing and radius verified
- [x] Sort dropdown open state checked on both viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)