### PR TITLE
feat(data): publish lens data 2026.05.30 build 1

### DIFF
--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -62,10 +62,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0BCR6YBJR"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -160,10 +164,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B071R2XGWW"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -253,10 +261,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08BQGD44P"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 58,
@@ -334,10 +346,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0CHG2XF1Z"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -450,10 +466,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B01MR6Z8Z2"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -543,10 +563,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -646,10 +666,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09DTJ9R5T"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -751,10 +775,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08412X7BV"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -844,10 +872,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0759FTQ4T"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -938,10 +970,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07TWYNDQ2"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1032,10 +1068,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0CHG23DJC"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1124,10 +1164,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B01MS8EWXM"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1216,10 +1260,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08TPBNCYM"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1317,10 +1365,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07MWBDQN3"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1412,10 +1464,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B071CKRCN6"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1509,10 +1565,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0CHG2TGTD"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1604,10 +1664,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B01MZARLEQ"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1696,10 +1760,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07C51T679"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1789,10 +1857,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0D3WJ7CKD"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -1889,6 +1961,9 @@
         "url": "https://www.venuslens.net/product/laowa-8-15mm-f-2-8-ff-zoom-fisheye-2/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1980,6 +2055,9 @@
         "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2065,6 +2143,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2155,6 +2236,9 @@
         "url": "https://www.venuslens.net/product/the-laowa-35mm-f-2-8-zero-d-tilt-shift-0-5x-macro/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2240,6 +2324,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/laowa-55mm-f-2-8-tilt-shift-1x-macro/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2329,6 +2416,9 @@
         "url": "https://www.venuslens.net/product/laowa-100mm-f-2-8-tilt-shift-1x-macro/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2411,6 +2501,9 @@
         "url": "https://www.venuslens.net/product/laowa-17mm-f-4-gfx-zero-d/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2483,6 +2576,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/laowa-19mm-f-2-8-zero-d/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"

