### PR TITLE
fix(admin): replace unsupported uniq/uniqIf with count(DISTINCT)

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -20,12 +20,16 @@ export const revalidate = 0;
 const WINDOW = "INTERVAL '30' DAY";
 const DASHBOARD_FILTER = `timestamp > NOW() - ${WINDOW} AND blob7 != '1'`;
 
+// AE SQL supports `count(DISTINCT col)` but not ClickHouse's `uniq` /
+// `uniqIf` aggregates. For per-event-type distinct counts, wrap the
+// column in `IF(cond, col, NULL)` — count DISTINCT skips NULLs, so the
+// resulting cardinality is only over rows matching the condition.
 const Q_OVERVIEW = `
   SELECT
     SUM(_sample_interval) AS events,
-    uniq(blob1) AS sessions,
-    uniqIf(blob4, index1 = 'search') AS unique_queries,
-    uniqIf(blob4, index1 = 'lens_view') AS unique_lenses_viewed
+    count(DISTINCT blob1) AS sessions,
+    count(DISTINCT IF(index1 = 'search', blob4, NULL)) AS unique_queries,
+    count(DISTINCT IF(index1 = 'lens_view', blob4, NULL)) AS unique_lenses_viewed
   FROM xglass_events
   WHERE ${DASHBOARD_FILTER}
 `;
@@ -34,7 +38,7 @@ const Q_LOCALE_SPLIT = `
   SELECT
     blob2 AS locale,
     SUM(_sample_interval) AS events,
-    uniq(blob1) AS sessions
+    count(DISTINCT blob1) AS sessions
   FROM xglass_events
   WHERE ${DASHBOARD_FILTER} AND blob2 != ''
   GROUP BY locale
@@ -86,9 +90,9 @@ const Q_COMPARE_FUNNEL = `
     sumIf(_sample_interval, index1 = 'compare_add') AS adds,
     sumIf(_sample_interval, index1 = 'compare_view') AS views,
     sumIf(_sample_interval, index1 = 'compare_scroll') AS scrolls,
-    uniqIf(blob1, index1 = 'compare_add') AS sids_add,
-    uniqIf(blob1, index1 = 'compare_view') AS sids_view,
-    uniqIf(blob1, index1 = 'compare_scroll') AS sids_scroll
+    count(DISTINCT IF(index1 = 'compare_add', blob1, NULL)) AS sids_add,
+    count(DISTINCT IF(index1 = 'compare_view', blob1, NULL)) AS sids_view,
+    count(DISTINCT IF(index1 = 'compare_scroll', blob1, NULL)) AS sids_scroll
   FROM xglass_events
   WHERE index1 IN ('compare_add', 'compare_view', 'compare_scroll')
     AND ${DASHBOARD_FILTER}


### PR DESCRIPTION
## Summary

Cloudflare Analytics Engine SQL doesn't implement ClickHouse's `uniq` / `uniqIf`. Three dashboard queries used them and were silently returning `http_422`; the error banner from #301 finally surfaced this, which is what this fix addresses.

- `Q_OVERVIEW`: `uniq(blob1)` → `count(DISTINCT blob1)`; both `uniqIf(blob4, cond)` → `count(DISTINCT IF(cond, blob4, NULL))`
- `Q_LOCALE_SPLIT`: same swap on the sessions aggregate
- `Q_COMPARE_FUNNEL`: all three `uniqIf(blob1, cond)` → `count(DISTINCT IF(cond, blob1, NULL))`

`count(DISTINCT col)` skips NULLs, so wrapping the column in `IF(cond, col, NULL)` cardinality-counts only rows matching the condition — the semantic equivalent of `uniqIf`.

## Why this slipped through

Every other dashboard query uses only `SUM` / `sumIf`, which AE does support, so the symptom looked like a data shape problem until #301 added per-query error visibility.

## Test plan

- [ ] Load `/admin/analytics` after deploy — red error banner should be gone
- [ ] Top four stats (Events / Sessions / Unique queries / Unique lenses viewed) show real numbers, not `—`
- [ ] Locale · split card shows rows
- [ ] Compare · funnel shows session counts in the right column

Ref: [AE SQL aggregate functions](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/aggregate-functions/)