### PR TITLE
refactor(feedback): unify inline feedback entry points to one look and copy

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -394,20 +394,16 @@ export default async function LensDetailPage({ params }: { params: Params }) {
               </div>
             ))}
           </div>
-          <div className="flex items-center gap-3 px-2 pt-4">
-            <p className="text-xs text-zinc-400 dark:text-zinc-500">
-              {t("nudgeText")}
-            </p>
+          <p className="px-2 pt-4 text-xs text-zinc-400 dark:text-zinc-500">
+            {t("nudgeText")}{" "}
             <FeedbackTrigger
               type="data_issue"
               context={{ lensId: lens.id, lensModel: lens.model, lensBrand: tBrand(lens.brand) }}
               fields={reportableFields}
-              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 px-2.5 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:border-zinc-300 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-300"
             >
-              <Flag className="size-4" />
-              {t("reportIssue")}
+              {t("feedbackLink")}
             </FeedbackTrigger>
-          </div>
+          </p>
       </div>
 
       <CollectionPills

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -110,10 +110,7 @@ export default async function CollectionPage({
             CTA below. */}
         <p className="mt-8 text-sm text-zinc-500 dark:text-zinc-400">
           {t("feedbackPrompt")}{" "}
-          <FeedbackTrigger
-            type="general"
-            className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-          >
+          <FeedbackTrigger type="general">
             {t("feedbackLink")}
           </FeedbackTrigger>
         </p>

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -255,10 +255,7 @@ export default async function AboutContent() {
         <p className="text-sm text-zinc-600 dark:text-zinc-400">
           {t.rich("coverageSuggest", {
             feedback: (chunks) => (
-              <FeedbackTrigger
-                type="general"
-                className="underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-              >
+              <FeedbackTrigger type="general">
                 {chunks}
               </FeedbackTrigger>
             ),
@@ -272,10 +269,7 @@ export default async function AboutContent() {
           <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
             {t.rich("dataAccuracyCaveat", {
               feedback: (chunks) => (
-                <FeedbackTrigger
-                  type="data_issue"
-                  className="underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-                >
+                <FeedbackTrigger type="data_issue">
                   {chunks}
                 </FeedbackTrigger>
               ),
@@ -418,10 +412,7 @@ export default async function AboutContent() {
             <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
               {t.rich("supportIntegrity", {
                 feedback: (chunks) => (
-                  <FeedbackTrigger
-                    type="general"
-                    className="underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-                  >
+                  <FeedbackTrigger type="general">
                     {chunks}
                   </FeedbackTrigger>
                 ),

--- a/src/components/FeedbackTrigger.tsx
+++ b/src/components/FeedbackTrigger.tsx
@@ -7,6 +7,7 @@ import FeedbackDialog, {
   type FeedbackType,
 } from "./FeedbackDialog";
 import { track } from "@/lib/analytics";
+import { FEEDBACK_LINK_CLS } from "@/lib/ui-tokens";
 
 interface FeedbackTriggerProps {
   type: FeedbackType;
@@ -21,7 +22,10 @@ export default function FeedbackTrigger({
   type,
   context,
   fields,
-  className,
+  // Defaults to the shared inline feedback-link look; callers that need a
+  // different shape (the page-chrome report button, the compare-table cell)
+  // pass their own className to override.
+  className = FEEDBACK_LINK_CLS,
   children,
   stopPropagation = false,
 }: FeedbackTriggerProps) {

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -204,10 +204,7 @@ export default function LensListClient() {
               </p>
               <p className="text-xs text-zinc-400 dark:text-zinc-500">
                 {t("suggestLens")}{" "}
-                <FeedbackTrigger
-                  type="general"
-                  className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                >
+                <FeedbackTrigger type="general">
                   {t("suggestLensLink")}
                 </FeedbackTrigger>
                 <span className="mx-2 opacity-40">·</span>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -250,7 +250,6 @@ export default function LensSearchDialog({
                   <FeedbackTrigger
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
-                    className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>
@@ -312,7 +311,6 @@ export default function LensSearchDialog({
                   <FeedbackTrigger
                     type="general"
                     context={{ searchQuery: deferredQuery.trim() }}
-                    className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
                   >
                     {t("suggestLensLink")}
                   </FeedbackTrigger>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -14,6 +14,7 @@ import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { mountToUrlSegment } from "@/lib/mount";
 import { useNav } from "@/context/NavContext";
 import { usePwa } from "@/lib/usePwa";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import MountSwitcher from "@/components/MountSwitcher";
 import FeedbackDialog from "@/components/FeedbackDialog";
@@ -31,6 +32,16 @@ export default function Nav() {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const lastScrollY = useRef(0);
   const headerRef = useRef<HTMLElement>(null);
+
+  // Both nav entries (desktop link + mobile menu item) open one Nav-level
+  // dialog rather than going through FeedbackTrigger: the mobile menu unmounts
+  // on select, which would tear down a trigger-owned dialog before it opens.
+  // Route both through this one handler so they still fire the same
+  // feedback_open event FeedbackTrigger does — no tracking gap.
+  function openFeedback() {
+    track("feedback_open", { feedback_type: "general" });
+    setFeedbackOpen(true);
+  }
 
   useEffect(() => {
     if (isPwa) {
@@ -152,7 +163,7 @@ export default function Nav() {
           )}
           <button
             type="button"
-            onClick={() => setFeedbackOpen(true)}
+            onClick={openFeedback}
             className={cn(linkCls(false), "hidden sm:inline")}
           >
             {t("feedback")}
@@ -195,7 +206,7 @@ export default function Nav() {
                     </Menu.LinkItem>
                   )}
                   <Menu.Item
-                    onSelect={() => setFeedbackOpen(true)}
+                    onClick={openFeedback}
                     className={mobileLinkCls(false)}
                   >
                     <Flag className="h-4 w-4 shrink-0" />

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Menu } from "@base-ui/react/menu";
-import { EllipsisVertical, Send, Info, Download } from "lucide-react";
+import { EllipsisVertical, Flag, Info, Download } from "lucide-react";
 import { Link, usePathname } from "@/i18n/navigation";
 import Iris from "@/components/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
@@ -198,7 +198,7 @@ export default function Nav() {
                     onSelect={() => setFeedbackOpen(true)}
                     className={mobileLinkCls(false)}
                   >
-                    <Send className="h-4 w-4 shrink-0" />
+                    <Flag className="h-4 w-4 shrink-0" />
                     {t("feedback")}
                   </Menu.Item>
                   <Menu.LinkItem

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -62,6 +62,18 @@ export const ICON_NAV_BTN_CLS =
   "dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-800 dark:active:text-zinc-100";
 
 /**
+ * Inline feedback link — the single look for every feedback entry point that
+ * reads as a text link (suggest-a-lens, report-a-data-issue, in-prose links).
+ * Baked into FeedbackTrigger as its default, so call sites pass no className
+ * and the treatment can never drift again. Inherits font size from the
+ * surrounding sentence; fixes a uniform muted rest color + hover so the links
+ * no longer differ by context.
+ */
+export const FEEDBACK_LINK_CLS =
+  "text-zinc-500 underline underline-offset-2 transition-colors " +
+  "hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100";
+
+/**
  * Underlined text link / inline action (clear filters, toggle, text-only CTA).
  * Pair with per-site font-size, tracking, and whitespace classes.
  */

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -231,6 +231,7 @@
     "officialSite": "Official Page",
     "reportIssue": "Report an issue",
     "nudgeText": "Spotted an error in the data?",
+    "feedbackLink": "Tell me",
     "fieldOfficialLink": "Official Link",
     "fieldLensImage": "Lens Image",
     "fieldGroupMedia": "Media & Links",
@@ -360,11 +361,11 @@
     "coverageColCinema": "Cinema",
     "coverageRowTotal": "Total",
     "coverageLegend": "✓ Covered · ◐ Partial · ○ Under evaluation · — No plans · N/A Not applicable",
-    "coverageSuggest": "Missing a lens you're looking for? <feedback>Let me know</feedback>",
+    "coverageSuggest": "Missing a lens you're looking for? <feedback>Tell me</feedback>",
     "coverageViewLink": "View lens coverage →",
     "dataAccuracyTitle": "Data & Accuracy",
     "dataAccuracyIntro": "All data in X-Glass is produced by two independent pipelines. The spec pipeline collects and structures lens specifications from official brand websites. The pricing pipeline independently samples reference prices from e-commerce storefronts. The two are fully isolated, each with its own data sources and quality control process.",
-    "dataAccuracyCaveat": "X-Glass covers hundreds of lenses across dozens of spec dimensions, and I kindly ask for your patience with the small errors and stale entries that slip through — if you spot anything off, please <feedback>let me know</feedback>. For anything critical to a purchase, please confirm on the manufacturer's official page.",
+    "dataAccuracyCaveat": "X-Glass covers hundreds of lenses across dozens of spec dimensions, and I kindly ask for your patience with the small errors and stale entries that slip through — if you spot anything off, please <feedback>tell me</feedback>. For anything critical to a purchase, please confirm on the manufacturer's official page.",
     "dataSpecTitle": "Spec data",
     "dataSpecPoint1Title": "Data comes from official brand websites only",
     "dataSpecPoint1Body": "Canonical spec values are collected from brand official sites. Third-party material is not used as a source for published values.",
@@ -410,7 +411,7 @@
     "supportTitle": "Support the Project",
     "supportCost": "Building X-Glass involves running a multi-stage data pipeline to gather, clean, and normalize specs from dozens of manufacturer sites, as well as collect price reference data. It is an ongoing commitment, not a one-time build.",
     "supportAffiliate": "For your convenience, some pages include purchase links to dealers, some of which are affiliate links. If you make a purchase through them, X-Glass earns a small commission at absolutely no extra cost to you — this simply helps sustain my development and keeps the platform free and ad-free.",
-    "supportIntegrity": "Affiliate partnerships never influence rankings or pricing data. The codebase is open source — you're welcome to verify how it works under the hood. If you ever encounter a broken link, a model mismatch, or any dealer issues, <feedback>please let me know</feedback> so I can fix it promptly.",
+    "supportIntegrity": "Affiliate partnerships never influence rankings or pricing data. The codebase is open source — you're welcome to verify how it works under the hood. If you ever encounter a broken link, a model mismatch, or any dealer issues, please <feedback>tell me</feedback> so I can fix it promptly.",
     "supportDonate": "If X-Glass helped you find the right lens or saved you some research time, consider supporting the project directly.",
     "supportDonateAlt": "You can also support the project directly — every bit helps keep X-Glass going.",
     "donationKofi": "Support on Ko-fi",
@@ -540,6 +541,6 @@
     "viewAllCollections": "View all collections",
     "breadcrumbCollections": "Collections",
     "feedbackPrompt": "Missing a lens or spot an error?",
-    "feedbackLink": "Let us know"
+    "feedbackLink": "Tell me"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -231,6 +231,7 @@
     "officialSite": "官方介绍",
     "reportIssue": "反馈问题",
     "nudgeText": "发现数据有误？",
+    "feedbackLink": "告诉我",
     "fieldOfficialLink": "官方链接",
     "fieldLensImage": "镜头图片",
     "fieldGroupMedia": "媒体与链接",
@@ -410,7 +411,7 @@
     "supportTitle": "支持项目",
     "supportCost": "搭建 X-Glass 是一件需要长期维护和持续投入的事，并不是一劳永逸的单次开发。为了保证数据质量，我需要运行一套多阶段的数据流水线，用来收集、清洗并校准来自数十个厂商官网的参数，同时还需要整理相关的价格参考数据。",
     "supportAffiliate": "为了方便大家查看或购买，部分页面提供了跳转到商家的购买链接，其中有一些属于联盟营销（Affiliate）链接。如果大家通过这些链接下单，X-Glass 会获得一笔微薄的佣金。这不会让大家多花一分钱，但能帮我分担部分维护成本，让工具保持免费且无广告。",
-    "supportIntegrity": "联盟合作绝不会影响排名或价格数据。X-Glass 的代码完全开源，欢迎随时查看代码是如何实现的。如果发现链接失效、型号错配或其他问题，欢迎<feedback>向我反馈</feedback>，我会及时修复与处理。",
+    "supportIntegrity": "联盟合作绝不会影响排名或价格数据。X-Glass 的代码完全开源，欢迎随时查看代码是如何实现的。如果发现链接失效、型号错配或其他问题，欢迎<feedback>告诉我</feedback>，我会及时修复与处理。",
     "supportDonate": "如果 X-Glass 帮你选到了心仪的镜头，或者为你节省了时间，欢迎直接赞赏支持。",
     "supportDonateAlt": "你也可以直接赞赏来支持这个项目，每一份支持都是对我的鼓励。",
     "donationKofi": "Support on Ko-fi",
@@ -540,6 +541,6 @@
     "viewAllCollections": "查看所有合集",
     "breadcrumbCollections": "合集",
     "feedbackPrompt": "这个合集有遗漏或错误？",
-    "feedbackLink": "告诉我们"
+    "feedbackLink": "告诉我"
   }
 }


### PR DESCRIPTION
Unifies the site's feedback entry points — both the inline links and the Nav entries.

## Inline links (the "text link" family)
- **One style, centralized.** New `FEEDBACK_LINK_CLS`, baked into `FeedbackTrigger` as the default `className`. The 7 inline entry points (all-lenses & search empty states, collection footer, the 3 About prose links, lens-detail bottom link) now pass **no className** — one muted, underlined, hover-to-ink look that inherits the surrounding sentence's font size. Callers needing a different shape (page-chrome report button, compare-table cell) still override via `className`.
- **Detail-page bottom entry** (was a bordered chip + Flag, one size too large because it sat outside the prompt `<p>`): dropped the chip + icon, moved inline into the nudge sentence.
- **Copy → "告诉我 / Tell me"** (first-person, matching product voice). Fixes the `告诉我们 / Let us know` plural outlier and the reuse of the data-issue `reportIssue` label for a soft nudge. The detail bottom link gets its own label so the top chrome button keeps `反馈问题 / Report an issue`.

## Nav entries
- Both Nav feedback entries bypassed `FeedbackTrigger`, so they never fired the `feedback_open` event the rest of the site emits. Routed both (desktop link + mobile menu item) through one shared `openFeedback()` handler that fires the identical event.
- **Bug fix:** the mobile overflow-menu item was **dead** — it used `onSelect`, which base-ui's `Menu.Item` doesn't have (`onSelect` is a valid React text-selection handler, so it typechecked but never fired on click). Tapping it just closed the menu; the dialog never opened. Changed to `onClick`. The dialog stays hoisted to Nav level on purpose (the menu unmounts on click, which would tear down a trigger-owned dialog).
- Nav mobile icon Send → Flag, matching the report-issue icon.

## Out of scope (intentionally untouched)
Page-chrome report buttons (`UTILITY_BTN_CLS`) and the compare-table cell.

## Verification
- `tsc` clean (pre-existing `api/track` ANALYTICS error aside), ESLint clean.
- Inline links render to the unified class (no border/icon, underline, inherit prose size); detail bottom link now matches its 12px prompt.
- Nav: desktop click **and** mobile tap each open the dialog and emit `feedback_open {feedback_type: general}` (verified at runtime via sendBeacon capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)