--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -53,6 +53,9 @@
         "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -136,6 +139,13 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0G1LSZ9WL"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -230,6 +240,9 @@
         "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -319,6 +332,13 @@
         "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43"
       },
       {
+        "channel": "amazon",
+        "asin": "B0FPG43R7L"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -399,6 +419,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/10"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -485,6 +508,13 @@
         "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z"
       },
       {
+        "channel": "amazon",
+        "asin": "B0BGRFCXVF"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -569,6 +599,9 @@
         "url": "https://7artisans.store/products/10"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -649,6 +682,13 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B08LPP5GWD"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -737,6 +777,13 @@
     },
     "purchaseChannels": [
       {
+        "channel": "amazon",
+        "asin": "B07D9ZV3Z7"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -817,6 +864,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/25mm-f0-95"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -919,6 +969,9 @@
         "url": "https://7artisans.store/products/10"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1001,6 +1054,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/35mm-f1-2"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -1086,6 +1142,13 @@
         "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc"
       },
       {
+        "channel": "amazon",
+        "asin": "B099DN2CKF"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1167,6 +1230,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/10"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -1255,6 +1321,9 @@
         "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1334,6 +1403,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/50mm-f1-8"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -1417,6 +1489,9 @@
         "url": "https://7artisans.store/products/10"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1492,6 +1567,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/55mm-f1-4"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -1576,6 +1654,13 @@
         "url": "https://7artisans.store/products/60mm-f2-8"
       },
       {
+        "channel": "amazon",
+        "asin": "B09B9JWQ7N"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1657,6 +1742,9 @@
         "url": "https://7artisans.store/products/10"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1733,6 +1821,13 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0FSKDDLQ6"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -1825,6 +1920,9 @@
         "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1906,6 +2004,9 @@
         "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -1980,6 +2081,13 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/af-35mm-f1-4"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0F8V5LSGC"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2057,6 +2165,13 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0GGGSTXM3"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2140,6 +2255,13 @@
         "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
       },
       {
+        "channel": "amazon",
+        "asin": "B0GGG86QCP"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2220,6 +2342,9 @@
       {
         "channel": "official",
         "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2307,6 +2432,9 @@
         "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2385,6 +2513,13 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0C9Z95TK6"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2479,6 +2614,13 @@
         "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount"
       },
       {
+        "channel": "amazon",
+        "asin": "B0FJF8VRNJ"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2568,6 +2710,13 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B09PK1HVBP"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2660,6 +2809,9 @@
         "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2732,6 +2884,9 @@
         "url": "https://www.amazon.com/Brightin-Fujifilm-Aperture-Portrait-X-Pro1-3/dp/B07Z4B95KM"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -2794,6 +2949,9 @@
       }
     },
     "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
       {
         "channel": "bhphoto"
       }
@@ -2868,6 +3026,13 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0GTDX8VC2"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -2959,6 +3124,9 @@
         "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -3033,6 +3201,9 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -3115,6 +3286,9 @@
         "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -3185,6 +3359,9 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -3262,6 +3439,9 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -3348,6 +3528,9 @@
       {
         "channel": "official",
         "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -3448,6 +3631,9 @@
         "url": "https://www.amazon.com/Brightin-XF-Mount-Mirrorless-Fit/dp/B0D3KV8TLL"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -3530,10 +3716,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -3635,10 +3821,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -3755,10 +3941,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0FWV2C6TP"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -3863,10 +4053,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B079BRLDF7"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -3951,10 +4145,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -4047,10 +4241,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0153YQRU4"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -4128,10 +4326,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08412XPWK"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -4233,10 +4435,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B016YU67L0"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -4331,10 +4537,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00F9X8PF0"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -4420,10 +4630,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07FQ83W5W"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -4516,10 +4730,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0C5Q7YSDV"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -4619,10 +4837,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08L41GDC8"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 72,
@@ -4713,10 +4935,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00FPKDPF2"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -4795,10 +5021,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B009L1HC2I"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 58,
@@ -4881,10 +5111,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0D3WSY8W9"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -4986,10 +5220,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0DJQ1X149"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -5098,10 +5336,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00RSQTDMA"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 77,
@@ -5190,10 +5432,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07TWYSHYB"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -5284,10 +5530,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00W6VZLFA"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -5372,10 +5622,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07NQDKBDL"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -5487,10 +5741,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0092MD6S0"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 58,
@@ -5574,10 +5832,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0B2HWW749"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 72,
@@ -5671,10 +5933,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00KZHOYSW"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 67,
@@ -5742,10 +6008,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B006ZSNRWO"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 52,
@@ -5819,10 +6089,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0923F7V45"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -5907,10 +6181,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B01KNXOCO8"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6000,10 +6278,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09DTKDNMX"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 58,
@@ -6071,10 +6353,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -6149,10 +6431,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0FD1P65Z3"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6242,10 +6528,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08TP4QYT2"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 39,
@@ -6320,10 +6610,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -6403,10 +6693,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0BK2P7PNK"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 43,
@@ -6481,10 +6775,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09DTJQSCH"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 58,
@@ -6559,10 +6857,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B016S28I4S"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6653,10 +6955,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B006UL00R6"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6755,10 +7061,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00NGFLO74"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6853,10 +7163,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B01MS6WINK"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -6945,10 +7259,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08GX7RYD3"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 77,
@@ -7039,10 +7357,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00CNZTPGA"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 62,
@@ -7116,10 +7438,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00NF6ZGAA"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -7206,10 +7532,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0BCR4STVP"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -7298,10 +7628,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00HK8Z9AG"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -7383,10 +7717,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B006ZSNU4O"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 39,
@@ -7477,10 +7815,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B08TMZ59ZW"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 67,
@@ -7559,10 +7901,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0759GMLVP"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -7655,10 +8001,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B00XI4PAZ0"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 62,
@@ -7748,10 +8098,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07Z37HMXQ"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "filterMm": 77,
@@ -7839,10 +8193,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0B2J6YKSH"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -7938,10 +8296,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B07FQB2T4F"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -8034,10 +8396,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0DJQ1NB2H"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -8137,6 +8503,9 @@
         "url": "https://www.venuslens.net/product/laowa-4mm-f-2-8-mft/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -8223,6 +8592,9 @@
       }
     },
     "purchaseChannels": [
+      {
+        "channel": "ebay"
+      },
       {
         "channel": "bhphoto"
       }
@@ -8329,6 +8701,9 @@
         "url": "https://www.venuslens.net/product/laowa-8-16mm-f3-5-5-zoom-cf/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -8414,6 +8789,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/9mm/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -8505,6 +8883,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/laowa-10mm-f-4-cookie/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -8602,6 +8983,9 @@
         "url": "https://www.venuslens.net/product/laowa-12-24mm-f-5-6-zoom-shift-cf/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -8696,6 +9080,9 @@
         "url": "https://www.venuslens.net/product/laowa-65mm-f-2-8-2x-ultra-macro-apo/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -8778,6 +9165,9 @@
       {
         "channel": "official",
         "url": "https://www.venuslens.net/product/laowa-argus-25mm-f-0-95-apsc-apo/"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -8871,6 +9261,9 @@
         "url": "https://www.venuslens.net/product/laowa-argus-33mm-f-0-95-cf-apo/"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -8946,11 +9339,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/aps-c-25mm-f1-8-%E8%87%AA%E5%8A%A8%E5%AF%B9%E7%84%A6%E9%95%9C%E5%A4%B4"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9031,11 +9424,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/af-55mm-f1-8"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "lensMaterial": "Metal",
@@ -9111,11 +9504,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-7-5mm-f2-8-aps-c-fisheye-lens"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9202,11 +9595,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-12mm-f2-8-aps-c-ultra-wide-lens-copy"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "lensMaterial": "Metal",
@@ -9284,11 +9677,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9374,11 +9767,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-24mm-f6-3-full-frame-ultra-slim-pancake-lens"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9466,11 +9859,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens-copy"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9552,11 +9945,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-35mm-f1-2-aps-c-lens"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9638,11 +10031,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-35mm-f0-95-ultra-bright-aps-c-lens"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9723,11 +10116,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/mf-25mm-f2-8-aps-c-lens-copy"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9808,11 +10201,11 @@
     },
     "purchaseChannels": [
       {
-        "channel": "ebay"
-      },
-      {
         "channel": "official",
         "url": "https://www.sg-image.com/products/50mm-f1-8-mf-full-frame-lens-with-shaped-aperture"
+      },
+      {
+        "channel": "ebay"
       }
     ],
     "compatibleMounts": [
@@ -9910,10 +10303,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0FDH4RZN5"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10025,10 +10422,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0CJVRTY76"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10123,10 +10524,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0FMLCR1DR"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10226,10 +10631,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0GQJ9TLX2"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10349,10 +10758,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0DYNPG9NQ"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10454,10 +10867,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09T78KGRP"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10568,10 +10985,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0BMD377VK"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10664,10 +11085,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0C1VKPXP6"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10760,10 +11185,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09T6N7HRT"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10857,10 +11286,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09T78FM8M"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -10967,10 +11400,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0CH1JSJ6V"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11078,10 +11515,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0C6R7DH31"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11186,10 +11627,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0B3MNLZH3"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11299,10 +11744,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B09M5D2NJC"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11414,10 +11863,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "amazon",
+        "asin": "B0BJ4939R1"
       },
       {
         "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -11505,11 +11958,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-cine-lens"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11598,11 +12054,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/100mm-f2-8macro"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11685,11 +12144,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11775,11 +12237,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/af-17mm-f1-8-air"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11857,11 +12322,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0DSBKLVM4"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -11951,11 +12423,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/af27"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0BKJN5C79"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12036,11 +12515,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0F7HCHKLG"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12132,11 +12618,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/56mm"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0CYX5CN5T"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12228,11 +12721,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12323,11 +12819,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-7-5mm-f2"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0GTYF8QQB"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12415,11 +12918,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/102"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0CPSQS3XN"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12507,11 +13017,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B09ND1RSNN"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12597,11 +13114,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-25mm-f2"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0BCHX2G78"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12681,11 +13205,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-35mm-f1-4"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B08KGNXN1P"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12769,11 +13300,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-35mm-f0-95"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12861,11 +13395,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -12945,11 +13482,18 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B08QYVBLC3"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -13030,11 +13574,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/aps-c-50mm-f0-95"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -13117,11 +13664,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/tilt50mm"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -13207,11 +13757,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/tilt-35mm-f1-4"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -13301,11 +13854,14 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
-      },
-      {
         "channel": "official",
         "url": "https://ttartisan.store/products/ts100"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
+        "channel": "bhphoto"
       }
     ],
     "compatibleMounts": [
@@ -13409,6 +13965,13 @@
         "url": "https://viltrox.com/products/af-9mm-f2-8-xf"
       },
       {
+        "channel": "amazon",
+        "asin": "B0FXMKDKLT"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -13485,6 +14048,13 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B09TF3BDNN"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -13590,6 +14160,13 @@
         "url": "https://viltrox.com/products/af-15mm-f1-7-xf"
       },
       {
+        "channel": "amazon",
+        "asin": "B0FFMF6MRV"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -13670,6 +14247,9 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -13771,6 +14351,13 @@
         "url": "https://viltrox.com/products/af-25mm-f1-7-x"
       },
       {
+        "channel": "amazon",
+        "asin": "B0DS58QJPD"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -13849,6 +14436,13 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0CFLCGSWH"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -13934,6 +14528,13 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/af-28mm-f4-5-x"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0DSVL8Q9V"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -14025,6 +14626,9 @@
         "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -14108,6 +14712,13 @@
         "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount"
       },
       {
+        "channel": "amazon",
+        "asin": "B0DP6YY71M"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -14183,6 +14794,13 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/af-56mm-f1-2-xf"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0FLY6529Q"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -14272,6 +14890,9 @@
         "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens"
       },
       {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -14356,6 +14977,13 @@
         "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z"
       },
       {
+        "channel": "amazon",
+        "asin": "B0CZKWLBV7"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -14431,6 +15059,13 @@
       {
         "channel": "official",
         "url": "https://viltrox.com/products/75mm-f12-xf-lens"
+      },
+      {
+        "channel": "amazon",
+        "asin": "B0BQXPK27P"
+      },
+      {
+        "channel": "ebay"
       },
       {
         "channel": "bhphoto"
@@ -14521,6 +15156,13 @@
         "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount"
       },
       {
+        "channel": "amazon",
+        "asin": "B07Q4VS1XM"
+      },
+      {
+        "channel": "ebay"
+      },
+      {
         "channel": "bhphoto"
       }
     ],
@@ -14602,10 +15244,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -14694,10 +15336,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -14783,10 +15425,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -14875,10 +15517,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -14967,10 +15609,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -15060,10 +15702,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [
@@ -15146,10 +15788,10 @@
     },
     "purchaseChannels": [
       {
-        "channel": "bhphoto"
+        "channel": "ebay"
       },
       {
-        "channel": "ebay"
+        "channel": "bhphoto"
       }
     ],
     "accessories": [

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.25",
-  "lastUpdated": "2026-05-25T05:58:39.773Z",
+  "version": "2026.05.30",
+  "lastUpdated": "2026-05-30T04:14:17.692Z",
   "lensCount": 196,
   "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `x-glass-pipeline`.

- **Version**: `2026.05.30` build 1
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`