### PR TITLE
feat(lenses): underline tabs for library view nav, search in filter row

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -91,13 +91,14 @@ export default async function CollectionsIndexPage({
 
   return (
     <main className={`${LENS_INDEX_SHELL_CLS} pt-4 pb-16 sm:pt-8`}>
-      {/* Switcher + summary — same flex-col gap-2 structure as the all-lenses
-          header so the switcher and title land at the same position on both
-          pages. The descriptive, keyword-rich title stays as an sr-only h1
-          for SEO (mirroring the browse page); the visible header is a
-          one-line summary the tab label can't convey — collection and lens
-          counts — plus a short categorization subtitle. */}
-      <header id="collections-top" className="flex flex-col gap-4 pb-3">
+      {/* Switcher + summary. The switcher is the first child and shares the
+          page's top padding, so it lands at the same position as the browse
+          tabs. The summary sits closer to the chip rail it describes than to
+          the tab divider above. The descriptive, keyword-rich title stays as
+          an sr-only h1 for SEO (mirroring the browse page); the visible header
+          is a one-line summary the tab label can't convey — collection and
+          lens counts — plus a short categorization subtitle. */}
+      <header id="collections-top" className="flex flex-col gap-5 pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <LensSectionNav />
         </div>

--- a/src/components/LensFilters.tsx
+++ b/src/components/LensFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown, RotateCcw, SlidersHorizontal } from "lucide-react";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
@@ -14,7 +14,7 @@ import FeatureToggleGroup from "./lens-filters/FeatureToggleGroup";
 import FilterRow from "./lens-filters/FilterRow";
 import MultiSelectChipGroup from "./lens-filters/MultiSelectChipGroup";
 import TypeSegmentedControl from "./lens-filters/TypeSegmentedControl";
-import { miniLabelClass } from "./lens-filters/styles";
+import { miniLabelClass, rowLabelClass } from "./lens-filters/styles";
 import { useFiltersTelemetry } from "./LensFilters.telemetry";
 
 interface Props {
@@ -25,6 +25,8 @@ interface Props {
   hasActiveFilters: boolean;
   activeFilterCount: number;
   onReset: () => void;
+  /** Rendered at the right edge of the brand row (e.g. the lens search trigger). */
+  searchSlot?: ReactNode;
 }
 
 export default function LensFilters({
@@ -35,6 +37,7 @@ export default function LensFilters({
   hasActiveFilters,
   activeFilterCount,
   onReset,
+  searchSlot,
 }: Props) {
   const t = useTranslations("LensList");
   const tBadge = useTranslations("SpecialtyBadge");
@@ -229,28 +232,38 @@ export default function LensFilters({
     <div className="flex min-w-0 flex-1 flex-col">
       {/* Primary filters: always visible on all viewports */}
       <div className="flex flex-col gap-2 sm:gap-3">
-        <div className="sm:hidden">
-          <BrandFilterMenu
-            brands={brands}
-            selected={filters.brands}
-            brandLabels={brandNames}
-            allLabel={allOptionLabel}
-            triggerLabel={brandTriggerLabel}
-            onToggle={(brand) =>
-              updateFilters("brands", toggleMultiFilter(filters.brands, brand, brands))
-            }
-            onClear={() => updateFilters("brands", [])}
-          />
-        </div>
-        <div className="hidden sm:block">
-          <FilterRow label={t("brand")}>
-            <MultiSelectChipGroup
-              allLabel={allOptionLabel}
-              allSelected={filters.brands.length === 0}
-              onSelectAll={() => updateFilters("brands", [])}
-              options={brandOptions}
-            />
-          </FilterRow>
+        {/* Brand row carries the search trigger on its right edge so search
+            shares a line with the first filter instead of taking its own. The
+            brand control itself swaps between a dropdown (mobile) and a chip
+            group (desktop); search renders once, outside that swap. */}
+        <div className="flex items-center gap-2 sm:items-start sm:gap-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="sm:hidden">
+              <BrandFilterMenu
+                brands={brands}
+                selected={filters.brands}
+                brandLabels={brandNames}
+                allLabel={allOptionLabel}
+                triggerLabel={brandTriggerLabel}
+                onToggle={(brand) =>
+                  updateFilters("brands", toggleMultiFilter(filters.brands, brand, brands))
+                }
+                onClear={() => updateFilters("brands", [])}
+              />
+            </div>
+            <div className="hidden sm:flex sm:items-start sm:gap-2.5">
+              <span className={rowLabelClass}>{t("brand")}</span>
+              <div className="min-w-0 flex-1">
+                <MultiSelectChipGroup
+                  allLabel={allOptionLabel}
+                  allSelected={filters.brands.length === 0}
+                  onSelectAll={() => updateFilters("brands", [])}
+                  options={brandOptions}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="shrink-0">{searchSlot}</div>
         </div>
 
         <div className="flex gap-2 sm:hidden">

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -98,14 +98,7 @@ export default function LensListClient() {
     <>
       <div className={`${LENS_INDEX_SHELL_CLS} flex flex-col pt-4 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] sm:pt-8`}>
         <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <LensSectionNav />
-            <LensSearchDialog
-              triggerVariant="button"
-              triggerLabel={tSearch("browseTrigger")}
-              triggerClassName="sm:h-10"
-            />
-          </div>
+          <LensSectionNav />
           <LensFilters
             filters={filters}
             brands={brands}
@@ -114,6 +107,15 @@ export default function LensListClient() {
             hasActiveFilters={hasActiveFilters}
             activeFilterCount={activeFilterCount}
             onReset={clearAllFilters}
+            // Search shares the brand row's right edge — it scopes the lens
+            // list, so it belongs in the refine zone, not the navigation bar.
+            searchSlot={
+              <LensSearchDialog
+                triggerVariant="button"
+                triggerLabel={tSearch("browseTrigger")}
+                triggerClassName="sm:h-10"
+              />
+            }
           />
         </div>
 

--- a/src/components/LensSectionNav.tsx
+++ b/src/components/LensSectionNav.tsx
@@ -8,8 +8,10 @@ import { cn } from "@/lib/utils";
 
 /**
  * Switcher between the two views of the lens library: the filterable list
- * ("所有镜头") and the curated collections ("合集"). Mirrors the in-page
- * filter segmented controls so the whole header reads as one control family.
+ * ("所有镜头") and the curated collections ("合集"). Rendered as underline
+ * tabs sitting on a full-width divider — a deliberately different component
+ * type from the filter pills below, so page-level view switching reads as
+ * navigation, not as another refinement control.
  */
 export default function LensSectionNav() {
   const t = useTranslations("Nav");
@@ -25,7 +27,7 @@ export default function LensSectionNav() {
   return (
     <nav
       aria-label={t("lenses")}
-      className="inline-flex rounded-xl bg-zinc-100 p-1 dark:bg-zinc-800"
+      className="flex w-full items-center gap-6 border-b border-zinc-200 dark:border-zinc-800"
     >
       {tabs.map((tab) => {
         const selected = tab.key === active;
@@ -35,13 +37,13 @@ export default function LensSectionNav() {
             href={tab.href}
             aria-current={selected ? "page" : undefined}
             className={cn(
-              // Same segmented-control shape as the filter controls below, but
-              // a notch larger/bolder with stronger active contrast — it's the
-              // primary view switcher, not a secondary filter.
-              "inline-flex h-9 items-center justify-center rounded-lg px-4 text-[13px] font-semibold transition-colors sm:h-8",
+              // -mb-px pulls the 2px active indicator down to overlap the
+              // nav's 1px bottom border, so the underline reads as the tab's
+              // own indicator rather than a doubled rule.
+              "relative -mb-px flex items-center border-b-2 pb-3 pt-0.5 text-[15px] font-semibold transition-colors",
               selected
-                ? "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-50 dark:shadow-none"
-                : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
+                ? "border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-50"
+                : "border-transparent text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
             )}
           >
             {tab.label}


### PR DESCRIPTION
## What

Make page-level view switching look different from in-list refinement by using a different component type for each.

- **`LensSectionNav`**: pill segmented control → underline tabs on a full-width divider, so **All Lenses / Collections** reads as navigation rather than another filter. Shared by the browse and collections pages.
- **Search trigger**: moved out of the nav row into the right edge of the brand filter row (browse only), where it belongs as a list-scoping control. Renders once; the brand control still swaps dropdown (mobile) / chips (desktop) beside it.
- **Collections header**: pull the summary closer to the chip rail it describes than to the tab divider above.

## Non-obvious bits

- The brand row is `items-center` on mobile (the `h-9` dropdown and the `h-11` search button line up) but `sm:items-start` on desktop — so search stays pinned top-right when brand chips wrap to multiple lines.
- `LensSectionNav` is rendered per-page (not in the shared `(browse)` layout), so the restyle applies to both pages from one change.

## Test plan

- [x] Verified across mobile/desktop × zh/en + 820px intermediate (chip wrap) via Playwright
- [x] Collections page: tabs render, no search, summary spacing
- [x] ESLint + `tsc --noEmit` clean