### PR TITLE
feat(purchase): add Amazon affiliate channel with ASIN direct links

### DIFF
--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -149,8 +149,9 @@ const lensBaseShape = {
     requireCurrency("global", "used", value.global?.used, "USD");
   }).optional(),
   purchaseChannels: z.array(z.strictObject({
-    channel: z.enum(['official', 'ebay', 'bhphoto']),
+    channel: z.enum(['official', 'amazon', 'ebay', 'bhphoto']),
     url: nonEmptyStringSchema.optional(),
+    asin: nonEmptyStringSchema.optional(),
   })).min(1).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),

--- a/src/lib/purchase-channel-priority.ts
+++ b/src/lib/purchase-channel-priority.ts
@@ -1,0 +1,32 @@
+import type { PurchaseChannel } from "@/lib/types";
+
+type ChannelType = PurchaseChannel["channel"];
+
+const BRAND_PRIORITY: Record<string, ChannelType[]> = {
+  "7artisans": ["official", "amazon", "ebay", "bhphoto"],
+  brightinstar: ["official", "amazon", "ebay", "bhphoto"],
+  ttartisan: ["amazon", "official", "ebay", "bhphoto"],
+  viltrox: ["amazon", "official", "ebay", "bhphoto"],
+  laowa: ["amazon", "official", "ebay", "bhphoto"],
+  fujifilm: ["amazon", "ebay", "bhphoto"],
+  sigma: ["amazon", "ebay", "bhphoto"],
+  tamron: ["amazon", "ebay", "bhphoto"],
+  voigtlander: ["amazon", "ebay", "bhphoto"],
+  sgimage: ["amazon", "official", "ebay"],
+  meike: ["amazon", "official", "ebay"],
+  sirui: ["amazon", "official", "ebay"],
+};
+
+const DEFAULT_PRIORITY: ChannelType[] = ["amazon", "official", "ebay", "bhphoto"];
+
+export function sortPurchaseChannels(
+  channels: PurchaseChannel[],
+  brand: string,
+): PurchaseChannel[] {
+  const priority = BRAND_PRIORITY[brand.toLowerCase()] ?? DEFAULT_PRIORITY;
+  return [...channels].sort((a, b) => {
+    const ai = priority.indexOf(a.channel);
+    const bi = priority.indexOf(b.channel);
+    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+  });
+}

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -1,5 +1,7 @@
 import type { Lens } from "@/lib/types";
+import { sortPurchaseChannels } from "@/lib/purchase-channel-priority";
 
+const AMAZON_TAG = "xglass0a-20";
 const EPN_CAMPAIGN_ID = "5339154376";
 const EPN_TOOL_ID = "10001";
 
@@ -35,7 +37,7 @@ const EBAY_MARKETS: Record<string, EbayMarket> = {
 const EBAY_DEFAULT_MARKET = EBAY_MARKETS.US;
 
 export interface PurchaseLink {
-  channel: "official" | "ebay" | "bhphoto";
+  channel: "official" | "amazon" | "ebay" | "bhphoto";
   label: string;
   url: string;
   isAffiliate: boolean;
@@ -68,6 +70,10 @@ function buildEbayUrl(
     params.push(`customid=${encodeURIComponent(customId)}`);
   }
   return `${target}&${params.join("&")}`;
+}
+
+function buildAmazonUrl(asin: string): string {
+  return `https://www.amazon.com/dp/${asin}/?tag=${AMAZON_TAG}`;
 }
 
 function buildBhPhotoUrl(lens: Lens, locale: string): string {
@@ -108,9 +114,10 @@ export function buildPurchaseLinks(
     return [];
   }
 
+  const sorted = sortPurchaseChannels(lens.purchaseChannels, lens.brand);
   const links: PurchaseLink[] = [];
 
-  for (const ch of lens.purchaseChannels) {
+  for (const ch of sorted) {
     switch (ch.channel) {
       case "official":
         if (ch.url) {
@@ -120,6 +127,16 @@ export function buildPurchaseLinks(
             label: "Official",
             url: official.url,
             isAffiliate: official.isAffiliate,
+          });
+        }
+        break;
+      case "amazon":
+        if (ch.asin) {
+          links.push({
+            channel: "amazon",
+            label: "Amazon",
+            url: buildAmazonUrl(ch.asin),
+            isAffiliate: true,
           });
         }
         break;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -280,8 +280,9 @@ interface LensLocaleTranslations {
 }
 
 export interface PurchaseChannel {
-  channel: 'official' | 'ebay' | 'bhphoto';
+  channel: 'official' | 'amazon' | 'ebay' | 'bhphoto';
   url?: string;
+  asin?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `amazon` as a new purchase channel type with `asin` field
- Build Amazon affiliate URLs as ASIN direct links (`amazon.com/dp/{ASIN}/?tag=xglass0a-20`)
- Only render Amazon when ASIN data is available (no search link fallback)
- Introduce `purchase-channel-priority.ts`: per-brand channel ordering logic, decoupled from pipeline (which now emits an unordered availability set)
- Update Zod schema to accept the new channel type

## Architecture

Pipeline outputs available channels as an **unordered set** per lens. The frontend sorts them by brand-specific priority before rendering. This separation allows future GeoIP-based re-ranking without pipeline changes.

## Test plan

- [ ] Verify `npm run lint` passes
- [ ] Verify existing purchase links (Official, eBay, B&H) still render correctly
- [ ] After pipeline publish: verify Amazon links appear on lenses with ASINs
- [ ] Verify Amazon links open correct product pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)