### PR TITLE
feat(collections): add a Value category, browse/collections IA, and layout fixes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,8 +45,17 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:locale(en|zh)/lenses",
-        destination: "/:locale/lenses/x",
+        destination: "/:locale/lenses/x/browse",
         permanent: false,
+      },
+      // The all-lenses list lives at /lenses/[mount]/browse so it sits as a
+      // true sibling of /lenses/[mount]/collections. The bare mount path is a
+      // permanent (308) redirect to the list, so any old inbound link or
+      // bookmark to /lenses/x lands on the canonical browse URL.
+      {
+        source: "/:locale(en|zh)/lenses/:mount(x|gfx)",
+        destination: "/:locale/lenses/:mount/browse",
+        permanent: true,
       },
       {
         source: "/:locale(en|zh)/lenses/compare",

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -288,7 +288,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 pt-8 pb-[max(10rem,calc(var(--compare-bar-height,0px)+8rem))] flex flex-col gap-8">
       <div className="flex items-center justify-between">
         <Breadcrumb
-              segments={[{ label: tNav("lenses"), href: `/lenses/${seg}` }]}
+              segments={[{ label: tNav("lenses"), href: `/lenses/${seg}/browse` }]}
               current={displayName}
             />
         <div className="flex items-center gap-1">

--- a/src/app/[locale]/lenses/[mount]/(browse)/browse/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/browse/page.tsx
@@ -4,7 +4,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getLensesByMount } from "@/lib/lens";
 import { urlSegmentToMount } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
-import LensesLoading from "./loading";
+import LensesLoading from "../loading";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { notFound } from "next/navigation";
 
