### PR TITLE
feat(compare): shared collections section, restore footer links, add header feedback

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -23,6 +23,7 @@ import { deriveSpecialty } from "@/lib/lens-specialty";
 import { RetailersDropdown } from "@/components/RetailersDropdown";
 import { UTILITY_BTN_CLS } from "@/lib/ui-tokens";
 import { getMemberCollections } from "@/lib/collections";
+import CollectionPills from "@/components/CollectionPills";
 import { Link } from "@/i18n/navigation";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
@@ -409,38 +410,13 @@ export default async function LensDetailPage({ params }: { params: Params }) {
           </div>
       </div>
 
-      {memberCollections.length > 0 && (
-        <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
-          <div className="mb-4 flex items-baseline justify-between">
-            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-              {t("collectionsTitle")}
-            </h2>
-            <Link
-              href={`/lenses/${mount}/collections`}
-              className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-            >
-              {t("viewAllCollections")} →
-            </Link>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {memberCollections.map((c) => (
-              <Link
-                key={c.slug}
-                href={`/lenses/${mount}/collections/${c.slug}`}
-                className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
-              >
-                <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
-                  {locale === "zh" ? c.title.zh : c.title.en}
-                </span>
-                <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
-                  {c.lensCount}
-                </span>
-                <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
+      <CollectionPills
+        collections={memberCollections}
+        mountSegment={seg}
+        locale={locale}
+        title={t("collectionsTitle")}
+        viewAllLabel={t("viewAllCollections")}
+      />
     </div>
     <BackToTopButton />
     <ShareFAB lenses={[lens]} />

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { parseLensIds } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import { findPresetByIds } from "@/lib/curated-presets";
+import { getSharedCollections } from "@/lib/collections";
 import CompareTable from "@/components/CompareTable";
 import ComparePageHeader from "@/components/ComparePageHeader";
 import CompareTelemetry from "@/components/telemetry/CompareTelemetry";
@@ -110,8 +112,12 @@ export default async function ComparePage({
   }
 
   const tNav = await getTranslations("Nav");
+  const t = await getTranslations({ locale, namespace: "Compare" });
   const seg = mountToUrlSegment(resolvedMount);
   const lenses = parseLensIds(ids, resolvedMount, locale);
+  const sharedCollections = lenses.length > 0
+    ? getSharedCollections(lenses, resolvedMount, locale)
+    : [];
 
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 pt-4 sm:pt-8 pb-40 flex flex-col gap-3 sm:gap-4">
@@ -121,6 +127,38 @@ export default async function ComparePage({
       />
       <ComparePageHeader />
       <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
+      {sharedCollections.length > 0 && (
+        <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
+          <div className="mb-4 flex items-baseline justify-between">
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              {t("collectionsTitle")}
+            </h2>
+            <Link
+              href={`/lenses/${seg}/collections`}
+              className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+            >
+              {t("viewAllCollections")} →
+            </Link>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {sharedCollections.map((c) => (
+              <Link
+                key={c.slug}
+                href={`/lenses/${seg}/collections/${c.slug}`}
+                className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
+              >
+                <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
+                  {locale === "zh" ? c.title.zh : c.title.en}
+                </span>
+                <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
+                  {c.lensCount}
+                </span>
+                <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
       {resolvedMount === "X" && <CuratedComparisons />}
       <BackToTopButton />
       <CompareTelemetry lensIds={lenses.map((l) => l.id)} />

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { parseLensIds } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import { findPresetByIds } from "@/lib/curated-presets";
-import { getSharedCollections } from "@/lib/collections";
 import CompareTable from "@/components/CompareTable";
 import ComparePageHeader from "@/components/ComparePageHeader";
+import CompareCollections from "@/components/CompareCollections";
 import CompareTelemetry from "@/components/telemetry/CompareTelemetry";
 import CuratedComparisons from "@/components/CuratedComparisons";
 import BackToTopButton from "@/components/BackToTopButton";
@@ -112,12 +111,8 @@ export default async function ComparePage({
   }
 
   const tNav = await getTranslations("Nav");
-  const t = await getTranslations({ locale, namespace: "Compare" });
   const seg = mountToUrlSegment(resolvedMount);
   const lenses = parseLensIds(ids, resolvedMount, locale);
-  const sharedCollections = lenses.length > 0
-    ? getSharedCollections(lenses, resolvedMount, locale)
-    : [];
 
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 pt-4 sm:pt-8 pb-40 flex flex-col gap-3 sm:gap-4">
@@ -127,38 +122,7 @@ export default async function ComparePage({
       />
       <ComparePageHeader />
       <CompareTable key={lenses.length === 0 ? "_empty_" : ids} lenses={lenses} minColumns={2} hideBodyWhenEmpty />
-      {sharedCollections.length > 0 && (
-        <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
-          <div className="mb-4 flex items-baseline justify-between">
-            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-              {t("collectionsTitle")}
-            </h2>
-            <Link
-              href={`/lenses/${seg}/collections`}
-              className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-            >
-              {t("viewAllCollections")} →
-            </Link>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {sharedCollections.map((c) => (
-              <Link
-                key={c.slug}
-                href={`/lenses/${seg}/collections/${c.slug}`}
-                className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
-              >
-                <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
-                  {locale === "zh" ? c.title.zh : c.title.en}
-                </span>
-                <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
-                  {c.lensCount}
-                </span>
-                <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
+      <CompareCollections />
       {resolvedMount === "X" && <CuratedComparisons />}
       <BackToTopButton />
       <CompareTelemetry lensIds={lenses.map((l) => l.id)} />

--- a/src/components/CollectionPills.tsx
+++ b/src/components/CollectionPills.tsx
@@ -1,0 +1,55 @@
+import { Link } from "@/i18n/navigation";
+import type { MemberCollectionInfo } from "@/lib/collections";
+
+interface CollectionPillsProps {
+  collections: MemberCollectionInfo[];
+  mountSegment: string;
+  locale: string;
+  title: string;
+  viewAllLabel: string;
+}
+
+export default function CollectionPills({
+  collections,
+  mountSegment,
+  locale,
+  title,
+  viewAllLabel,
+}: CollectionPillsProps) {
+  if (collections.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          {title}
+        </h2>
+        <Link
+          href={`/lenses/${mountSegment}/collections`}
+          className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          {viewAllLabel} →
+        </Link>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {collections.map((c) => (
+          <Link
+            key={c.slug}
+            href={`/lenses/${mountSegment}/collections/${c.slug}`}
+            className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
+          >
+            <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
+              {locale === "zh" ? c.title.zh : c.title.en}
+            </span>
+            <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
+              {c.lensCount}
+            </span>
+            <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/CompareCollections.tsx
+++ b/src/components/CompareCollections.tsx
@@ -2,12 +2,12 @@
 
 import { useMemo } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import { Link } from "@/i18n/navigation";
 import { useCompare } from "@/context/CompareProvider";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { getLensesByMount } from "@/lib/lens";
 import { getSharedCollections } from "@/lib/collections";
 import { mountToUrlSegment } from "@/lib/mount";
+import CollectionPills from "@/components/CollectionPills";
 import type { Lens } from "@/lib/types";
 
 export default function CompareCollections() {
@@ -30,40 +30,13 @@ export default function CompareCollections() {
     [activeLenses, mount, locale],
   );
 
-  if (sharedCollections.length === 0) {
-    return null;
-  }
-
   return (
-    <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
-      <div className="mb-4 flex items-baseline justify-between">
-        <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          {t("collectionsTitle")}
-        </h2>
-        <Link
-          href={`/lenses/${seg}/collections`}
-          className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-        >
-          {t("viewAllCollections")} →
-        </Link>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {sharedCollections.map((c) => (
-          <Link
-            key={c.slug}
-            href={`/lenses/${seg}/collections/${c.slug}`}
-            className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
-          >
-            <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
-              {locale === "zh" ? c.title.zh : c.title.en}
-            </span>
-            <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
-              {c.lensCount}
-            </span>
-            <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
-          </Link>
-        ))}
-      </div>
-    </section>
+    <CollectionPills
+      collections={sharedCollections}
+      mountSegment={seg}
+      locale={locale}
+      title={t("collectionsTitle")}
+      viewAllLabel={t("viewAllCollections")}
+    />
   );
 }

--- a/src/components/CompareCollections.tsx
+++ b/src/components/CompareCollections.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { useCompare } from "@/context/CompareProvider";
+import { useEffectiveMount } from "@/hooks/useMountParam";
+import { getLensesByMount } from "@/lib/lens";
+import { getSharedCollections } from "@/lib/collections";
+import { mountToUrlSegment } from "@/lib/mount";
+import type { Lens } from "@/lib/types";
+
+export default function CompareCollections() {
+  const t = useTranslations("Compare");
+  const locale = useLocale();
+  const { compareIds } = useCompare();
+  const mount = useEffectiveMount();
+  const seg = mountToUrlSegment(mount);
+
+  const activeLenses = useMemo(
+    () =>
+      compareIds
+        .map((id) => getLensesByMount(mount, locale).find((l) => l.id === id))
+        .filter((l): l is Lens => l !== undefined),
+    [compareIds, mount, locale],
+  );
+
+  const sharedCollections = useMemo(
+    () => getSharedCollections(activeLenses, mount, locale),
+    [activeLenses, mount, locale],
+  );
+
+  if (sharedCollections.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="border-t border-zinc-200 pt-6 dark:border-zinc-800">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          {t("collectionsTitle")}
+        </h2>
+        <Link
+          href={`/lenses/${seg}/collections`}
+          className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          {t("viewAllCollections")} →
+        </Link>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {sharedCollections.map((c) => (
+          <Link
+            key={c.slug}
+            href={`/lenses/${seg}/collections/${c.slug}`}
+            className="group inline-flex items-center gap-2 rounded-full border border-zinc-200 px-3 py-1.5 text-sm transition-colors hover:border-zinc-900 hover:bg-zinc-900 hover:text-white dark:border-zinc-700 dark:hover:border-zinc-100 dark:hover:bg-zinc-100 dark:hover:text-zinc-900"
+          >
+            <span className="font-normal text-zinc-900 group-hover:text-white dark:text-zinc-100 dark:group-hover:text-zinc-900">
+              {locale === "zh" ? c.title.zh : c.title.en}
+            </span>
+            <span className="text-xs text-zinc-400 group-hover:text-zinc-400 dark:text-zinc-500 dark:group-hover:text-zinc-500">
+              {c.lensCount}
+            </span>
+            <span className="text-zinc-300 group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-400" aria-hidden="true">→</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -51,9 +51,17 @@ export default function ComparePageHeader() {
   const presetTitle = matchedPreset?.title[lang];
   const presetSubtitle = matchedPreset?.subtitle[lang];
 
+  // On mobile cold-start the entire row is invisible (h1 is `sm:block`,
+  // no buttons render until there's at least one lens), but the wrapper
+  // still occupies a flex slot in the parent column — its zero height
+  // plus the parent's `gap-3` doubles to ~24px of empty space between
+  // the breadcrumb and the table. Collapse the wrapper to `display:none`
+  // when there's nothing in it on mobile.
+  const isEmpty = activeLenses.length === 0;
+
   return (
     <>
-      <div className="flex items-center gap-3">
+      <div className={`flex items-center gap-3 ${isEmpty ? "hidden sm:flex" : ""}`}>
         <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h1>

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -93,19 +93,19 @@ export default function ComparePageHeader() {
             {tList("clearCompare")}
           </button>
         )}
-        {activeLenses.length >= 1 && (
-          <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-1">
+          {activeLenses.length >= 1 && (
             <ShareButton lenses={activeLenses} presetTitle={presetTitle} presetSubtitle={presetSubtitle} />
-            <FeedbackTrigger
-              type="general"
-              context={{}}
-              className={UTILITY_BTN_CLS}
-            >
-              <Flag className="size-4" />
-              <span className="hidden sm:inline">{t("reportIssue")}</span>
-            </FeedbackTrigger>
-          </div>
-        )}
+          )}
+          <FeedbackTrigger
+            type="general"
+            context={{}}
+            className={UTILITY_BTN_CLS}
+          >
+            <Flag className="size-4" />
+            <span className="hidden sm:inline">{t("reportIssue")}</span>
+          </FeedbackTrigger>
+        </div>
       </div>
 
       <ShareFAB

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -4,8 +4,11 @@ import { useMemo } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { toast } from "sonner";
 import LensSearchDialog from "@/components/LensSearchDialog";
+import { Flag } from "lucide-react";
 import { ShareButton } from "@/components/share/ShareButton";
 import ShareFAB from "@/components/ShareFAB";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
+import { UTILITY_BTN_CLS } from "@/lib/ui-tokens";
 import { useCompare } from "@/context/CompareProvider";
 import { useClearCompareWithUndo } from "@/hooks/useClearCompareWithUndo";
 import { useCompareLensSearch } from "@/hooks/useCompareLensSearch";
@@ -91,8 +94,16 @@ export default function ComparePageHeader() {
           </button>
         )}
         {activeLenses.length >= 1 && (
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-1">
             <ShareButton lenses={activeLenses} presetTitle={presetTitle} presetSubtitle={presetSubtitle} />
+            <FeedbackTrigger
+              type="general"
+              context={{}}
+              className={UTILITY_BTN_CLS}
+            >
+              <Flag className="size-4" />
+              <span className="hidden sm:inline">{t("reportIssue")}</span>
+            </FeedbackTrigger>
           </div>
         )}
       </div>

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -51,17 +51,9 @@ export default function ComparePageHeader() {
   const presetTitle = matchedPreset?.title[lang];
   const presetSubtitle = matchedPreset?.subtitle[lang];
 
-  // On mobile cold-start the entire row is invisible (h1 is `sm:block`,
-  // no buttons render until there's at least one lens), but the wrapper
-  // still occupies a flex slot in the parent column — its zero height
-  // plus the parent's `gap-3` doubles to ~24px of empty space between
-  // the breadcrumb and the table. Collapse the wrapper to `display:none`
-  // when there's nothing in it on mobile.
-  const isEmpty = activeLenses.length === 0;
-
   return (
     <>
-      <div className={`flex items-center gap-3 ${isEmpty ? "hidden sm:flex" : ""}`}>
+      <div className="flex items-center gap-3">
         <h1 className="hidden sm:block text-2xl font-bold text-zinc-900 dark:text-zinc-50">
           {t("title")}
         </h1>

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -11,9 +11,11 @@ import { useNavLock } from "@/context/ScrollContainerContext";
 import { usePwa } from "@/lib/usePwa";
 import Image from "next/image";
 import { useTranslations, useLocale } from "next-intl";
-import { ChevronLeft, ChevronRight, TriangleAlert, X } from "lucide-react";
+import { ArrowUpRight, ChevronLeft, ChevronRight, Flag, TriangleAlert, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
+import { ICON_CLOSE_BTN_CLS, TEXT_LINK_CLS } from "@/lib/ui-tokens";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
+import { getLensUrl } from "@/lib/lens";
 import { BoolCell } from "@/components/ui/bool-cell";
 import { FieldNotePopover } from "@/components/ui/field-note-popover";
 import SpecialtyBadges from "@/components/SpecialtyBadges";
@@ -865,6 +867,61 @@ export default function CompareTable({ lenses: initialLenses, minColumns = 0, hi
             );
           })}
         </tbody>
+
+        {orderedLenses.length > 0 && (
+          <tfoot>
+            <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-800/60">
+              <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" />
+              {orderedLenses.map((lens) => {
+                const url = getLensUrl(lens, locale);
+                const fields = visibleGroups.flatMap((group) =>
+                  group.rows
+                    .map((row) => {
+                      const resolved = resolvedPerLens.get(lens.id)?.get(row.label);
+                      return resolved
+                        ? { label: row.label, currentValue: resolved.plainText, group: group.label }
+                        : null;
+                    })
+                    .filter((f): f is NonNullable<typeof f> => f !== null)
+                );
+                return (
+                  <td key={lens.id} className="px-3 py-2">
+                    <div className="flex flex-col items-center justify-center gap-0.5">
+                      {url ? (
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
+                        >
+                          <ArrowUpRight className="h-3 w-3 shrink-0" />
+                          {t("officialSite")}
+                        </a>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 text-zinc-300 dark:text-zinc-600 cursor-not-allowed">
+                          <ArrowUpRight className="h-3 w-3 shrink-0" />
+                          {t("officialSite")}
+                        </span>
+                      )}
+                      <FeedbackTrigger
+                        type="data_issue"
+                        context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
+                        fields={fields}
+                        className={`inline-flex items-center gap-1 text-xs font-medium whitespace-nowrap py-1 ${TEXT_LINK_CLS}`}
+                      >
+                        <Flag className="h-3 w-3 shrink-0" />
+                        {t("reportIssue")}
+                      </FeedbackTrigger>
+                    </div>
+                  </td>
+                );
+              })}
+              {Array.from({ length: emptySlotCount }).map((_, i) => (
+                <td key={`empty-links-${i}`} className="border-l border-zinc-200 dark:border-zinc-800" />
+              ))}
+            </tr>
+          </tfoot>
+        )}
 
       </table>
     </div>

--- a/src/components/CuratedComparisons.tsx
+++ b/src/components/CuratedComparisons.tsx
@@ -105,13 +105,12 @@ export default function CuratedComparisons() {
           className="overflow-x-auto snap-x snap-mandatory scroll-pl-4 [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:none]"
           style={scrollerMask ? { maskImage: scrollerMask, WebkitMaskImage: scrollerMask } : undefined}
         >
-          <div className="flex items-start gap-2 px-4 pb-0.5">
+          <div className="inline-flex items-start gap-2 px-4 pb-0.5">
             {curatedPresets.map((preset) => (
               <div key={preset.slug} className="shrink-0 snap-start w-[calc((100vw-2.5rem)/1.5)]">
                 <PresetCard preset={preset} />
               </div>
             ))}
-            <div className="shrink-0 w-2" aria-hidden="true" />
           </div>
         </div>
 

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -301,3 +301,23 @@ export function getMemberCollections(
       lensCount: allLenses.filter((l) => c.filter(l, locale)).length,
     }));
 }
+
+export function getSharedCollections(
+  lenses: Lens[],
+  mount: Mount,
+  locale: string,
+): MemberCollectionInfo[] {
+  if (lenses.length === 0) {
+    return [];
+  }
+  if (lenses.length === 1) {
+    return getMemberCollections(lenses[0], mount, locale);
+  }
+  const allLenses = getLensesByMount(mount, locale);
+  return Object.values(COLLECTIONS)
+    .filter((c) => lenses.every((lens) => c.filter(lens, locale)))
+    .map((c) => ({
+      ...c,
+      lensCount: allLenses.filter((l) => c.filter(l, locale)).length,
+    }));
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -278,7 +278,9 @@
     "shiftLeft": "Move left",
     "shiftRight": "Move right",
     "curatedTitle": "Curated Comparisons",
-    "curatedHint": "Not sure where to start? Try one of my curated comparisons below."
+    "curatedHint": "Not sure where to start? Try one of my curated comparisons below.",
+    "collectionsTitle": "Featured In",
+    "viewAllCollections": "View all collections"
   },
   "Share": {
     "button": "Share",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -278,7 +278,9 @@
     "shiftLeft": "左移一列",
     "shiftRight": "右移一列",
     "curatedTitle": "精选对比",
-    "curatedHint": "还没想好比什么？试试下面这些精选对比吧。"
+    "curatedHint": "还没想好比什么？试试下面这些精选对比吧。",
+    "collectionsTitle": "所属专题",
+    "viewAllCollections": "查看所有专题"
   },
   "Share": {
     "button": "分享",


### PR DESCRIPTION
## Summary

- Add "Featured In" section to the compare page showing collections that all compared lenses share (intersection algorithm). Single lens degrades to detail-page behavior; empty intersection hides the section.
- Collections section is a client component (`CompareCollections`) that subscribes to `CompareProvider`, so it updates reactively when lenses are added/removed — no server round-trip needed.
- Restore per-lens Official Page and Report buttons in the table footer (removed in 4e15e85 along with the header links; only the footer should have been kept).
- Add Feedback button next to Share in `ComparePageHeader`, matching the detail page layout.

## Test plan

- [ ] Compare 2+ similar lenses (e.g. two 35mm primes) → "Featured In" shows intersection collections
- [ ] Compare 2 very different lenses (e.g. wide prime vs tele zoom) → section hidden (empty intersection)
- [ ] Single lens in compare → shows all member collections (detail-page parity)
- [ ] Remove a lens → collections update instantly without page reload
- [ ] Table footer shows Official Page + Report per lens column
- [ ] Header shows Share + Report buttons side by side
- [ ] Verify zh locale renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)