### PR TITLE
fix(admin): surface AE query errors and distinguish 0 from missing

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -227,6 +227,19 @@ function fmtNum(n: number): string {
   return n.toLocaleString("en-US");
 }
 
+// Renders "—" for absent values so the dashboard can distinguish "AE
+// returned no row / null aggregate" from "AE returned a genuine 0".
+function fmtMaybe(v: unknown): string {
+  if (v === null || v === undefined) {
+    return "—";
+  }
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) {
+    return "—";
+  }
+  return n.toLocaleString("en-US");
+}
+
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
@@ -394,6 +407,33 @@ export default async function AnalyticsDashboardPage() {
 
   const installCount = num((install.data[0] as { n?: number } | undefined)?.n);
 
+  // Surface non-credential query failures so a 0/empty card can be told
+  // apart from "AE call actually failed and we silently rendered nothing".
+  const queryErrors = (
+    [
+      ["overview", overview],
+      ["localeSplit", localeSplit],
+      ["referrers", referrers],
+      ["searchZero", searchZero],
+      ["searchAll", searchAll],
+      ["filterUsage", filterUsage],
+      ["compareFunnel", compareFunnel],
+      ["compareCombos", compareCombos],
+      ["lensViews", lensViews],
+      ["feedback", feedback],
+      ["share", share],
+      ["shareBySource", shareBySource],
+      ["install", install],
+      ["mountSwitch", mountSwitch],
+      ["outbound", outbound],
+      ["outboundBySource", outboundBySource],
+      ["purchaseByChannel", purchaseByChannel],
+      ["purchaseByLens", purchaseByLens],
+    ] as const
+  ).flatMap(([name, r]) =>
+    r.error && r.error !== "missing_credentials" ? [{ name, code: r.error }] : [],
+  );
+
   // Pre-format rows so JSX cells stay simple and `title` tooltips can
   // reference the original strings.
   const compareCombosRows = compareCombos.data.map((r) => ({
@@ -444,12 +484,27 @@ export default async function AnalyticsDashboardPage() {
         </p>
       </header>
 
+      {queryErrors.length > 0 && (
+        <div className="mb-6 rounded-2xl border border-red-300 bg-red-50 p-4 text-sm text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          <p className="font-medium">
+            {queryErrors.length} {queryErrors.length === 1 ? "query" : "queries"} failed
+          </p>
+          <ul className="mt-2 list-disc pl-5">
+            {queryErrors.map((e) => (
+              <li key={e.name}>
+                <code>{e.name}</code> → {e.code}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {/* Overview stats bar */}
       <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
-        <Stat label="Events" value={fmtNum(num(overviewRow?.events))} />
-        <Stat label="Sessions" value={fmtNum(num(overviewRow?.sessions))} />
-        <Stat label="Unique queries" value={fmtNum(num(overviewRow?.unique_queries))} />
-        <Stat label="Unique lenses viewed" value={fmtNum(num(overviewRow?.unique_lenses_viewed))} />
+        <Stat label="Events" value={fmtMaybe(overviewRow?.events)} />
+        <Stat label="Sessions" value={fmtMaybe(overviewRow?.sessions)} />
+        <Stat label="Unique queries" value={fmtMaybe(overviewRow?.unique_queries)} />
+        <Stat label="Unique lenses viewed" value={fmtMaybe(overviewRow?.unique_lenses_viewed)} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

- Replace silent-0 rendering of the four top Stats with `—` whenever the AE response is null/undefined/non-finite — a genuine 0 still renders as `0`
- Add a red banner above the dashboard listing any of the 18 queries that returned a non-credential error (`queryAE` silently swallows `http_*` into `data:[]` today, so a failed call rendered as "no data yet")

## Why

Currently, top overview reads as `0` whether the events table is empty, the SQL failed, or AE returned a NULL aggregate — making it impossible to tell a real data state from an outage. This is a small observability fix before adding new dimensions.

## Test plan

- [ ] Deploy and load `/admin/analytics` — banner should not appear when all queries succeed
- [ ] Confirm top Stats still show real numbers (not `—`) for periods with data
- [ ] If overview is empty: top stats show `—`, other empty cards still show "No data yet."