### PR TITLE
fix(ui): make Reset badge circular and prevent underline bleed-through

### DIFF
--- a/src/components/LensFilters.tsx
+++ b/src/components/LensFilters.tsx
@@ -210,11 +210,13 @@ export default function LensFilters({
             type="button"
             onClick={onReset}
             aria-label={t("reset")}
-            className="inline-flex cursor-pointer items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-rose-800 underline underline-offset-4 decoration-rose-200 hover:text-rose-900 dark:text-rose-400 dark:decoration-rose-800 dark:hover:text-rose-300"
+            className="inline-flex cursor-pointer items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-rose-800 hover:text-rose-900 dark:text-rose-400 dark:hover:text-rose-300"
           >
-            <RotateCcw size={11} />
-            {t("reset")}
-            <span aria-hidden="true" className="inline-flex min-w-4 items-center justify-center rounded-full bg-rose-800 px-1.5 font-mono text-[9px] font-bold leading-none text-white dark:bg-rose-700">
+            <span className="inline-flex items-center gap-1.5 underline underline-offset-4 decoration-rose-200 dark:decoration-rose-800">
+              <RotateCcw size={11} />
+              {t("reset")}
+            </span>
+            <span aria-hidden="true" className="inline-flex size-4 items-center justify-center rounded-full bg-rose-800 font-mono text-[9px] font-bold leading-none text-white dark:bg-rose-700">
               {activeFilterCount}
             </span>
           </button>


### PR DESCRIPTION
## Summary
- Reset badge: `min-w-4 px-1.5` → `size-4` to match More Filters badge (circle, not pill)
- Move `underline` from `<button>` to inner `<span>` wrapping only icon+text, so decoration no longer bleeds through the badge

## Test plan
- [ ] Reset badge is circular on both mobile and desktop
- [ ] No stray underline beneath the badge
- [ ] More Filters badge unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)