### PR TITLE
fix(collections): stop mobile horizontal bounce and scroll-spy momentum stall

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -97,7 +97,7 @@ export default async function CollectionsIndexPage({
           for SEO (mirroring the browse page); the visible header is a
           one-line summary the tab label can't convey — collection and lens
           counts — plus a short categorization subtitle. */}
-      <header id="collections-top" className="flex flex-col gap-2 pb-6">
+      <header id="collections-top" className="flex flex-col gap-4 pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <LensSectionNav />
         </div>

--- a/src/components/CollectionChipRail.tsx
+++ b/src/components/CollectionChipRail.tsx
@@ -93,7 +93,20 @@ export default function CollectionChipRail({
     }
     const active = rail.querySelector("[data-active=true]") as HTMLElement | null;
     if (active) {
-      active.scrollIntoView({ behavior: "smooth", inline: "nearest", block: "nearest" });
+      // Scroll the rail horizontally by hand instead of Element.scrollIntoView:
+      // scrollIntoView walks up to the document scrolling element to satisfy
+      // its block axis, and that programmatic scroll cancels the page's
+      // in-flight touch momentum — so a fast flick would dead-stop the moment
+      // scroll-spy lit a chip near the rail edge. scrollBy on the rail only
+      // ever touches the rail's own horizontal axis.
+      const railRect = rail.getBoundingClientRect();
+      const chipRect = active.getBoundingClientRect();
+      const pad = 24;
+      if (chipRect.left < railRect.left + pad) {
+        rail.scrollBy({ left: chipRect.left - railRect.left - pad, behavior: "smooth" });
+      } else if (chipRect.right > railRect.right - pad) {
+        rail.scrollBy({ left: chipRect.right - railRect.right + pad, behavior: "smooth" });
+      }
     }
   }, [activeId, sections]);
 
@@ -128,8 +141,8 @@ export default function CollectionChipRail({
   return (
     <HorizontalScrollRail
       scrollRef={railRef}
-      className="gap-1.5 px-6 py-3"
-      wrapperClassName="sticky z-20 -mx-6 border-b border-zinc-200 dark:border-zinc-800 bg-white/90 dark:bg-zinc-950/90 backdrop-blur-sm transition-[top] duration-300 ease-in-out"
+      className="gap-1.5 px-5 py-3 sm:px-6"
+      wrapperClassName="sticky z-20 -mx-5 sm:-mx-6 border-b border-zinc-200 dark:border-zinc-800 bg-white/90 dark:bg-zinc-950/90 backdrop-blur-sm transition-[top] duration-300 ease-in-out"
       wrapperStyle={{ top: navHidden ? 0 : "var(--nav-height)" }}
       fadeBg="from-white dark:from-zinc-950"
     >

--- a/src/components/ui/horizontal-scroll-rail.tsx
+++ b/src/components/ui/horizontal-scroll-rail.tsx
@@ -56,7 +56,7 @@ export function HorizontalScrollRail({
       <div
         ref={ref}
         className={cn(
-          "flex overflow-x-auto overflow-y-clip [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden",
+          "flex overflow-x-auto overflow-y-clip overscroll-x-contain [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden",
           className,
         )}
       >


### PR DESCRIPTION
Three mobile fixes on the collections index page.

## 1. Horizontal bounce
The sticky chip rail kept `-mx-6` (24px) after the page shell moved to `px-5` on mobile (#307), so it ran 4px past each viewport edge and gave the document a horizontal scroll to rubber-band. Margin/padding now track the shell (`-mx-5 sm:-mx-6`, `px-5 sm:px-6`) → flush full-bleed, 0 overflow. Also added `overscroll-x-contain` to the shared `HorizontalScrollRail` so a rail's own edge overscroll never chains to the viewport.

## 2. Scroll-spy momentum stall
Keeping the active chip visible used `Element.scrollIntoView`, which walks up to the document scroller for its block axis and cancels in-flight touch momentum — a fast flick dead-stopped the moment a chip near the rail edge lit up. Now the rail is scrolled by hand on its horizontal axis only, never touching the document scroller.

## 3. Header spacing
Segmented-control → title → chip-rail gaps were 8px / 24px ("tight above, loose below"). Rebalanced to 16px above (matching the all-lenses header's `gap-4`) and 12px below.

## Test plan
- Measured at 390px (zh) and 1440px (en): horizontal overflow 0 in all quadrants; rail flush within viewport/container.
- Scroll-spy: rail auto-scrolls to keep the active chip visible while `window.scrollY` stays stable.
- Header gaps measured at 16px / 12px.
- The momentum-stall is a touch-inertia behavior not reproducible on desktop; verified by root-cause removal + stable page Y. Real-device flick recommended as a final sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)