### PR TITLE
fix(collections): refine share CTA + scope it to the mount

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, Flag } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { COLLECTIONS, getCollectionStats, getRelatedCollectionsWithStats } from "@/lib/collections";
 import { getLensesByMount } from "@/lib/lens";
-import type { Mount } from "@/lib/types";
+import { urlSegmentToMount, mountSeoLabel } from "@/lib/mount";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { ACTION_ESCAPE_CLS, UTILITY_BTN_CLS } from "@/lib/ui-tokens";
 import CollectionLensGrid from "@/components/CollectionLensGrid";
@@ -31,14 +31,18 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { locale, mount, slug } = await params;
-  const stats = getCollectionStats(slug, mount as Mount, locale);
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount) {
+    return {};
+  }
+  const stats = getCollectionStats(slug, resolvedMount, locale);
   if (!stats) {
     return {};
   }
 
   const t = await getTranslations({ locale, namespace: "Collection" });
   const title = localized(stats.collection.title, locale);
-  const mountLabel = locale === "zh" ? "富士 X 卡口" : "Fujifilm X-Mount";
+  const mountLabel = t("mountLabel", { mount: mountSeoLabel(resolvedMount) });
   const seoTitle = `${title} — ${mountLabel}`;
   const description = localized(stats.collection.description, locale);
 
@@ -65,7 +69,10 @@ export default async function CollectionPage({
   const { locale, mount, slug } = await params;
   setRequestLocale(locale);
 
-  const resolvedMount = mount as Mount;
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount) {
+    notFound();
+  }
   const collectionStats = getCollectionStats(slug, resolvedMount, locale);
   if (!collectionStats) {
     notFound();
@@ -76,6 +83,7 @@ export default async function CollectionPage({
   const tNav = await getTranslations({ locale, namespace: "Nav" });
 
   const title = localized(collection.title, locale);
+  const mountLabel = t("mountLabel", { mount: mountSeoLabel(resolvedMount) });
   const description = localized(collection.description, locale);
   const statsLabel = t("stats", { count: lensCount, brandCount });
   const mountLenses = getLensesByMount(resolvedMount, locale);
@@ -97,7 +105,7 @@ export default async function CollectionPage({
               <ShareButton
                 lenses={lenses}
                 linkOnly
-                shareText={t("shareText", { title })}
+                shareText={t("shareText", { title, mount: mountLabel })}
                 triggerClassName={UTILITY_BTN_CLS}
               />
               <FeedbackTrigger type="general" className={UTILITY_BTN_CLS}>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -543,6 +543,6 @@
     "feedbackPrompt": "Missing a lens or spot an error?",
     "feedbackLink": "Tell me",
     "reportIssue": "Report an issue",
-    "shareText": "Check out the \"{title}\" lens collection on X-Glass"
+    "shareText": "Found a nice collection on X-Glass: {title}"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -543,6 +543,7 @@
     "feedbackPrompt": "Missing a lens or spot an error?",
     "feedbackLink": "Tell me",
     "reportIssue": "Report an issue",
-    "shareText": "Found a nice collection on X-Glass: {title}"
+    "mountLabel": "Fujifilm {mount}-Mount",
+    "shareText": "Found a nice collection on X-Glass: {title} ({mount})"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -543,6 +543,6 @@
     "feedbackPrompt": "这个合集有遗漏或错误？",
     "feedbackLink": "告诉我",
     "reportIssue": "反馈问题",
-    "shareText": "看看 X-Glass 上的「{title}」镜头合集"
+    "shareText": "在 X-Glass 发现一份不错的合集：{title}"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -543,6 +543,7 @@
     "feedbackPrompt": "这个合集有遗漏或错误？",
     "feedbackLink": "告诉我",
     "reportIssue": "反馈问题",
-    "shareText": "在 X-Glass 发现一份不错的合集：{title}"
+    "mountLabel": "富士 {mount} 卡口",
+    "shareText": "在 X-Glass 发现一份不错的合集：{title}（{mount}）"
   }
 }


### PR DESCRIPTION
## What

Follow-up to #312. Two things:

1. **Refine the share CTA copy.** The old text wrapped the title in a redundant "镜头/lens collection" frame, doubling the noun titles already carry. Treat the title as a self-contained name.
2. **Tell the reader which mount it's for.** A shared collection link gave no hint it's mount-specific — someone unfamiliar with X-Glass couldn't tell it's Fujifilm X. Append the public mount label, **derived from the route** (not hardcoded), so future GFX collections read correctly.

```
zh: 在 X-Glass 发现一份不错的合集：{title}（{mount}）
en: Found a nice collection on X-Glass: {title} ({mount})
```
Rendered (captured from the real `navigator.share` payload):
```
在 X-Glass 发现一份不错的合集：35mm 定焦镜头（富士 X 卡口）
👉 https://xglass.sentacraft.com/zh/lenses/x/collections/35mm
```

## Latent bug fixed along the way

The collection detail route cast the URL segment (`"x"`/`"gfx"`) straight to `Mount` and passed it to `getLensesByMount`, which only special-cases `"G"` (`mount === "G" ? gfxLenses : xLenses`). So a **GFX collection page fell through to the X catalog**, and `generateMetadata` hardcoded `"Fujifilm X-Mount"`. Now the segment is resolved via `urlSegmentToMount` first, and the mount label is built from `mountSeoLabel` — fixing both the data path and the title for GFX.

## Test plan

Verified at runtime (Playwright, localhost:3000):

- zh X collection title → `35mm 定焦镜头 — 富士 X 卡口`; GFX route title → `微距镜头 — 富士 GFX 卡口` (dynamic label, no hardcode).
- GFX route browse pill reads the GF catalog size (27), not the X catalog — confirms `getLensesByMount` now receives `"G"`.
- Native-share payload interpolates both `{title}` and `{mount}` correctly (captured above), in zh + en.
- `npm run lint` clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)