### PR TITLE
feat(collections): add client-side sort to collection detail

### DIFF
--- a/src/components/CollectionLensGrid.tsx
+++ b/src/components/CollectionLensGrid.tsx
@@ -1,37 +1,66 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import LensCard from "@/components/LensCard";
+import LensSortControl from "@/components/LensSortControl";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
-import { MAX_COMPARE } from "@/lib/lens";
+import { MAX_COMPARE, sortLenses, type SortKey } from "@/lib/lens";
 import type { Lens } from "@/lib/types";
+
+// A collection smaller than this fits within ~one desktop grid row, so sorting
+// it is noise rather than help — hide the control below the threshold.
+const SORT_MIN_LENSES = 5;
 
 export default function CollectionLensGrid({ lenses }: { lenses: Lens[] }) {
   const hookAttr = useUiHookAttr();
   const { compareIds, toggle } = useCompare();
+  // Local sort only — a collection is already a fixed membership set, so order
+  // is purely a view concern and never touches the URL or server data path.
+  const [sort, setSort] = useState<SortKey>("focalLength");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+
+  const displayed = useMemo(
+    () => sortLenses(lenses, sort, sortDir),
+    [lenses, sort, sortDir],
+  );
 
   if (lenses.length === 0) {
     return null;
   }
 
   return (
-    <div
-      {...hookAttr("grid")}
-      className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
-    >
-      {lenses.map((lens, i) => (
-        <LensCard
-          key={lens.id}
-          lens={lens}
-          isSelected={compareIds.includes(lens.id)}
-          selectionDisabled={
-            !compareIds.includes(lens.id) &&
-            compareIds.length >= MAX_COMPARE
-          }
-          onToggle={toggle}
-          priority={i < 8}
-        />
-      ))}
-    </div>
+    <>
+      {lenses.length >= SORT_MIN_LENSES && (
+        <div className="mb-4 flex justify-end">
+          <LensSortControl
+            sort={sort}
+            sortDir={sortDir}
+            onSortChange={setSort}
+            onToggleDir={() =>
+              setSortDir((dir) => (dir === "asc" ? "desc" : "asc"))
+            }
+          />
+        </div>
+      )}
+      <div
+        {...hookAttr("grid")}
+        className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
+      >
+        {displayed.map((lens, i) => (
+          <LensCard
+            key={lens.id}
+            lens={lens}
+            isSelected={compareIds.includes(lens.id)}
+            selectionDisabled={
+              !compareIds.includes(lens.id) &&
+              compareIds.length >= MAX_COMPARE
+            }
+            onToggle={toggle}
+            priority={i < 8}
+          />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -11,24 +11,16 @@ import {
   defaultFilters,
   MAX_COMPARE,
   type FilterState,
-  type SortKey,
 } from "@/lib/lens";
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
 import { useLensesApi } from "@/hooks/useLensesApi";
-import { ArrowDownWideNarrow, ArrowUp, ArrowDown } from "lucide-react";
 import BackToTopButton from "@/components/BackToTopButton";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
 import LensSectionNav from "./LensSectionNav";
+import LensSortControl from "./LensSortControl";
 import { LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
 import LensSearchDialog from "./LensSearchDialog";
 import LensesLoading from "@/app/[locale]/lenses/[mount]/(browse)/loading";
@@ -75,12 +67,6 @@ export default function LensListClient() {
     filters.focalCategories.length > 0,
     filters.features.length > 0,
   ].filter(Boolean).length;
-
-  const sortOptions = [
-    { value: "focalLength", label: t("sortFocalLength") },
-    { value: "maxAperture", label: t("sortAperture") },
-    { value: "weightG", label: t("sortWeight") },
-  ] as const satisfies readonly { value: SortKey; label: string }[];
 
   function updateFilters(updater: FilterState | ((prev: FilterState) => FilterState)) {
     const next = typeof updater === "function" ? updater(filters) : updater;
@@ -132,62 +118,19 @@ export default function LensListClient() {
               })}
             </p>
 
-            <div className="inline-flex h-9 items-stretch overflow-hidden rounded-xl border border-zinc-200/70 bg-white/80 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30">
-              <Select
-                value={filters.sort}
-                onValueChange={(value) =>
-                  updateFilters((current) => ({
-                    ...current,
-                    sort: (value ?? "focalLength") as SortKey,
-                  }))
-                }
-                items={sortOptions.map((option) => ({ ...option }))}
-              >
-                <SelectTrigger
-                  id="results-sort"
-                  className="h-full data-[size=default]:h-full gap-2 rounded-none border-0 bg-transparent py-0 px-3 text-[12px] shadow-none hover:bg-zinc-50/50 data-[popup-open]:bg-zinc-100 dark:hover:bg-zinc-800/30 dark:data-[popup-open]:bg-zinc-800/50 sm:text-[13px]"
-                >
-                  <ArrowDownWideNarrow className="size-3.5 shrink-0 text-zinc-900 dark:text-zinc-100" />
-                  <SelectValue placeholder={t("sortFocalLength")} />
-                </SelectTrigger>
-                <SelectContent
-                  align="end"
-                  alignOffset={-40}
-                  sideOffset={5}
-                  className="w-[calc(var(--anchor-width)+40px)] min-w-0 overflow-hidden rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.06)]"
-                >
-                  {sortOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      className="rounded-lg py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
-                    >
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <div className="w-px self-stretch bg-zinc-200 dark:bg-zinc-800" />
-              <button
-                type="button"
-                className="inline-flex items-center px-3 hover:bg-zinc-50/50 dark:hover:bg-zinc-800/30"
-                onClick={() =>
-                  updateFilters((current) => ({
-                    ...current,
-                    sortDir: current.sortDir === "asc" ? "desc" : "asc",
-                  }))
-                }
-                aria-label={
-                  filters.sortDir === "asc" ? t("sortAsc") : t("sortDesc")
-                }
-              >
-                {filters.sortDir === "asc" ? (
-                  <ArrowUp className="size-3.5" />
-                ) : (
-                  <ArrowDown className="size-3.5" />
-                )}
-              </button>
-            </div>
+            <LensSortControl
+              sort={filters.sort}
+              sortDir={filters.sortDir}
+              onSortChange={(sort) =>
+                updateFilters((current) => ({ ...current, sort }))
+              }
+              onToggleDir={() =>
+                updateFilters((current) => ({
+                  ...current,
+                  sortDir: current.sortDir === "asc" ? "desc" : "asc",
+                }))
+              }
+            />
           </div>
         </div>
 

--- a/src/components/LensSortControl.tsx
+++ b/src/components/LensSortControl.tsx
@@ -61,7 +61,10 @@ export default function LensSortControl({
             <SelectItem
               key={option.value}
               value={option.value}
-              className="rounded-lg py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
+              // Full-bleed highlight: square corners let the popup's own
+              // rounded-lg + overflow clip the top/bottom rows, instead of a
+              // rounded bar floating inside the menu with gaps at the edges.
+              className="rounded-none py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
             >
               {option.label}
             </SelectItem>

--- a/src/components/LensSortControl.tsx
+++ b/src/components/LensSortControl.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ArrowDownWideNarrow, ArrowUp, ArrowDown } from "lucide-react";
+import type { SortKey } from "@/lib/lens";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface Props {
+  sort: SortKey;
+  sortDir: "asc" | "desc";
+  onSortChange: (sort: SortKey) => void;
+  onToggleDir: () => void;
+}
+
+/**
+ * Sort key picker + direction toggle, shared by the browse list and the
+ * collection detail grid so both surfaces sort identically. Owns only the
+ * control UI and label copy; the caller holds the sort state.
+ */
+export default function LensSortControl({
+  sort,
+  sortDir,
+  onSortChange,
+  onToggleDir,
+}: Props) {
+  const t = useTranslations("LensList");
+
+  const sortOptions = [
+    { value: "focalLength", label: t("sortFocalLength") },
+    { value: "maxAperture", label: t("sortAperture") },
+    { value: "weightG", label: t("sortWeight") },
+  ] as const satisfies readonly { value: SortKey; label: string }[];
+
+  return (
+    <div className="inline-flex h-9 items-stretch overflow-hidden rounded-xl border border-zinc-200/70 bg-white/80 shadow-sm shadow-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/30">
+      <Select
+        value={sort}
+        onValueChange={(value) => onSortChange((value ?? "focalLength") as SortKey)}
+        items={sortOptions.map((option) => ({ ...option }))}
+      >
+        <SelectTrigger
+          id="results-sort"
+          className="h-full data-[size=default]:h-full gap-2 rounded-none border-0 bg-transparent py-0 px-3 text-[12px] shadow-none hover:bg-zinc-50/50 data-[popup-open]:bg-zinc-100 dark:hover:bg-zinc-800/30 dark:data-[popup-open]:bg-zinc-800/50 sm:text-[13px]"
+        >
+          <ArrowDownWideNarrow className="size-3.5 shrink-0 text-zinc-900 dark:text-zinc-100" />
+          <SelectValue placeholder={t("sortFocalLength")} />
+        </SelectTrigger>
+        <SelectContent
+          align="end"
+          alignOffset={-40}
+          sideOffset={5}
+          className="w-[calc(var(--anchor-width)+40px)] min-w-0 overflow-hidden rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.06)]"
+        >
+          {sortOptions.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              className="rounded-lg py-2 sm:py-2 text-[12px] text-zinc-500 dark:text-zinc-400 data-[selected]:text-zinc-900 dark:data-[selected]:text-zinc-50"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="w-px self-stretch bg-zinc-200 dark:bg-zinc-800" />
+      <button
+        type="button"
+        className="inline-flex items-center px-3 hover:bg-zinc-50/50 dark:hover:bg-zinc-800/30"
+        onClick={onToggleDir}
+        aria-label={sortDir === "asc" ? t("sortAsc") : t("sortDesc")}
+      >
+        {sortDir === "asc" ? (
+          <ArrowUp className="size-3.5" />
+        ) : (
+          <ArrowDown className="size-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a sort control to the collection detail page (`/lenses/[mount]/collections/[slug]`), reusing the browse list's sort UI: sort by focal length / aperture / weight, ascending or descending.

Collection detail previously listed lenses in raw data-file order with no way to reorder them. The largest collections (e.g. `under-400` = 82 lenses, `fujifilm` = 48) were hard to scan.

## Why sort, not filter

A collection is a fixed membership set defined by a single predicate, so its defining axis is exactly the one filter dimension already collapsed inside it (the brand filter is dead inside a brand collection, the focal filter is dead inside a focal-length collection, etc.). Reusing the full filter bar would always carry at least one redundant control and would blur the curated-vs-filter IA split between collections and browse. Sort is orthogonal to membership and has none of these problems.

## How

- Extract the sort key picker + direction toggle from `LensListClient` into a shared `LensSortControl`, so browse and collection detail sort identically.
- `CollectionLensGrid` holds local sort state and sorts the already-passed lens array client-side. No URL params, no server-data changes — SSG and SEO are untouched (the server still renders the full membership list).
- Gate the control to collections of ≥5 lenses; smaller ones fit roughly one desktop grid row, so a sort control there is noise.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `api/track/route.ts` Cloudflare-env error aside) and ESLint clean on touched files
- [x] Large collection (`fujifilm`, 48) desktop: control right-aligned, default focal-ascending order correct (8mm → 500mm)
- [x] Small collection (`85mm`, 2): control correctly hidden
- [x] Mobile 375px: control fits within content width, no overflow
- [x] Browse page sort unchanged after the extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)