### PR TITLE
fix(lenses): tone down detail-page price color

### DIFF
--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -39,7 +39,7 @@ export function PriceSection({ lens }: Props) {
   return (
     <div className="flex flex-col gap-1">
       {/* Row 1: Price + approx */}
-      <span className="text-xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
+      <span className="text-xl font-semibold tabular-nums text-zinc-700 dark:text-zinc-200">
         {t.rich("priceApprox", {
           price: priceDisplay,
           approx: (chunks) => (


### PR DESCRIPTION
## What

The lens detail page rendered its reference price in near-black (`zinc-900`), making it a second near-black element competing with the page title / model name.

Drop it to `zinc-700` — the same price color already used on the lens cards and in the compare table — so the title stays the only near-black element and the price reads as a secondary datum.

One-line change in `PriceSection`. Verified on the detail page: price is now visibly grayer than the black title (zinc-700 vs zinc-900), hierarchy reads title → price → source/disclaimer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)