### PR TITLE
feat(analytics): track PWA cold launches per entry point

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { getMessages, getTranslations, setRequestLocale } from "next-intl/server
 import RegisterSW from "@/components/RegisterSW";
 import AssetTelemetry from "@/components/AssetTelemetry";
 import OutboundLinkTelemetry from "@/components/telemetry/OutboundLinkTelemetry";
+import PwaLaunchTelemetry from "@/components/telemetry/PwaLaunchTelemetry";
 import SiteJsonLd from "@/components/SiteJsonLd";
 import { routing } from "@/i18n/routing";
 import Nav from "@/components/Nav";
@@ -176,6 +177,7 @@ export default async function LocaleLayout({
         <RegisterSW />
         <AssetTelemetry />
         <OutboundLinkTelemetry />
+        <PwaLaunchTelemetry />
       </body>
     </html>
   );

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -211,6 +211,18 @@ const Q_PURCHASE_BY_LENS = `
   LIMIT 20
 `;
 
+// Cold-launch attribution for PWA entry points. `source` distinguishes
+// the home-screen icon (pwa) from each manifest shortcut so we can see
+// which entry point actually gets used after install.
+const Q_PWA_LAUNCH = `
+  SELECT blob6 AS source, SUM(_sample_interval) AS launches
+  FROM xglass_events
+  WHERE index1 = 'pwa_launch'
+    AND ${DASHBOARD_FILTER}
+  GROUP BY source
+  ORDER BY launches DESC
+`;
+
 function pct(num: number, denom: number): string {
   if (denom <= 0) {
     return "—";
@@ -330,6 +342,7 @@ export default async function AnalyticsDashboardPage() {
     outboundBySource,
     purchaseByChannel,
     purchaseByLens,
+    pwaLaunch,
   ] = await Promise.all([
     queryAE(Q_OVERVIEW),
     queryAE(Q_LOCALE_SPLIT),
@@ -349,6 +362,7 @@ export default async function AnalyticsDashboardPage() {
     queryAE(Q_OUTBOUND_BY_SOURCE),
     queryAE(Q_PURCHASE_BY_CHANNEL),
     queryAE(Q_PURCHASE_BY_LENS),
+    queryAE(Q_PWA_LAUNCH),
   ]);
 
   if (overview.error === "missing_credentials") {
@@ -603,6 +617,16 @@ export default async function AnalyticsDashboardPage() {
             {fmtNum(installCount)}
           </p>
           <p className="mt-1 text-xs text-zinc-500">Accepted install prompts</p>
+        </Card>
+
+        <Card title="PWA · launches by entry">
+          <Table
+            rows={pwaLaunch.data}
+            columns={[
+              { key: "source", label: "Entry" },
+              { key: "launches", label: "Launches", align: "right", widthClass: COUNT_WIDTH },
+            ]}
+          />
         </Card>
 
         <Card title="Mount switch · direction">

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -24,20 +24,22 @@ export default function manifest(): MetadataRoute.Manifest {
     // Shortcuts appear on long-press of the home screen icon (Android) and
     // right-click of the taskbar icon (desktop Chrome/Edge).
     // URLs use un-prefixed paths — the i18n middleware redirects to the
-    // correct locale automatically.
+    // correct locale automatically. Each entry carries a distinct `ref`
+    // query so PwaLaunchTelemetry can attribute cold launches per entry
+    // point (icon vs. each shortcut).
     shortcuts: [
       {
         name: "Browse Lenses",
         short_name: "Browse",
         description: "Browse and filter all X Mount and G Mount lenses",
-        url: "/lenses/x",
+        url: "/lenses/x?ref=pwa-browse",
         icons: [{ src: "/icons/icon-192.png", sizes: "192x192" }],
       },
       {
         name: "Compare Lenses",
         short_name: "Compare",
         description: "Compare lenses side by side",
-        url: "/lenses/x/compare",
+        url: "/lenses/x/compare?ref=pwa-compare",
         icons: [{ src: "/icons/icon-192.png", sizes: "192x192" }],
       },
     ],

--- a/src/components/telemetry/PwaLaunchTelemetry.tsx
+++ b/src/components/telemetry/PwaLaunchTelemetry.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { track } from "@/lib/analytics";
+
+// Set of recognized launch-attribution sources, anchored to the values
+// written into the manifest's start_url and shortcut URLs. Anything else
+// in the `ref` query slot is ignored so unrelated traffic (someone manually
+// typing ?ref=foo) doesn't pollute the pwa_launch event stream.
+const VALID_REFS = new Set(["pwa", "pwa-browse", "pwa-compare"]);
+
+// sessionStorage guard prevents a second fire if the user refreshes the
+// landing URL while the ?ref= param is still present. One launch per
+// browser session is the right grain for cold-launch attribution.
+const STORAGE_KEY = "xg_pwa_launch_fired";
+
+export default function PwaLaunchTelemetry() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const ref = params.get("ref");
+    if (!ref || !VALID_REFS.has(ref)) {
+      return;
+    }
+    try {
+      if (sessionStorage.getItem(STORAGE_KEY) === "1") {
+        return;
+      }
+      sessionStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // Private mode / disabled storage — still fire, just without the guard.
+    }
+    track("pwa_launch", { source: ref });
+
+    // Strip ?ref from the URL so a copied/shared link doesn't re-attribute
+    // an external visitor as a PWA launch.
+    params.delete("ref");
+    const qs = params.toString();
+    const next = window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+    window.history.replaceState(null, "", next);
+  }, []);
+
+  return null;
+}

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -27,6 +27,7 @@ export const EVENT_NAMES = [
   "outbound_click",
   "mount_switch",
   "purchase_click",
+  "pwa_launch",
 ] as const;
 
 export type EventName = (typeof EVENT_NAMES)[number];


### PR DESCRIPTION
## Summary

- Add `pwa_launch` event + a `PwaLaunchTelemetry` client component that reads `?ref=` on mount, fires the event, then strips the param so a shared URL won't re-attribute an external visitor
- Give each manifest shortcut its own ref (`pwa-browse`, `pwa-compare`) so the dashboard can tell home-screen icon launches from shortcut launches
- New dashboard card "PWA · launches by entry" grouped by the ref value

## Notes

- `start_url: "/?ref=pwa"` was already in the manifest but unread — the launch source was effectively lost. This wires it up end-to-end.
- One launch per browser session via `sessionStorage`, so refreshing the landing URL won't double-count.
- Storage falls back gracefully (still fires the event in private mode where sessionStorage throws).

## Test plan

- [ ] Install PWA on a clean profile, cold-launch from icon → check `pwa_launch` event in AE with `source = pwa`
- [ ] Long-press icon → Browse shortcut → check `source = pwa-browse`
- [ ] Same flow for Compare shortcut → `source = pwa-compare`
- [ ] Confirm URL bar no longer shows `?ref=` after landing
- [ ] Refresh the landing page → no second event fires
- [ ] Dashboard `/admin/analytics` shows the new card with rows after some traffic accumulates