### PR TITLE
feat(schema): enforce per-market currency in lens pricing

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -115,6 +115,28 @@ const lensBaseShape = {
   pricing: z.strictObject({
     cn: pricingMarketSchema.optional(),
     global: pricingMarketSchema.optional(),
+  }).superRefine((value, ctx) => {
+    // Each market carries its own currency: cn → CNY, global → USD. The
+    // price filters compare raw amounts against currency-specific
+    // thresholds and trust this pairing, so enforce it at the data layer.
+    const requireCurrency = (
+      market: "cn" | "global",
+      slot: "new" | "used",
+      entry: { currency: string } | undefined,
+      currency: "CNY" | "USD",
+    ) => {
+      if (entry && entry.currency !== currency) {
+        ctx.addIssue({
+          code: "custom",
+          message: `pricing.${market}.${slot} must use ${currency}, got ${entry.currency}`,
+          path: [market, slot, "currency"],
+        });
+      }
+    };
+    requireCurrency("cn", "new", value.cn?.new, "CNY");
+    requireCurrency("cn", "used", value.cn?.used, "CNY");
+    requireCurrency("global", "new", value.global?.new, "USD");
+    requireCurrency("global", "used", value.global?.used, "USD");
   }).optional(),
   purchaseChannels: z.array(z.strictObject({
     channel: z.enum(['official', 'ebay', 'bhphoto']),

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -116,9 +116,19 @@ const lensBaseShape = {
     cn: pricingMarketSchema.optional(),
     global: pricingMarketSchema.optional(),
   }).superRefine((value, ctx) => {
-    // Each market carries its own currency: cn → CNY, global → USD. The
-    // price filters compare raw amounts against currency-specific
-    // thresholds and trust this pairing, so enforce it at the data layer.
+    // Market → currency pairing (cn → CNY, global → USD) is enforced here at
+    // the validation layer on purpose, rather than baked into the schema/type.
+    // The schema deliberately keeps `currency` as the open CNY | USD union for
+    // both markets so it stays flexible: if a locale ever legitimately carries
+    // a different currency, we relax this single guard and handle conversion at
+    // presentation time — no schema or type migration needed. For now, one
+    // currency per market is sufficient. Upstream, the pipeline scripts and the
+    // data-collection agent already follow this rule; this guard is the runtime
+    // backstop that fails loudly if a row ever slips through, since the price
+    // filters compare raw amounts against currency-specific thresholds and
+    // trust this pairing. A type-level constraint cannot replace it anyway:
+    // the data is JSON validated at runtime and TS types are erased, so
+    // external data needs a runtime check regardless.
     const requireCurrency = (
       market: "cn" | "global",
       slot: "new" | "used",


### PR DESCRIPTION
## What

Adds a `superRefine` to the lens `pricing` schema requiring `pricing.cn` entries to be **CNY** and `pricing.global` entries to be **USD**.

## Why

`currency` was only constrained to the set `{CNY, USD}` — nothing tied a market key to its currency, so `pricing.cn` in USD (or `pricing.global` in CNY) would pass validation. The `under-200` / `under-400` price filters read the raw `price` against currency-specific thresholds (`< 1000/2000` for cn, `< 200/400` for global) **without checking `currency`**, so a mismatched row would be silently misclassified. This enforces the market→currency pairing the filters already rely on.

## Verification

- `validate-lenses.mts` passes (X-mount).
- Direct scan of both `lenses.json` (169) and `lenses-gfx.json` (27): **0 violations** — existing data already satisfies the invariant, so the guard is non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)