### PR TITLE
feat(collections): add Share + Feedback chrome to collection detail

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -1,16 +1,17 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Flag } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { COLLECTIONS, getCollectionStats, getRelatedCollectionsWithStats } from "@/lib/collections";
 import { getLensesByMount } from "@/lib/lens";
 import type { Mount } from "@/lib/types";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
-import { ACTION_ESCAPE_CLS } from "@/lib/ui-tokens";
+import { ACTION_ESCAPE_CLS, UTILITY_BTN_CLS } from "@/lib/ui-tokens";
 import CollectionLensGrid from "@/components/CollectionLensGrid";
 import RelatedCollectionCard from "@/components/RelatedCollectionCard";
 import BackToTopButton from "@/components/BackToTopButton";
+import { ShareButton } from "@/components/share/ShareButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import FeedbackTrigger from "@/components/FeedbackTrigger";
 
@@ -84,7 +85,7 @@ export default async function CollectionPage({
     <>
       <main className="mx-auto max-w-6xl px-4 py-8 pb-[max(10rem,calc(var(--compare-bar-height,0px)+8rem))]">
         <header className="mb-8">
-          <div className="mb-4">
+          <div className="mb-4 flex items-center justify-between gap-3">
             <Breadcrumb
               segments={[
                 { label: tNav("lenses"), href: `/lenses/${mount}/browse` },
@@ -92,6 +93,18 @@ export default async function CollectionPage({
               ]}
               current={title}
             />
+            <div className="flex shrink-0 items-center gap-1">
+              <ShareButton
+                lenses={lenses}
+                linkOnly
+                shareText={t("shareText", { title })}
+                triggerClassName={UTILITY_BTN_CLS}
+              />
+              <FeedbackTrigger type="general" className={UTILITY_BTN_CLS}>
+                <Flag className="size-4" />
+                <span className="hidden sm:inline">{t("reportIssue")}</span>
+              </FeedbackTrigger>
+            </div>
           </div>
           <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
             {title}

--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -4,17 +4,15 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { ChevronUp } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Z } from "@/config/ui";
+import { Z, FAB_REVEAL_SCROLL_Y } from "@/config/ui";
 import { spring } from "@/lib/animation";
-
-const SCROLL_THRESHOLD = 400;
 
 export default function BackToTopButton() {
   const tc = useTranslations("Common");
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setShow(window.scrollY > SCROLL_THRESHOLD);
+    const onScroll = () => setShow(window.scrollY > FAB_REVEAL_SCROLL_Y);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -95,11 +95,10 @@ export default function ComparePageHeader() {
         )}
         <div className="ml-auto flex items-center gap-1">
           {activeLenses.length >= 1 && (
-            <ShareButton lenses={activeLenses} presetTitle={presetTitle} presetSubtitle={presetSubtitle} />
+            <ShareButton lenses={activeLenses} presetTitle={presetTitle} presetSubtitle={presetSubtitle} triggerClassName={UTILITY_BTN_CLS} />
           )}
           <FeedbackTrigger
             type="general"
-            context={{}}
             className={UTILITY_BTN_CLS}
           >
             <Flag className="size-4" />

--- a/src/components/ShareFAB.tsx
+++ b/src/components/ShareFAB.tsx
@@ -2,12 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Z } from "@/config/ui";
+import { Z, FAB_REVEAL_SCROLL_Y } from "@/config/ui";
 import { spring } from "@/lib/animation";
 import { ShareButton } from "@/components/share/ShareButton";
 import type { Lens } from "@/lib/types";
-
-const SCROLL_THRESHOLD = 400;
 
 interface Props {
   lenses: Lens[];
@@ -19,7 +17,7 @@ export default function ShareFAB({ lenses, presetTitle, presetSubtitle }: Props)
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setShow(window.scrollY > SCROLL_THRESHOLD);
+    const onScroll = () => setShow(window.scrollY > FAB_REVEAL_SCROLL_Y);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -36,6 +36,14 @@ interface ShareButtonProps {
   presetTitle?: string;
   /** Pre-fill the poster slogan from a curated preset subtitle. User can still override. */
   presetSubtitle?: string;
+  /**
+   * Link-only mode: skip the comparison-poster surface entirely and offer just
+   * copy-link + native share. For pages whose subject isn't a ≤MAX_COMPARE lens
+   * set (e.g. a collection of many lenses), where the spec poster doesn't apply.
+   */
+  linkOnly?: boolean;
+  /** Native-share message body in linkOnly mode. Falls back to the lens CTA. */
+  shareText?: string;
 }
 
 function computePosterTitle(
@@ -50,7 +58,7 @@ function computePosterTitle(
   return lenses.map((l) => lensDisplayName(tBrand(l.brand), l.series, l.model));
 }
 
-export function ShareButton({ lenses, variant = "default", triggerClassName, iconOnly, presetTitle, presetSubtitle }: ShareButtonProps) {
+export function ShareButton({ lenses, variant = "default", triggerClassName, iconOnly, presetTitle, presetSubtitle, linkOnly, shareText }: ShareButtonProps) {
   const t = useTranslations("Share");
   const locale = useLocale();
   const tImage = useTranslations("ShareImage");
@@ -154,9 +162,9 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
 
   const handleNativeShare = useCallback(async () => {
     const isSingle = lenses.length === 1;
-    const cta = isSingle
+    const cta = shareText ?? (isSingle
       ? t("shareCtaSingle")
-      : t("shareCtaMulti", { count: lenses.length });
+      : t("shareCtaMulti", { count: lenses.length }));
     const pageUrl = window.location.href;
     try {
       await navigator.share({
@@ -171,7 +179,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
       }
       toast.error(t("shareFailed"));
     }
-  }, [lenses, t]);
+  }, [lenses, shareText, t]);
 
   const handleDownload = useCallback(async () => {
     if (!posterRef.current) {
@@ -248,6 +256,56 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
   const tabClass =
     "flex-1 rounded-md px-3 py-1.5 text-sm font-medium text-zinc-500 transition-colors hover:text-zinc-900 data-[active]:bg-white data-[active]:text-zinc-900 data-[active]:shadow-xs dark:text-zinc-400 dark:hover:text-zinc-50 dark:data-[active]:bg-zinc-700 dark:data-[active]:text-zinc-50 outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 cursor-pointer";
 
+  // Copy-link + native-share controls. Shared between the Link tab (poster
+  // mode) and the linkOnly panel so the two never drift.
+  const linkSection = (
+    <div className="flex flex-col gap-3">
+      <div className="select-all break-all rounded-md bg-zinc-100 px-3 py-2.5 font-mono text-xs leading-relaxed text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+        {truncatedUrl}
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={handleCopy}
+          className={cn(
+            "flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors",
+            copied
+              ? "bg-green-600 text-white hover:bg-green-700"
+              : copyFailed
+                ? "bg-red-600 text-white hover:bg-red-700"
+                : "bg-zinc-900 text-zinc-50 hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          )}
+        >
+          {copied ? (
+            <><Check className="size-4" />{t("copied")}</>
+          ) : copyFailed ? (
+            <><Copy className="size-4" />{t("copyFailed")}</>
+          ) : (
+            <><Copy className="size-4" />{t("copyLink")}</>
+          )}
+        </button>
+        {canNativeShare && (
+          <button
+            onClick={handleNativeShare}
+            title={t("nativeShare")}
+            className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            <Share2 className="size-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  // Link-only panel: no poster surface, just the copy/share controls.
+  const linkOnlyContent = (
+    <div className="flex flex-col gap-4 p-4">
+      <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+        {t("button")}
+      </h2>
+      {linkSection}
+    </div>
+  );
+
   const panelContent = (
     <div className="flex flex-col gap-4 p-4">
       <div className="flex flex-col gap-0.5">
@@ -264,40 +322,8 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
         </Tabs.List>
 
         {/* ── Link tab ─────────────────────────────────────────── */}
-        <Tabs.Panel value="link" className="flex flex-col gap-3">
-          <div className="select-all break-all rounded-md bg-zinc-100 px-3 py-2.5 font-mono text-xs leading-relaxed text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-            {truncatedUrl}
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={handleCopy}
-              className={cn(
-                "flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors",
-                copied
-                  ? "bg-green-600 text-white hover:bg-green-700"
-                  : copyFailed
-                    ? "bg-red-600 text-white hover:bg-red-700"
-                    : "bg-zinc-900 text-zinc-50 hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-              )}
-            >
-              {copied ? (
-                <><Check className="size-4" />{t("copied")}</>
-              ) : copyFailed ? (
-                <><Copy className="size-4" />{t("copyFailed")}</>
-              ) : (
-                <><Copy className="size-4" />{t("copyLink")}</>
-              )}
-            </button>
-            {canNativeShare && (
-              <button
-                onClick={handleNativeShare}
-                title={t("nativeShare")}
-                className="flex items-center justify-center rounded-lg border border-zinc-200 px-3 py-2.5 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-              >
-                <Share2 className="size-4" />
-              </button>
-            )}
-          </div>
+        <Tabs.Panel value="link">
+          {linkSection}
         </Tabs.Panel>
 
         {/* ── Image tab ────────────────────────────────────────── */}
@@ -382,6 +408,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
   );
 
   const isFab = variant === "fab";
+  const activePanel = linkOnly ? linkOnlyContent : panelContent;
 
   const defaultTriggerClass =
     triggerClassName ??
@@ -412,7 +439,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
       <Popover.Portal>
         <Popover.Positioner side={isFab ? "top" : "bottom"} align="end" sideOffset={8}>
           <Popover.Popup className="w-96 max-h-[calc(100svh-80px)] overflow-y-auto origin-(--transform-origin) rounded-xl bg-white shadow-lg ring-1 ring-zinc-200 duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:bg-zinc-900 dark:ring-zinc-800">
-            {panelContent}
+            {activePanel}
           </Popover.Popup>
         </Popover.Positioner>
       </Popover.Portal>
@@ -433,7 +460,7 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
               <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
             </div>
             <div className="overflow-y-auto pb-8">
-              {panelContent}
+              {activePanel}
             </div>
           </Drawer.Popup>
         </Drawer.Viewport>

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -52,6 +52,12 @@ export const Z = {
 // scroll; the nav bar sits above it in a flex column. Individual pages should
 // use h-full / flex-1 rather than calc(100dvh - navHeight).
 
+// ── Floating action buttons ─────────────────────────────────────────────────
+//
+// Vertical scroll past this many pixels before reveal-on-scroll FABs
+// (Back-to-Top, Share) fade in. Shared so the affordances appear in lockstep.
+export const FAB_REVEAL_SCROLL_Y = 400;
+
 // ── Lens list / compare ───────────────────────────────────────────────────────
 
 // TODO: max number of lenses that can be compared simultaneously

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -541,6 +541,8 @@
     "viewAllCollections": "View all collections",
     "breadcrumbCollections": "Collections",
     "feedbackPrompt": "Missing a lens or spot an error?",
-    "feedbackLink": "Tell me"
+    "feedbackLink": "Tell me",
+    "reportIssue": "Report an issue",
+    "shareText": "Check out the \"{title}\" lens collection on X-Glass"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -541,6 +541,8 @@
     "viewAllCollections": "查看所有合集",
     "breadcrumbCollections": "合集",
     "feedbackPrompt": "这个合集有遗漏或错误？",
-    "feedbackLink": "告诉我"
+    "feedbackLink": "告诉我",
+    "reportIssue": "反馈问题",
+    "shareText": "看看 X-Glass 上的「{title}」镜头合集"
   }
 }


### PR DESCRIPTION
## What

Collection detail pages were missing the top-right **Share + Feedback** chrome that lens detail and compare pages have. This adds them.

The catch: the existing "Share" is a **≤4-lens comparison poster** (`SharePoster`, `MAX_COMPARE = 4`). A collection holds many lenses, so that poster doesn't apply. Share is therefore routed through a new **link-only** mode (copy URL + native share, no poster).

## Changes

- **`ShareButton`** — new `linkOnly` + `shareText` props. `linkOnly` skips the poster surface and renders only copy-link + native-share. The copy/share controls are factored into a shared block reused by the Link tab, so the two can't drift. The default (poster) path is byte-for-byte unchanged.
- **Collection detail** — Share (linkOnly) + Feedback added to the breadcrumb row, mirroring lens-detail chrome. **No Share FAB** (a link-share floating button adds little until there's a collection poster); only Back-to-Top stays in the FAB slot.
- **Drift cleanup**
  - Compare-page Share now uses the same `UTILITY_BTN_CLS` as its sibling Feedback (was the bare default trigger — Share/Feedback looked different in the same row).
  - Dropped the redundant empty `context={{}}` on the compare Feedback trigger.
  - Hoisted the duplicated FAB reveal threshold into `config/ui` as `FAB_REVEAL_SCROLL_Y`, shared by `ShareFAB` and `BackToTopButton`.

## Test plan

Verified at runtime (Playwright + getBoundingClientRect, localhost:3000):

- Collection chrome across **mobile 390 / desktop 1440 × en / zh**: renders, icon-only on mobile (no wrap, no overflow, 175px clear of breadcrumb), labels resolve on desktop, no raw i18n key leak.
- Link-only Share panel shows **only** URL + Copy Link + native share — no poster tab; copy fires the `share_action` beacon.
- FAB slot on collection has **only Back-to-Top** after scroll — no Share FAB.
- Regression: lens-detail Share still shows both Image + Link tabs (poster path intact).
- `npm run lint` clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)