@@ -22,7 +22,7 @@ export async function generateMetadata({
   if (!resolvedMount) {
     return {
       title: t("title"),
-      alternates: buildAlternates(locale, `lenses/${mount}`),
+      alternates: buildAlternates(locale, `lenses/${mount}/browse`),
     };
   }
 
@@ -42,7 +42,7 @@ export async function generateMetadata({
       description,
       images: defaultOgImages(),
     },
-    alternates: buildAlternates(locale, `lenses/${mount}`),
+    alternates: buildAlternates(locale, `lenses/${mount}/browse`),
   };
 }
 

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -12,6 +12,7 @@ import CollectionLensGrid from "@/components/CollectionLensGrid";
 import RelatedCollectionCard from "@/components/RelatedCollectionCard";
 import BackToTopButton from "@/components/BackToTopButton";
 import Breadcrumb from "@/components/Breadcrumb";
+import FeedbackTrigger from "@/components/FeedbackTrigger";
 
 type Params = Promise<{ locale: string; mount: string; slug: string }>;
 
@@ -86,7 +87,7 @@ export default async function CollectionPage({
           <div className="mb-4">
             <Breadcrumb
               segments={[
-                { label: tNav("lenses"), href: `/lenses/${mount}` },
+                { label: tNav("lenses"), href: `/lenses/${mount}/browse` },
                 { label: t("breadcrumbCollections"), href: `/lenses/${mount}/collections` },
               ]}
               current={title}
@@ -103,6 +104,19 @@ export default async function CollectionPage({
           </p>
         </header>
         <CollectionLensGrid lenses={lenses} />
+
+        {/* Completeness feedback sits right after the grid, while the user is
+            still in this collection's context — not after the leave-the-page
+            CTA below. */}
+        <p className="mt-8 text-sm text-zinc-500 dark:text-zinc-400">
+          {t("feedbackPrompt")}{" "}
+          <FeedbackTrigger
+            type="general"
+            className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+          >
+            {t("feedbackLink")}
+          </FeedbackTrigger>
+        </p>
 
         <footer className="mt-12">
           <div className="mb-4 flex items-baseline justify-between">
@@ -130,7 +144,7 @@ export default async function CollectionPage({
           </ul>
           <div className="mt-6 flex justify-center border-t border-zinc-100 pt-5 dark:border-zinc-800">
             <Link
-              href={`/lenses/${mount}`}
+              href={`/lenses/${mount}/browse`}
               className={`rounded-xl ${ACTION_ESCAPE_CLS}`}
             >
               <span>{t("browseAllPill", { count: mountLenses.length })}</span>

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -13,13 +13,13 @@ import {
   APERTURE_SLUGS,
   TRAIT_SLUGS,
   DEDICATED_SLUGS,
-  FOCUS_SLUGS,
+  VALUE_SLUGS,
 } from "@/lib/collections";
 import { getLensesByMount } from "@/lib/lens";
 import type { Mount } from "@/lib/types";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
-import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
-import Breadcrumb from "@/components/Breadcrumb";
+import { ACTION_PRIMARY_CLS, LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
+import LensSectionNav from "@/components/LensSectionNav";
 import CollectionChipRail from "@/components/CollectionChipRail";
 
 type Params = Promise<{ locale: string; mount: string }>;
@@ -56,12 +56,12 @@ const CATEGORIES = [
   { id: "section-zoom", key: "category_zoom", slugs: ZOOM_SLUGS, marker: ["ZOOM"] },
   { id: "section-brand", key: "category_brand", slugs: BRAND_SLUGS, marker: ["BRAND"] },
   { id: "section-series", key: "category_series", slugs: SERIES_SLUGS, marker: ["SERIES"] },
+  { id: "section-value", key: "category_value", slugs: VALUE_SLUGS, marker: ["VALUE"] },
   { id: "section-price", key: "category_price", slugs: PRICE_SLUGS, marker: ["$"] },
   { id: "section-portability", key: "category_portability", slugs: PORTABILITY_SLUGS, marker: ["G"] },
   { id: "section-aperture", key: "category_aperture", slugs: APERTURE_SLUGS, marker: ["ƒ"], markerItalic: true },
   { id: "section-trait", key: "category_trait", slugs: TRAIT_SLUGS, marker: ["WR"] },
   { id: "section-dedicated", key: "category_dedicated", slugs: DEDICATED_SLUGS, marker: ["✦"] },
-  { id: "section-focus", key: "category_focus", slugs: FOCUS_SLUGS, marker: ["AF", "MF"] },
 ] as const;
 
 export default async function CollectionsIndexPage({
@@ -73,7 +73,6 @@ export default async function CollectionsIndexPage({
   setRequestLocale(locale);
 
   const t = await getTranslations({ locale, namespace: "Collection" });
-  const tNav = await getTranslations({ locale, namespace: "Nav" });
   const mountLenses = getLensesByMount(mount as Mount, locale);
 
   const countFor = (slug: string) => {
@@ -91,25 +90,26 @@ export default async function CollectionsIndexPage({
   const totalLenses = mountLenses.length;
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 pt-8 pb-16">
-      {/* Breadcrumb */}
-      <div className="mb-4">
-        <Breadcrumb
-          segments={[{ label: tNav("lenses"), href: `/lenses/${mount}` }]}
-          current={t("breadcrumbCollections")}
-        />
-      </div>
-
-      {/* Page title row */}
-      <header id="collections-top" className="pb-6">
-        <h1 className="font-heading text-[32px] font-bold leading-[1.15] text-zinc-900 dark:text-zinc-100">
-          {t("indexTitle")}
-        </h1>
-        <p className="mt-2.5 max-w-[560px] text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
-          {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
-          {" — "}
-          {t("indexDescription")}
-        </p>
+    <main className={`${LENS_INDEX_SHELL_CLS} pt-4 pb-16 sm:pt-8`}>
+      {/* Switcher + summary — same flex-col gap-2 structure as the all-lenses
+          header so the switcher and title land at the same position on both
+          pages. The descriptive, keyword-rich title stays as an sr-only h1
+          for SEO (mirroring the browse page); the visible header is a
+          one-line summary the tab label can't convey — collection and lens
+          counts — plus a short categorization subtitle. */}
+      <header id="collections-top" className="flex flex-col gap-2 pb-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <LensSectionNav />
+        </div>
+        <div>
+          <h1 className="sr-only">{t("indexTitle")}</h1>
+          <p className="text-[15px] font-medium text-zinc-900 dark:text-zinc-100">
+            {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
+          </p>
+          <p className="mt-1 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+            {t("indexSubtitle")}
+          </p>
+        </div>
       </header>
 
       {/* Sticky chip rail */}
@@ -185,7 +185,7 @@ export default async function CollectionsIndexPage({
       {/* Footer CTA */}
       <footer className="mt-8 flex justify-center">
         <Link
-          href={`/lenses/${mount}`}
+          href={`/lenses/${mount}/browse`}
           className={`inline-flex items-center gap-2 rounded-full px-6 py-2.5 text-sm font-semibold ${ACTION_PRIMARY_CLS}`}
         >
           {t("browseAllPill", { count: totalLenses })}

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -117,7 +117,7 @@ export default async function ComparePage({
   return (
     <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 pt-4 sm:pt-8 pb-40 flex flex-col gap-3 sm:gap-4">
       <Breadcrumb
-        segments={[{ label: tNav("lenses"), href: `/lenses/${seg}` }]}
+        segments={[{ label: tNav("lenses"), href: `/lenses/${seg}/browse` }]}
         current={tNav("compare")}
       />
       <ComparePageHeader />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -183,5 +183,11 @@ details[open] > div {
   }
   html {
     @apply font-sans;
+    /* Reserve the scrollbar gutter so a view that overflows and one that
+       doesn't keep the same layout viewport width. Without this, switching
+       between two views (e.g. the lens list vs collections) where one has a
+       scrollbar and the other doesn't shifts every centered container — and
+       the fixed nav's right-aligned items — by the scrollbar width. */
+    scrollbar-gutter: stable;
   }
 }

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -32,7 +32,7 @@ export default function manifest(): MetadataRoute.Manifest {
         name: "Browse Lenses",
         short_name: "Browse",
         description: "Browse and filter all X Mount and G Mount lenses",
-        url: "/lenses/x?ref=pwa-browse",
+        url: "/lenses/x/browse?ref=pwa-browse",
         icons: [{ src: "/icons/icon-192.png", sizes: "192x192" }],
       },
       {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,10 +13,9 @@ function url(path: string): string {
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPaths = [
-    "/lenses",
-    "/lenses/x",
+    "/lenses/x/browse",
     "/lenses/x/compare",
-    "/lenses/gfx",
+    "/lenses/gfx/browse",
     "/lenses/gfx/compare",
     "/lenses/x/collections",
     "/about",

--- a/src/components/HomeCta.tsx
+++ b/src/components/HomeCta.tsx
@@ -13,7 +13,7 @@ export default function HomeCta() {
   return (
     <>
       <Link
-        href={`/lenses/${seg}`}
+        href={`/lenses/${seg}/browse`}
         className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 font-medium text-sm hover:opacity-90 transition-opacity"
       >
         {h("cta")} →

--- a/src/components/InstallPage.tsx
+++ b/src/components/InstallPage.tsx
@@ -108,7 +108,7 @@ export default function InstallPage() {
           </h2>
           <p className="mt-3 text-zinc-500 dark:text-zinc-400 text-sm">{t("installedBody")}</p>
           <Link
-            href="/lenses/x"
+            href="/lenses/x/browse"
             className="mt-8 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-zinc-800 dark:bg-zinc-50 text-zinc-50 dark:text-zinc-900 font-medium text-sm hover:opacity-90 transition-opacity"
           >
             {t("openApp")} →

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/ui/select";
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
+import LensSectionNav from "./LensSectionNav";
+import { LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
 import LensSearchDialog from "./LensSearchDialog";
 import LensesLoading from "@/app/[locale]/lenses/[mount]/(browse)/loading";
 import FeedbackTrigger from "./FeedbackTrigger";
@@ -94,13 +96,15 @@ export default function LensListClient() {
 
   return (
     <>
-      <div className="w-full max-w-7xl mx-auto px-5 sm:px-6 pt-4 sm:pt-8 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] flex flex-col">
+      <div className={`${LENS_INDEX_SHELL_CLS} flex flex-col pt-4 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] sm:pt-8`}>
         <div className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-              {t("title")}
-            </h2>
-            <LensSearchDialog triggerVariant="button" triggerLabel={tSearch("browseTrigger")} />
+            <LensSectionNav />
+            <LensSearchDialog
+              triggerVariant="button"
+              triggerLabel={tSearch("browseTrigger")}
+              triggerClassName="sm:h-10"
+            />
           </div>
           <LensFilters
             filters={filters}

--- a/src/components/LensSectionNav.tsx
+++ b/src/components/LensSectionNav.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import { useEffectiveMount } from "@/hooks/useMountParam";
+import { mountToUrlSegment } from "@/lib/mount";
+import { cn } from "@/lib/utils";
+
+/**
+ * Switcher between the two views of the lens library: the filterable list
+ * ("所有镜头") and the curated collections ("合集"). Mirrors the in-page
+ * filter segmented controls so the whole header reads as one control family.
+ */
+export default function LensSectionNav() {
+  const t = useTranslations("Nav");
+  const pathname = usePathname();
+  const seg = mountToUrlSegment(useEffectiveMount());
+  const active = pathname.includes("/collections") ? "collections" : "browse";
+
+  const tabs = [
+    { key: "browse", label: t("allLenses"), href: `/lenses/${seg}/browse` },
+    { key: "collections", label: t("collections"), href: `/lenses/${seg}/collections` },
+  ] as const;
+
+  return (
+    <nav
+      aria-label={t("lenses")}
+      className="inline-flex rounded-xl bg-zinc-100 p-1 dark:bg-zinc-800"
+    >
+      {tabs.map((tab) => {
+        const selected = tab.key === active;
+        return (
+          <Link
+            key={tab.key}
+            href={tab.href}
+            aria-current={selected ? "page" : undefined}
+            className={cn(
+              // Same segmented-control shape as the filter controls below, but
+              // a notch larger/bolder with stronger active contrast — it's the
+              // primary view switcher, not a secondary filter.
+              "inline-flex h-9 items-center justify-center rounded-lg px-4 text-[13px] font-semibold transition-colors sm:h-8",
+              selected
+                ? "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-50 dark:shadow-none"
+                : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/MountSwitcher.tsx
+++ b/src/components/MountSwitcher.tsx
@@ -43,7 +43,7 @@ export default function MountSwitcher() {
     }
     setPreference(value);
     if (urlMount !== null) {
-      router.push(`/lenses/${mountToUrlSegment(value)}`);
+      router.push(`/lenses/${mountToUrlSegment(value)}/browse`);
     }
   };
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Menu } from "@base-ui/react/menu";
-import { Check, ChevronDown, EllipsisVertical, Send, Info, Download } from "lucide-react";
+import { EllipsisVertical, Send, Info, Download } from "lucide-react";
 import { Link, usePathname } from "@/i18n/navigation";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
@@ -28,7 +28,6 @@ export default function Nav() {
   const { navLocked, lockNav, setNavHidden } = useNav();
   const isPwa = usePwa();
   const [scrolledDown, setScrolledDown] = useState(false);
-  const [lensesMenuOpen, setLensesMenuOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const lastScrollY = useRef(0);
   const headerRef = useRef<HTMLElement>(null);
@@ -55,7 +54,6 @@ export default function Nav() {
     setScrolledDown(false);
     lastScrollY.current = 0;
     lockNav(false);
-    setLensesMenuOpen(false);
   }, [pathname, lockNav]);
 
   const isDesktop = useBreakpoint("sm");
@@ -65,8 +63,7 @@ export default function Nav() {
   }, [hidden, setNavHidden]);
 
   const seg = mountToUrlSegment(effectiveMount);
-  const browseHref = `/lenses/${seg}`;
-  const collectionsHref = `/lenses/${seg}/collections`;
+  const browseHref = `/lenses/${seg}/browse`;
   const compareHref = compareIds.length > 0
     ? `/lenses/${seg}/compare?ids=${compareIds.join(",")}`
     : `/lenses/${seg}/compare`;
@@ -85,53 +82,9 @@ export default function Nav() {
         : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 hover:bg-zinc-50 dark:hover:bg-zinc-900"
     }`;
 
-  const isOnCollections = pathname.includes("/collections");
   const isBrowseActive = pathname.startsWith("/lenses") && !pathname.includes("/compare");
   const isCompareActive = pathname.includes("/compare");
   const showMountSwitcher = pathname === "/" || pathname.startsWith("/lenses");
-
-  const menuItemCls = (active: boolean) =>
-    cn(
-      "block px-4 py-2.5 transition-colors outline-none pointer-fine:data-highlighted:bg-zinc-50 dark:pointer-fine:data-highlighted:bg-zinc-800/50",
-      active && "bg-zinc-50 dark:bg-zinc-800/30"
-    );
-
-  const lensesMenuPopup = (
-    <Menu.Popup className="w-44 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 overflow-hidden origin-(--transform-origin) duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-      <Menu.LinkItem
-        render={<Link href={browseHref} />}
-        className={menuItemCls(isBrowseActive && !isOnCollections)}
-      >
-        <span className="flex items-center justify-between gap-2">
-          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-            {t("allLenses")}
-          </span>
-          {isBrowseActive && !isOnCollections && (
-            <Check className="size-3.5 text-zinc-400 dark:text-zinc-500 shrink-0" />
-          )}
-        </span>
-        <span className="block text-xs font-normal text-zinc-400 dark:text-zinc-500 mt-0.5">
-          {t("allLensesHint")}
-        </span>
-      </Menu.LinkItem>
-      <Menu.LinkItem
-        render={<Link href={collectionsHref} />}
-        className={menuItemCls(isOnCollections)}
-      >
-        <span className="flex items-center justify-between gap-2">
-          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-            {t("collections")}
-          </span>
-          {isOnCollections && (
-            <Check className="size-3.5 text-zinc-400 dark:text-zinc-500 shrink-0" />
-          )}
-        </span>
-        <span className="block text-xs font-normal text-zinc-400 dark:text-zinc-500 mt-0.5">
-          {t("collectionsHint")}
-        </span>
-      </Menu.LinkItem>
-    </Menu.Popup>
-  );
 
   // When the user is *already on* the compare page and clicks the nav's
   // "对比" link, the intuitive read is "reset this comparison and start
@@ -181,17 +134,9 @@ export default function Nav() {
 
         {/* Right: shared items + breakpoint-specific overflow */}
         <div className="flex items-center gap-1 sm:gap-2">
-          <Menu.Root open={lensesMenuOpen} onOpenChange={setLensesMenuOpen}>
-            <Menu.Trigger className={cn(linkCls(isBrowseActive), "inline-flex items-center gap-0.5")}>
-              {t("lenses")}
-              <ChevronDown className="size-3 transition-transform duration-150 data-[popup-open]:rotate-180" />
-            </Menu.Trigger>
-            <Menu.Portal>
-              <Menu.Positioner side="bottom" align="end" sideOffset={6} className="z-50">
-                {lensesMenuPopup}
-              </Menu.Positioner>
-            </Menu.Portal>
-          </Menu.Root>
+          <Link href={browseHref} className={linkCls(isBrowseActive)}>
+            {t("lenses")}
+          </Link>
           <Link href={compareHref} onClick={handleCompareLinkClick} className={linkCls(isCompareActive)}>
             {t("compare")}
           </Link>

--- a/src/config/static-routes.ts
+++ b/src/config/static-routes.ts
@@ -24,8 +24,8 @@ export const STATIC_LOCALIZED_SUBPATHS = [
   "",
   "about",
   "get",
-  "lenses/x",
-  "lenses/gfx",
+  "lenses/x/browse",
+  "lenses/gfx/browse",
 ] as const;
 
 /**

--- a/src/data/collections.json
+++ b/src/data/collections.json
@@ -586,36 +586,6 @@
       }
     },
     {
-      "slug": "autofocus",
-      "title": {
-        "en": "Autofocus Lenses",
-        "zh": "自动对焦镜头"
-      },
-      "description": {
-        "en": "Every X-mount optic with native autofocus capability, from first-party Fujifilm units to third-party designs. All lenses listed here support full electronic body integration, continuous AF tracking, and digital aperture control.",
-        "zh": "所有支持自动对焦的 X 卡口镜头，涵盖富士原厂和各家副厂。本页收录的每一支都能与机身联动——连续追焦、眼部识别、电子光圈控制，开箱即用。"
-      },
-      "shortDescription": {
-        "en": "Native AF with tracking and eye detection",
-        "zh": "原生 AF，追焦与眼控全支持"
-      }
-    },
-    {
-      "slug": "manual-focus",
-      "title": {
-        "en": "Manual Focus Lenses",
-        "zh": "手动对焦镜头"
-      },
-      "description": {
-        "en": "The complete manual-focus directory for the X-mount system. From highly economic vintage drawing optics to high-end boutique metal work, these tools honor intentional framing with physical mechanical rings, dense form factors, and unique optical personalities that automated systems rarely clone.",
-        "zh": "X 卡口纯手动对焦镜头的全景索引。从注重性价比的复古氛围老味道，到做工严丝合缝的福伦达工艺品。手动镜头的魅力在于指尖拨动对焦环时的绝对掌控感、紧凑的体积，以及现代自动镜头较难复刻的独特味道。"
-      },
-      "shortDescription": {
-        "en": "Mechanical focus for tactile, intentional shooting",
-        "zh": "纯手动，质感与独特味道"
-      }
-    },
-    {
       "slug": "value-af",
       "title": {
         "en": "Value AF from Independent Makers",
@@ -628,6 +598,36 @@
       "shortDescription": {
         "en": "Affordable native AF from domestic makers",
         "zh": "国产品牌的平价自动对焦主力"
+      }
+    },
+    {
+      "slug": "value-mf",
+      "title": {
+        "en": "Value Manual-Focus Lenses",
+        "zh": "平价手动对焦镜头"
+      },
+      "description": {
+        "en": "Manual-focus lenses from value brands — a tactile, all-manual shooting experience at accessible prices.",
+        "zh": "高性价比品牌推出的手动对焦镜头合集，以亲民价格提供纯粹的手动对焦体验。"
+      },
+      "shortDescription": {
+        "en": "Affordable manual primes",
+        "zh": "平价品牌的手动定焦"
+      }
+    },
+    {
+      "slug": "value-095",
+      "title": {
+        "en": "Value f/0.95 Fast Primes",
+        "zh": "平价 f/0.95 大光圈镜头"
+      },
+      "description": {
+        "en": "f/0.95 primes from value brands — the shallowest depth of field and the most low-light reach at accessible prices.",
+        "zh": "高性价比品牌的 f/0.95 大光圈定焦合集，以亲民价格提供极浅景深与暗光能力。"
+      },
+      "shortDescription": {
+        "en": "Affordable f/0.95 glass",
+        "zh": "平价 f/0.95 大光圈"
       }
     }
   ]

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -32,10 +32,12 @@ function xBrand(brand: string): LensFilter {
   return (lens) => xPhoto(lens) && lens.brand === brand;
 }
 
-const DOMESTIC_BRANDS = ["viltrox", "7artisans", "ttartisan", "brightinstar", "sgimage"];
+// Affordable third-party brands grouped under the Value category. Extend this
+// list as more budget makers (of any origin) get added.
+const VALUE_BRANDS = ["viltrox", "7artisans", "ttartisan", "brightinstar", "sgimage", "laowa"];
 
 const FILTERS: Record<string, LensFilter> = {
-  // --- Prime (定焦) ---
+  // --- Prime ---
   "23mm": xPrime(22, 24),
   "35mm": xPrime(33, 36),
   "50mm": xPrime(48, 51),
@@ -44,7 +46,7 @@ const FILTERS: Record<string, LensFilter> = {
   "wide-angle-primes": (lens) =>
     xPhoto(lens) && !isZoom(lens) && lens.focalLengthMin <= 18,
 
-  // --- Zoom (变焦) ---
+  // --- Zoom ---
   "wide-zoom": (lens) =>
     xPhoto(lens) && isZoom(lens) && lens.focalLengthMin <= 12,
 
@@ -69,7 +71,7 @@ const FILTERS: Record<string, LensFilter> = {
     xPhoto(lens) &&
     (isZoom(lens) ? lens.focalLengthMax >= 300 : lens.focalLengthMin >= 200),
 
-  // --- Brand (品牌) ---
+  // --- Brand ---
   fujifilm: (lens) => xPhoto(lens) && lens.brand === "fujifilm",
   "7artisans": xBrand("7artisans"),
   viltrox: (lens) => xPhoto(lens) && lens.brand === "viltrox" && lens.af === true,
@@ -81,7 +83,7 @@ const FILTERS: Record<string, LensFilter> = {
   tamron: xBrand("tamron"),
   sgimage: xBrand("sgimage"),
 
-  // --- Series (系列) ---
+  // --- Series ---
   "fujifilm-xf": (lens) =>
     xPhoto(lens) && lens.brand === "fujifilm" && lens.series === "XF",
   "fujifilm-xc": (lens) =>
@@ -95,7 +97,7 @@ const FILTERS: Record<string, LensFilter> = {
   "voigtlander-nokton": (lens) =>
     xPhoto(lens) && lens.brand === "voigtlander" && lens.series === "Nokton",
 
-  // --- Price (价格) ---
+  // --- Price ---
   "under-200": (lens, locale) => {
     if (locale === "zh") {
       const p = lens.pricing?.cn?.new?.price;
@@ -114,7 +116,7 @@ const FILTERS: Record<string, LensFilter> = {
     return xPhoto(lens) && p != null && p < 400;
   },
 
-  // --- Portability (便携) ---
+  // --- Portability ---
   "under-200g": (lens) => {
     if (!xPhoto(lens)) {
       return false;
@@ -129,7 +131,7 @@ const FILTERS: Record<string, LensFilter> = {
     lens.length?.mm != null &&
     lens.length.mm <= 40,
 
-  // --- Aperture (光圈) ---
+  // --- Aperture ---
   "fast-aperture-primes": (lens) => {
     if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
       return false;
@@ -144,13 +146,13 @@ const FILTERS: Record<string, LensFilter> = {
     lens.maxAperture != null &&
     !Array.isArray(lens.maxAperture),
 
-  // --- Trait (特性) ---
+  // --- Trait ---
   "weather-sealed": (lens) =>
     xPhoto(lens) && (lens.wr === true || lens.wr === "partial"),
 
   "with-ois": (lens) => xPhoto(lens) && lens.ois === true,
 
-  // --- Dedicated (专用镜头) ---
+  // --- Dedicated ---
   cine: (lens) => xMount(lens) && lens.isCine === true,
 
   fisheye: (lens) =>
@@ -163,11 +165,18 @@ const FILTERS: Record<string, LensFilter> = {
   macro: (lens) =>
     xPhoto(lens) && !!lens.opticalTraits?.includes("macro"),
 
-  // --- Focus (对焦方式) ---
-  autofocus: (lens) => xPhoto(lens) && lens.af === true,
-  "manual-focus": (lens) => xPhoto(lens) && lens.af === false,
+  // --- Value (affordable third-party brands) ---
   "value-af": (lens) =>
-    xPhoto(lens) && DOMESTIC_BRANDS.includes(lens.brand) && lens.af === true,
+    xPhoto(lens) && VALUE_BRANDS.includes(lens.brand) && lens.af === true,
+  "value-mf": (lens) =>
+    xPhoto(lens) && VALUE_BRANDS.includes(lens.brand) && lens.af === false,
+  "value-095": (lens) => {
+    if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
+      return false;
+    }
+    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
+    return VALUE_BRANDS.includes(lens.brand) && ap <= 0.95;
+  },
 };
 
 const parsed: LensCollection[] = collectionsData.collections.map((entry) => {
@@ -191,7 +200,7 @@ export const PORTABILITY_SLUGS = ["under-200g", "pancake"];
 export const APERTURE_SLUGS = ["fast-aperture-primes", "constant-aperture"];
 export const TRAIT_SLUGS = ["weather-sealed", "with-ois", "super-tele"];
 export const DEDICATED_SLUGS = ["cine", "fisheye", "tilt-shift", "macro"];
-export const FOCUS_SLUGS = ["autofocus", "manual-focus", "value-af"];
+export const VALUE_SLUGS = ["value-af", "value-mf", "value-095"];
 
 export function getRelatedCollections(
   slug: string,

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -8,6 +8,15 @@
  *   Selected state  → zinc-900 border + ring (light) / zinc-100 (dark)
  */
 
+/**
+ * Shared outer container for the lens-library index pages (the all-lenses
+ * list and the collections index). Single source of truth for their width +
+ * horizontal padding so the two never drift — keeping the section switcher
+ * and header pinned to the same left edge when switching between them.
+ * Compose with per-page vertical padding.
+ */
+export const LENS_INDEX_SHELL_CLS = "mx-auto w-full max-w-7xl px-5 sm:px-6";
+
 /** Primary action button (compare, add-to-compare, hero CTA). */
 export const ACTION_PRIMARY_CLS =
   "bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors";

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -18,9 +18,7 @@
   "Nav": {
     "lenses": "Browse",
     "allLenses": "All Lenses",
-    "allLensesHint": "Filter & sort",
     "collections": "Collections",
-    "collectionsHint": "Pancakes, travel zooms, constant aperture…",
     "compare": "Compare",
     "about": "About",
     "getApp": "Get App",
@@ -519,17 +517,18 @@
     "relatedCollections": "Related collections",
     "indexTitle": "Lens Collections for Fujifilm X-Mount",
     "indexDescription": "Curated lens collections for the Fujifilm X-mount system — organized by focal length, brand, aperture, and more.",
-    "indexStats": "{count} collections · {lensCount} lenses total",
+    "indexStats": "{count} collections · {lensCount} lenses",
+    "indexSubtitle": "Organized by focal length, brand, aperture, and more.",
     "category_prime": "Prime Lenses",
     "category_zoom": "Zoom Lenses",
     "category_brand": "By Brand",
     "category_series": "By Series",
+    "category_value": "Value Picks",
     "category_price": "By Price",
     "category_portability": "Portability",
     "category_aperture": "Aperture",
     "category_trait": "Features",
     "category_dedicated": "Dedicated Lenses",
-    "category_focus": "Focus Type",
     "lensCount": "{count} lenses",
     "lensCountShort": "{count}",
     "sectionCount": "{count} collections",
@@ -539,6 +538,8 @@
     "browseAllTitle": "Browse all lenses",
     "browseAllPill": "Browse {count} cataloged lenses",
     "viewAllCollections": "View all collections",
-    "breadcrumbCollections": "Collections"
+    "breadcrumbCollections": "Collections",
+    "feedbackPrompt": "Missing a lens or spot an error?",
+    "feedbackLink": "Let us know"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -17,10 +17,8 @@
   },
   "Nav": {
     "lenses": "镜头库",
-    "allLenses": "所有镜头",
-    "allLensesHint": "按条件筛选",
-    "collections": "合集",
-    "collectionsHint": "饼干头、一镜走天下、恒定光圈…",
+    "allLenses": "全部镜头",
+    "collections": "主题合集",
     "compare": "对比",
     "about": "关于",
     "getApp": "获取应用",
@@ -519,17 +517,18 @@
     "relatedCollections": "相关合集",
     "indexTitle": "富士 X 卡口镜头合集",
     "indexDescription": "富士 X 卡口镜头合集——按焦段、品牌、光圈等维度分类整理。",
-    "indexStats": "{count} 个合集 · 共 {lensCount} 支镜头",
+    "indexStats": "共 {count} 个合集 · {lensCount} 支镜头",
+    "indexSubtitle": "按焦段、品牌、光圈等维度分类整理",
     "category_prime": "定焦",
     "category_zoom": "变焦",
     "category_brand": "品牌",
     "category_series": "系列",
+    "category_value": "高性价比",
     "category_price": "价格",
     "category_portability": "便携",
     "category_aperture": "光圈",
     "category_trait": "特性",
     "category_dedicated": "专用镜头",
-    "category_focus": "对焦方式",
     "lensCount": "{count} 支镜头",
     "lensCountShort": "{count} 支",
     "sectionCount": "{count} 个合集",
@@ -539,6 +538,8 @@
     "browseAllTitle": "浏览全部镜头",
     "browseAllPill": "浏览已收录的 {count} 支镜头",
     "viewAllCollections": "查看所有合集",
-    "breadcrumbCollections": "合集"
+    "breadcrumbCollections": "合集",
+    "feedbackPrompt": "这个合集有遗漏或错误？",
+    "feedbackLink": "告诉我们"
   }
 }


### PR DESCRIPTION
## What

**Taxonomy**
- Dropped the redundant Autofocus / Manual-focus collections (the list already has an AF/MF filter).
- Added a **Value** category for affordable third-party glass: `value-af`, `value-mf` (new), `value-095` (new). The brand list (`VALUE_BRANDS`) is **origin-agnostic** — budget makers of any origin can be added later (not tied to "domestic").
- **Collection copy is unchanged from `main`.** The two new collections carry placeholder copy pending a dedicated rewrite.

**Routing & navigation**
- Moved the all-lenses list to `/lenses/[mount]/browse` so it is a true sibling of `/collections`. Switching happens via an in-page segmented control; the nav "Browse" dropdown is gone (now a direct link to the list).

**Header & layout**
- Both index pages lead with the shared switcher. Collections shows a one-line count summary + an `sr-only` `<h1>` in place of the big title; the all-lenses list keeps its live result count next to the sort.
- `scrollbar-gutter: stable`, matched control/search heights, and a shared container token so switching tabs never shifts the layout or the fixed nav.
- Adds a feedback prompt under the collection-detail lens grid (reuses the existing `FeedbackTrigger` + inline link style). No other feedback CTAs are touched.

## Non-obvious notes
- **Redirect, not rename of content:** the bare `/lenses/:mount` now **308**-redirects to `/browse`. `next.config`, `sitemap`, `static-routes`, `manifest`, and all internal links were updated together.
- **SEO h1 preserved:** the keyword-rich title moved into an `sr-only <h1>` (mirroring the browse page); the visible header is the count summary.
- **Layout stability:** `scrollbar-gutter: stable` keeps the viewport width constant so a scrolling/non-scrolling view doesn't shift centered containers or the fixed nav. The two index pages share `LENS_INDEX_SHELL_CLS`.
- **Placeholder copy:** `value-mf` / `value-095` titles & descriptions are provisional; the category label ("高性价比" / "Value Picks") and these strings will be rewritten editorially.
- `src/data/collections.json` is hand-authored editorial content (not pipeline-generated), edited directly here.

## Test plan
- `/lenses/x` and `/lenses/gfx` → 308 → `…/browse`; `/lenses` and `/lenses/compare` still resolve.
- Switch 全部镜头 ⇄ 主题合集: control, title, and nav stay put (verified by box coords); no scrollbar jump.
- Value category shows value-af / value-mf / value-095 with live counts; Autofocus/Manual-focus collections 404 (removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)