### PR TITLE
refactor(pricing): multi-source pricing arrays + derive purchase links

### DIFF
--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -59,7 +59,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BCR6YBJR",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -161,7 +161,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B071R2XGWW",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -258,7 +258,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08BQGD44P",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -343,7 +343,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CHG2XF1Z",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -463,7 +463,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B01MR6Z8Z2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -658,7 +658,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09DTJ9R5T",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -767,7 +767,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08412X7BV",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -864,7 +864,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0759FTQ4T",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -959,7 +959,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07TWYNDQ2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1057,7 +1057,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CHG23DJC",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1153,7 +1153,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B01MS8EWXM",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1249,7 +1249,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08TPBNCYM",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1354,7 +1354,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07MWBDQN3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1453,7 +1453,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B071CKRCN6",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1554,7 +1554,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CHG2TGTD",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1653,7 +1653,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B01MZARLEQ",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1749,7 +1749,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07C51T679",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1846,7 +1846,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0D3WJ7CKD",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -1954,7 +1954,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-8-15mm-f-2-8-ff-zoom-fisheye-2/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2049,7 +2049,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2134,7 +2134,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2220,7 +2220,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/the-laowa-35mm-f-2-8-zero-d-tilt-shift-0-5x-macro/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2305,7 +2305,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-55mm-f-2-8-tilt-shift-1x-macro/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2390,7 +2390,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-100mm-f-2-8-tilt-shift-1x-macro/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2470,7 +2470,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-17mm-f-4-gfx-zero-d/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -2542,7 +2542,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-19mm-f-2-8-zero-d/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]

--- a/src/data/lenses-gfx.json
+++ b/src/data/lenses-gfx.json
@@ -44,30 +44,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 16700,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 16700,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10060492752899.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2399.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BCR6YBJR",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2399.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf20-35mmf4-r-wr-lens-600023098/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-82",
       "Rear lens cap RLCP-002",
@@ -142,30 +146,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 17450,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 17450,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34145961465.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B071R2XGWW",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf23mmf4-gf23mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -235,30 +243,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 11890,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 11890,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10020018785513.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08BQGD44P",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf30mmf3-5-r-wr-lens-600021771/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -316,30 +328,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 28900,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 28900,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10085916730903.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 4499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CHG2XF1Z",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 4499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf30mmf5-6-t-s-lens-600023617/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-77",
       "Rear lens cap RLCP-002",
@@ -432,30 +448,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 15500,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 15500,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34146337216.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2099.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B01MR6Z8Z2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2099.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf32-64mmf4-gf32-64mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -533,22 +553,17 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 36500,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 36500,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10106601817304.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap",
       "Rear lens cap",
@@ -628,30 +643,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6490,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 6490,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10045648996176.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1149.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09DTJ9R5T",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1149.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf35-70mmf4-5-5-6-gf35-70mmf4-5-5-6/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-62 II",
       "Lens rear cap RLCP-002",
@@ -733,30 +752,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 15900,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 15900,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/65684722559.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2099.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08412X7BV",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2099.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf45-100mmf4-gf45-100mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -826,30 +849,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 11350,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 11350,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34146648738.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0759FTQ4T",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf45mmf2-8-gf45mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -928,22 +955,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 1149.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07TWYNDQ2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1149.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf50mmf3-5-gf50mmf3-5/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-62II",
       "Rear lens cap RLCP-002",
@@ -1014,30 +1042,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 16500,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 16500,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10085923350658.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2099.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CHG23DJC",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2099.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf55mmf1-7-r-wr-lens-600023613/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-77",
       "Rear lens cap RLCP-002",
@@ -1106,30 +1138,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 10350,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 10350,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34147237153.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B01MS8EWXM",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf63mmf2-8-gf63mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -1198,30 +1234,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 16900,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 16900,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10026516023777.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2099.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08TPBNCYM",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2099.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf80mmf1-7-gf80mmf1-7/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -1299,30 +1339,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 14350,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 14350,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/41597564004.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1799.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07MWBDQN3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1799.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf100-200mmf5-6-gf100-200mmf5-6/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-67II",
       "Lens rear cap RLCP-002",
@@ -1394,30 +1438,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 19000,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 19000,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34147658802.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3199.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B071CKRCN6",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3199.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf110mmf2-gf110mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-77",
       "Lens rear cap RLCP-002",
@@ -1491,30 +1539,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 24900,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 24900,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10085924078736.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CHG2TGTD",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf110mmf5-6ts-gf110mmf5-6ts/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-72 II",
       "Rear lens cap RLCP-002",
@@ -1586,30 +1638,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 18250,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 18250,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/34147891035.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3099.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B01MZARLEQ",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3099.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf120mmf4-gf120mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-72II",
       "Rear lens cap RLCP-002",
@@ -1678,30 +1734,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 21350,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 21350,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/39645909466.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3799.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07C51T679",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3799.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf250mmf4-gf250mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-82",
       "Lens rear cap RLCP-002",
@@ -1771,30 +1831,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 25500,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 25500,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10106604346465.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0D3WJ7CKD",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/gf500mmf5-6-r-lm-ois-wr-600023753/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-95",
       "Rear lens cap RLCP-002",
@@ -1874,24 +1938,28 @@
       "zh": "老蛙 8-15mm f2.8 Fisheye Zoom GFX"
     },
     "pricing": {
+      "cn": {
+        "new": [
+          {
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=935545508705",
+            "sampledAt": "2026-05-18"
+          }
+        ]
+      },
       "global": {
-        "new": {
-          "price": 699,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 699,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-8-15mm-f-2-8-ff-zoom-fisheye-2/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-8-15mm-f-2-8-ff-zoom-fisheye-2/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1965,24 +2033,28 @@
       "zh": "老蛙 17mm f4 GFX"
     },
     "pricing": {
+      "cn": {
+        "new": [
+          {
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=995024947971",
+            "sampledAt": "2026-05-18"
+          }
+        ]
+      },
       "global": {
-        "new": {
-          "price": 999,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2045,31 +2117,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 8469,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 8469,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=995024947971",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1249,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1249,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-zero-d-tilt-shift-shift/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2133,31 +2203,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 8469,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 8469,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=995615398774",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1249,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1249,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/the-laowa-35mm-f-2-8-zero-d-tilt-shift-0-5x-macro/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/the-laowa-35mm-f-2-8-zero-d-tilt-shift-0-5x-macro/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2220,31 +2288,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 8469,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 8469,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=842461490021",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1249,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1249,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-55mm-f-2-8-tilt-shift-1x-macro/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-55mm-f-2-8-tilt-shift-1x-macro/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2307,31 +2373,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 8469,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 8469,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=842461490021",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1249,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1249,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-100mm-f-2-8-tilt-shift-1x-macro/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-100mm-f-2-8-tilt-shift-1x-macro/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2389,31 +2453,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 7950,
-          "currency": "CNY",
-          "source": "京东·老蛙官方旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 7950,
+            "currency": "CNY",
+            "source": "京东·老蛙官方旗舰店",
+            "url": "https://item.jd.com/10062842206174.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 999,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-17mm-f-4-gfx-zero-d/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-17mm-f-4-gfx-zero-d/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "filterMm": 86,
     "lensConfiguration": {
       "groups": 14,
@@ -2463,31 +2525,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6950,
-          "currency": "CNY",
-          "source": "京东·老蛙官方旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 6950,
+            "currency": "CNY",
+            "source": "京东·老蛙官方旗舰店",
+            "url": "https://item.jd.com/10066947084689.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 999,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-19mm-f-2-8-zero-d/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-19mm-f-2-8-zero-d/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm G",
       "Hasselblad XCD"

--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -48,7 +48,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -131,13 +131,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0G1LSZ9WL",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -227,7 +227,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -314,13 +314,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FPG43R7L",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -400,7 +400,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -482,13 +482,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BGRFCXVF",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -570,7 +570,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -650,13 +650,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08LPP5GWD",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -742,7 +742,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07D9ZV3Z7",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ],
@@ -828,7 +828,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/25mm-f0-95",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -926,7 +926,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1008,7 +1008,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/35mm-f1-2",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1089,13 +1089,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B099DN2CKF",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -1176,7 +1176,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1260,7 +1260,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1339,7 +1339,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/50mm-f1-8",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1418,7 +1418,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1493,7 +1493,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/55mm-f1-4",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1573,13 +1573,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/60mm-f2-8",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09B9JWQ7N",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -1658,7 +1658,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/10",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1734,13 +1734,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FSKDDLQ6",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -1828,7 +1828,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1907,7 +1907,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -1981,13 +1981,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-35mm-f1-4",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0F8V5LSGC",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2062,13 +2062,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0GGGSTXM3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2147,13 +2147,13 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0GGG86QCP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2233,7 +2233,7 @@
             "currency": "USD",
             "source": "7artisans.store",
             "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -2316,7 +2316,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -2394,13 +2394,13 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0C9Z95TK6",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2490,13 +2490,13 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FJF8VRNJ",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2585,13 +2585,13 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09PK1HVBP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2679,7 +2679,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -2746,7 +2746,7 @@
             "currency": "USD",
             "source": "Amazon · Brightin Star Official Store",
             "url": "https://www.amazon.com/Brightin-Fujifilm-Aperture-Portrait-X-Pro1-3/dp/B07Z4B95KM",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-10"
           }
         ]
@@ -2880,13 +2880,13 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0GTDX8VC2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -2973,7 +2973,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3047,7 +3047,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3125,7 +3125,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3195,7 +3195,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3270,7 +3270,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3354,7 +3354,7 @@
             "currency": "USD",
             "source": "brightinstar.com",
             "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -3450,7 +3450,7 @@
             "currency": "USD",
             "source": "Amazon · Brightin Star Official Store",
             "url": "https://www.amazon.com/Brightin-XF-Mount-Mirrorless-Fit/dp/B0D3KV8TLL",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-10"
           }
         ]
@@ -3747,7 +3747,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FWV2C6TP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -3856,7 +3856,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B079BRLDF7",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4033,7 +4033,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0153YQRU4",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ],
@@ -4114,7 +4114,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08412XPWK",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4220,7 +4220,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B016YU67L0",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4319,7 +4319,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00F9X8PF0",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ],
@@ -4411,7 +4411,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07FQ83W5W",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4511,7 +4511,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0C5Q7YSDV",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4618,7 +4618,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08L41GDC8",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4713,7 +4713,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00FPKDPF2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ],
@@ -4795,7 +4795,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B009L1HC2I",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4885,7 +4885,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0D3WSY8W9",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -4991,7 +4991,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DJQ1X149",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5104,7 +5104,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00RSQTDMA",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5197,7 +5197,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07TWYSHYB",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5295,7 +5295,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00W6VZLFA",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5387,7 +5387,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07NQDKBDL",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5503,7 +5503,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0092MD6S0",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5594,7 +5594,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0B2HWW749",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5692,7 +5692,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00KZHOYSW",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5764,7 +5764,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B006ZSNRWO",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5845,7 +5845,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0923F7V45",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -5934,7 +5934,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B01KNXOCO8",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6031,7 +6031,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09DTKDNMX",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6179,7 +6179,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FD1P65Z3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6276,7 +6276,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08TP4QYT2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6433,7 +6433,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BK2P7PNK",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6515,7 +6515,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09DTJQSCH",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6597,7 +6597,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B016S28I4S",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6695,7 +6695,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B006UL00R6",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6801,7 +6801,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00NGFLO74",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6903,7 +6903,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B01MS6WINK",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -6999,7 +6999,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08GX7RYD3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7097,7 +7097,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00CNZTPGA",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7175,7 +7175,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00NF6ZGAA",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7269,7 +7269,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BCR4STVP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7362,7 +7362,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00HK8Z9AG",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7451,7 +7451,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B006ZSNU4O",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7549,7 +7549,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08TMZ59ZW",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7635,7 +7635,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0759GMLVP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7735,7 +7735,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B00XI4PAZ0",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7832,7 +7832,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07Z37HMXQ",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -7927,7 +7927,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0B2J6YKSH",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -8030,7 +8030,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07FQB2T4F",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -8130,7 +8130,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DJQ1NB2H",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -8235,7 +8235,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-4mm-f-2-8-mft/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -8423,7 +8423,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-8-16mm-f3-5-5-zoom-cf/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -8502,7 +8502,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/9mm/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ],
@@ -8591,7 +8591,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-10mm-f-4-cookie/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ],
@@ -8690,7 +8690,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-12-24mm-f-5-6-zoom-shift-cf/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -8776,7 +8776,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-65mm-f-2-8-2x-ultra-macro-apo/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ],
@@ -8864,7 +8864,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-argus-25mm-f-0-95-apsc-apo/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ]
@@ -8947,7 +8947,7 @@
             "currency": "USD",
             "source": "venuslens.net",
             "url": "https://www.venuslens.net/product/laowa-argus-33mm-f-0-95-cf-apo/",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-18"
           }
         ],
@@ -9030,7 +9030,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/aps-c-25mm-f1-8-%E8%87%AA%E5%8A%A8%E5%AF%B9%E7%84%A6%E9%95%9C%E5%A4%B4",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9113,7 +9113,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/af-55mm-f1-8",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9191,7 +9191,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-7-5mm-f2-8-aps-c-fisheye-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9280,7 +9280,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-12mm-f2-8-aps-c-ultra-wide-lens-copy",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9360,7 +9360,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9448,7 +9448,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-24mm-f6-3-full-frame-ultra-slim-pancake-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9538,7 +9538,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens-copy",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9622,7 +9622,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-35mm-f1-2-aps-c-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9706,7 +9706,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-35mm-f0-95-ultra-bright-aps-c-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9789,7 +9789,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/mf-25mm-f2-8-aps-c-lens-copy",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9872,7 +9872,7 @@
             "currency": "USD",
             "source": "sg-image.com",
             "url": "https://www.sg-image.com/products/50mm-f1-8-mf-full-frame-lens-with-shaped-aperture",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -9970,7 +9970,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FDH4RZN5",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10089,7 +10089,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CJVRTY76",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10191,7 +10191,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FMLCR1DR",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10298,7 +10298,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0GQJ9TLX2",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10425,7 +10425,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DYNPG9NQ",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10534,7 +10534,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09T78KGRP",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10652,7 +10652,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BMD377VK",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10752,7 +10752,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0C1VKPXP6",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10852,7 +10852,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09T6N7HRT",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -10953,7 +10953,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09T78FM8M",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11067,7 +11067,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CH1JSJ6V",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11182,7 +11182,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0C6R7DH31",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11294,7 +11294,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0B3MNLZH3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11411,7 +11411,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09M5D2NJC",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11530,7 +11530,7 @@
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BJ4939R1",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           },
           {
@@ -11627,7 +11627,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-cine-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -11718,7 +11718,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/100mm-f2-8macro",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -11803,7 +11803,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -11891,7 +11891,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/af-17mm-f1-8-air",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -11971,13 +11971,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DSBKLVM4",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12069,13 +12069,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/af27",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BKJN5C79",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12158,13 +12158,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0F7HCHKLG",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12258,13 +12258,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/56mm",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CYX5CN5T",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12358,7 +12358,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -12451,13 +12451,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-7-5mm-f2",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0GTYF8QQB",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12547,13 +12547,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/102",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CPSQS3XN",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12643,13 +12643,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09ND1RSNN",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12737,13 +12737,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-25mm-f2",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BCHX2G78",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12825,13 +12825,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-35mm-f1-4",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08KGNXN1P",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -12917,7 +12917,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-35mm-f0-95",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13007,7 +13007,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13089,13 +13089,13 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B08QYVBLC3",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -13178,7 +13178,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/aps-c-50mm-f0-95",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13263,7 +13263,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/tilt50mm",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13351,7 +13351,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/tilt-35mm-f1-4",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13440,7 +13440,7 @@
             "currency": "USD",
             "source": "ttartisan.store",
             "url": "https://ttartisan.store/products/ts100",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13542,13 +13542,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/af-9mm-f2-8-xf",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FXMKDKLT",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -13624,13 +13624,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B09TF3BDNN",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -13731,13 +13731,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/af-15mm-f1-7-xf",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FFMF6MRV",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -13817,7 +13817,7 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -13914,13 +13914,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/af-25mm-f1-7-x",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DS58QJPD",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -13998,13 +13998,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CFLCGSWH",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14087,13 +14087,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/af-28mm-f4-5-x",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DSVL8Q9V",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14180,7 +14180,7 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -14261,13 +14261,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0DP6YY71M",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14342,13 +14342,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/af-56mm-f1-2-xf",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0FLY6529Q",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14433,7 +14433,7 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           }
         ]
@@ -14515,13 +14515,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0CZKWLBV7",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14596,13 +14596,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/75mm-f12-xf-lens",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B0BQXPK27P",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]
@@ -14688,13 +14688,13 @@
             "currency": "USD",
             "source": "viltrox.com",
             "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount",
-            "channel": "official",
+            "purchasableChannel": "official",
             "sampledAt": "2026-05-09"
           },
           {
             "source": "Amazon",
             "url": "https://www.amazon.com/dp/B07Q4VS1XM",
-            "channel": "amazon",
+            "purchasableChannel": "amazon",
             "sampledAt": "2026-05-30"
           }
         ]

--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -31,31 +31,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 670,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 670,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10062473752141.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 149,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 149,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/4mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -116,31 +114,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1090,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1090,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10204898752312.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0G1LSZ9WL",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/mf-6mm-f-2-0-aps-c-lens-for-sony-e-fuji-x-eos-r-nikon-z-panasonic-olympus-m43"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -208,31 +210,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 639,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 639,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10027028201649.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 139,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 139,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/7-5mm-f2-8-mk-ii"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -297,31 +297,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 499,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 499,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10160933790025.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 99,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 99,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FPG43R7L",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10mm-f-3-5-aps-c-lens-for-sony-e-fuji-x-nikon-z-panasonic-olympus-m43"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -379,31 +383,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1896,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1896,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589262308.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -463,31 +465,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 593,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 593,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10164361585110.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 149,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 149,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BGRFCXVF",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/12mm-f-2-8-aps-c-lens-for-e-eos-m-fx-m43-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -547,31 +553,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1596,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1596,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589262309.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -629,31 +633,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 270,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 270,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10068170968055.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 59,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 59,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08LPP5GWD",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/18mm-f-6-3-mark-ii-aps-c-lens-for-sony-e-fujifilm-x-nikon-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -719,14 +727,25 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 394,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 394,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/22071562982.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07D9ZV3Z7",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ],
         "used": {
           "price": 53,
           "currency": "USD",
@@ -735,11 +754,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -797,31 +811,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1299,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1299,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10038643493366.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 179,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 179,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/25mm-f0-95",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/25mm-f0-95"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -897,31 +909,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1496,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1496,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589262310.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -981,31 +991,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 369,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 369,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10023827550733.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 119,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 119,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/35mm-f1-2",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/35mm-f1-2"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -1064,31 +1072,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 329,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 329,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10200036685867.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 69,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 69,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B099DN2CKF",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/7artisans-35mm-f1-4-apsc"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1147,31 +1159,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1496,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1496,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589310711.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1233,31 +1243,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 969,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 969,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10160356865706.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 226,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 226,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/50mm-f1-4-aps-c-tilt-lens-for-e-fx-m43"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1314,31 +1322,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 299,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 299,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/23196870151.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 66,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 66,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/50mm-f1-8",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/50mm-f1-8"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1395,31 +1401,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1496,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1496,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589310712.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1472,31 +1476,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 494,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 494,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/23702204564.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 76,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 76,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/55mm-f1-4",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/55mm-f1-4"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1554,31 +1556,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 899,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 899,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10034452578266.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 159,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 159,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/60mm-f2-8",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09B9JWQ7N",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/60mm-f2-8"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1635,31 +1641,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1496,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1496,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10106589310713.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 489,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 489,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/10",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/10"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1713,31 +1717,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 939,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 939,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10187125174593.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FSKDDLQ6",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-10mm-f2-8-aps-c-lens-for-e-fx-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -1803,31 +1811,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 599,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 599,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10212588856782.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 125,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 125,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -1884,31 +1890,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 419,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 419,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10109385145704.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 103,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 103,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-27mm-f2-8-aps-c-lens-for-fx"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Aluminum alloy",
     "filterMm": 39,
     "lensConfiguration": {
@@ -1960,31 +1964,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 699,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 699,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10144266042361.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 169,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 169,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-35mm-f1-4",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0F8V5LSGC",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-35mm-f1-4"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Metal+polymer plastic",
     "filterMm": 62,
     "lensConfiguration": {
@@ -2037,31 +2045,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 599,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 599,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10212592143407.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 125,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 125,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0GGGSTXM3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -2118,31 +2130,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 599,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 599,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10213996269124.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 125,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 125,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0GGG86QCP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/af-25-35-50mm-f1-8-aps-c-lens-for-e-fx-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z"
@@ -2200,31 +2216,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1399,
-          "currency": "CNY",
-          "source": "京东·七工匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1399,
+            "currency": "CNY",
+            "source": "京东·七工匠官方旗舰店",
+            "url": "https://item.jd.com/10066663391778.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 319,
-          "currency": "USD",
-          "source": "7artisans.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 319,
+            "currency": "USD",
+            "source": "7artisans.store",
+            "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://7artisans.store/products/12mm-t2-9-aps-c-mf-cine-lens-for-fujifilm-x-sony-e-m43-canon-rf-nikon-z-sigma-l-panasonic-l-leica-l-cl-tl"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -2285,31 +2299,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 899,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 899,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10109759393601.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 190,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 190,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/af50mm-f1-4-aps-c-autofocus-lens-large-aperture-portrait-fixed-focus-lens-suitable-fit-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -2365,31 +2377,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 539,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 539,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/42197028359.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 140,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 140,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0C9Z95TK6",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/7-5mm-f2-8-aps-c-fisheye-manual-focus-lens-with-nd-filter-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2457,31 +2473,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 529,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 529,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10206375369431.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 120,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 120,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FJF8VRNJ",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/10mm-f5-6-pro-aps-c-fisheye-lens-wide-angle-lens-for-fujifilm-xf-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -2548,31 +2568,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 259,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 259,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10039170180560.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 66,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 66,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09PK1HVBP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/10mm-f5-6-aps-c-fisheye-lens-wide-angle-lens-pancake-lens-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -2638,31 +2662,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 799,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 799,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10100484539176.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 166,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 166,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/12mm-f2-0-iii-aps-c-ultra-wide-angle-big-aperture-cameras-lens-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 9,
@@ -2718,23 +2740,18 @@
         }
       },
       "global": {
-        "new": {
-          "price": 65.99,
-          "currency": "USD",
-          "source": "Amazon · Brightin Star Official Store",
-          "sampledAt": "2026-05-10"
-        }
+        "new": [
+          {
+            "price": 65.99,
+            "currency": "USD",
+            "source": "Amazon · Brightin Star Official Store",
+            "url": "https://www.amazon.com/Brightin-Fujifilm-Aperture-Portrait-X-Pro1-3/dp/B07Z4B95KM",
+            "channel": "amazon",
+            "sampledAt": "2026-05-10"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.amazon.com/Brightin-Fujifilm-Aperture-Portrait-X-Pro1-3/dp/B07Z4B95KM"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon EF-M",
@@ -2785,19 +2802,17 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 399,
-          "currency": "CNY",
-          "source": "天猫·brightinstar旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 399,
+            "currency": "CNY",
+            "source": "天猫·brightinstar旗舰店",
+            "url": "https://brightinstar.tmall.com/search.htm?q=35mm+F1.2",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": 43,
     "lensConfiguration": {
@@ -2848,31 +2863,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 639,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 639,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10207438401683.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 190,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 190,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0GTDX8VC2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/brightin-star-35mm-f1-4-full-frame-large-aperture-manual-focus-lens-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -2937,31 +2956,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 379,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 379,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/35521215376.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 70,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 70,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/35mm-f1-7-aps-c-wide-angle-manual-focus-prime-lens-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": 43,
     "lensConfiguration": {
@@ -3013,31 +3030,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 999,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10161505403978.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 200,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 200,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/35mm-f0-95-aps-c-luminous-version-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -3093,31 +3108,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 509,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 509,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10136248141644.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 100,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 100,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f1-4-iii-aps-c-manual-focus-portrait-lens-for-fujifilm-x"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "filterMm": 55,
     "lensConfiguration": {
       "groups": 5,
@@ -3165,31 +3178,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 299,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 299,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10081229168136.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 70,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 70,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f1-8-aps-c-manual-focus-lens-fit-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -3242,31 +3253,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 999,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10120084186243.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 200,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 200,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/50mm-f0-95-aps-c-night-god-portrait-star-manual-fixed-focus-lens-suitable-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -3328,31 +3337,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 939,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 939,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10210192269620.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 230,
-          "currency": "USD",
-          "source": "brightinstar.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 230,
+            "currency": "USD",
+            "source": "brightinstar.com",
+            "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://brightinstar.com/products/brightin-star-60mm-f2-8-2x-macro-aps-c-manual-focus-prime-lens-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -3426,31 +3433,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 999,
-          "currency": "CNY",
-          "source": "京东·星曜光学官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 999,
+            "currency": "CNY",
+            "source": "京东·星曜光学官方旗舰店",
+            "url": "https://item.jd.com/10210192269614.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 229.99,
-          "currency": "USD",
-          "source": "Amazon · Brightin Star Official Store",
-          "sampledAt": "2026-05-10"
-        }
+        "new": [
+          {
+            "price": 229.99,
+            "currency": "USD",
+            "source": "Amazon · Brightin Star Official Store",
+            "url": "https://www.amazon.com/Brightin-XF-Mount-Mirrorless-Fit/dp/B0D3KV8TLL",
+            "channel": "amazon",
+            "sampledAt": "2026-05-10"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.amazon.com/Brightin-XF-Mount-Mirrorless-Fit/dp/B0D3KV8TLL"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon EF-M",
@@ -3520,22 +3525,17 @@
     },
     "pricing": {
       "global": {
-        "new": {
-          "price": 4499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 4499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/mkx18-55mmt2-9-mkx18-55mmt2-9/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Tripod collar foot",
       "Support foot",
@@ -3625,22 +3625,17 @@
     },
     "pricing": {
       "global": {
-        "new": {
-          "price": 4999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 4999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/mkx50-135mmt2-9-mkx50-135mmt2-9/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Tripod collar foot",
       "Support foot",
@@ -3737,30 +3732,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2550,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2550,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/100239539021.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 399.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FWV2C6TP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 399.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xc13-33mmf3-5-6-3-ois-lens-16960719/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-49",
       "Rear lens cap"
@@ -3853,22 +3852,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 349.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B079BRLDF7",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 349.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xc15-45mmf3-5-5-6-xc15-45mmf3-5-5-6/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-52II",
       "Lens rear cap"
@@ -3949,14 +3949,6 @@
       "en": "Fujifilm XC 16-50mm OIS II",
       "zh": "富士 XC 16-50mm OIS II"
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -4037,6 +4029,14 @@
         }
       },
       "global": {
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0153YQRU4",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ],
         "used": {
           "price": 175,
           "currency": "USD",
@@ -4045,14 +4045,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -4118,22 +4110,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 239.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08412XPWK",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 239.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xc35mmf2-xc35mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-43"
     ],
@@ -4223,22 +4216,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 449.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B016YU67L0",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 449.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xc50-230mmf4-5-6-7-xc50-230mmf4-5-6-7/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Lens hood"
@@ -4321,6 +4315,14 @@
     },
     "pricing": {
       "global": {
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00F9X8PF0",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ],
         "used": {
           "price": 279.99,
           "currency": "USD",
@@ -4329,14 +4331,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -4402,30 +4396,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 9990,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 9990,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/37862049857.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1799.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07FQ83W5W",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1799.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf8-16mmf2-8-xf8-16mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-8-16",
       "Lens rear cap RLCP-001",
@@ -4498,30 +4496,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5490,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5490,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10076684016873.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0C5Q7YSDV",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf8mmf3-5-xf8mmf3-5/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-62 II",
       "Rear lens cap RLCP-001",
@@ -4601,30 +4603,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6990,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 6990,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10025233765523.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1049.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08L41GDC8",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1049.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf10-24mmf4-ii-xf10-24mmf4-ii/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 72,
     "lensConfiguration": {
       "groups": 10,
@@ -4703,6 +4709,14 @@
         }
       },
       "global": {
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00FPKDPF2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ],
         "used": {
           "price": 400,
           "currency": "USD",
@@ -4711,14 +4725,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -4785,22 +4791,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 899.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B009L1HC2I",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 899.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf14mmf2-8-xf14mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 7,
@@ -4863,30 +4870,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4990,
-          "currency": "CNY",
-          "source": "天猫·富士官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4990,
+            "currency": "CNY",
+            "source": "天猫·富士官方旗舰店",
+            "url": "https://fujifilm.tmall.com/category-1106901591.htm",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 849.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0D3WSY8W9",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 849.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16-50mmf2-8-4-8-r-lm-wr-16814817/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-58 II",
       "Rear lens cap RLCP-001",
@@ -4976,22 +4987,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 1399.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DJQ1X149",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1399.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16-55mmf2-8-r-lm-wr-ii-lens-16836580/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-72 II",
       "Rear lens cap RLCP-001",
@@ -5088,22 +5100,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00RSQTDMA",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16-55mmf2-8-xf16-55mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 12,
@@ -5180,22 +5193,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07TWYSHYB",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16-80mmf4-xf16-80mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-72II",
       "Rear lens cap RLCP-001",
@@ -5266,30 +5280,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6620,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 6620,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33779863063.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1049.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00W6VZLFA",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1049.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16mmf1-4-xf16mmf1-4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens hood LH-XF16"
     ],
@@ -5354,30 +5372,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2680,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2680,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/41634837954.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 449.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07NQDKBDL",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 449.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf16mmf2-8-xf16mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-49",
       "Lens rear cap RLCP-001",
@@ -5477,22 +5499,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0092MD6S0",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf18-55mmf2-8-4-xf18-55mmf2-8-4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -5556,30 +5579,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5990,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5990,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10060482260075.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0B2HWW749",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf18-120mmf4-xf18-120mmf4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 72,
     "lensConfiguration": {
       "groups": 12,
@@ -5661,22 +5688,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00KZHOYSW",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf18-135mmf3-5-5-6-xf18-135mmf3-5-5-6/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 67,
     "lensConfiguration": {
       "groups": 12,
@@ -5732,22 +5760,23 @@
     },
     "pricing": {
       "global": {
-        "new": {
-          "price": 699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B006ZSNRWO",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf18mmf2-xf18mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 52,
     "lensConfiguration": {
       "groups": 7,
@@ -5801,30 +5830,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6490,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 6490,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10031234224839.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1199.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0923F7V45",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1199.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf18mmf1-4-xf18mmf1-4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens hood LH-XF18"
     ],
@@ -5897,22 +5930,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B01KNXOCO8",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf23mmf2-xf23mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-43",
       "Lens rear cap RLCP-001",
@@ -5982,30 +6016,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5840,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5840,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10045634723640.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1049.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09DTKDNMX",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1049.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf23mmf1-4-r-lm-wr-xf23mmf1-4-r-lm-wr/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -6061,22 +6099,17 @@
     },
     "pricing": {
       "global": {
-        "new": {
-          "price": 899.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 899.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf23mmf1-4-r-lens-16405575/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -6131,30 +6164,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2890,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2890,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10199711725340.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FD1P65Z3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf23mmf2-8-xf23mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-39 II",
       "Rear lens cap RLCP-001",
@@ -6224,30 +6261,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2690,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2690,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10026515405137.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 449.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08TP4QYT2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 449.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf27mmf2-8-r-wr-xf27mmf2-8-r-wr/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 39,
     "lensConfiguration": {
       "groups": 5,
@@ -6318,14 +6359,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -6385,30 +6418,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4190,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4190,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10065781422895.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BK2P7PNK",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf30mmf2-8-xf30mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 43,
     "lensConfiguration": {
       "groups": 9,
@@ -6463,30 +6500,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5190,
-          "currency": "CNY",
-          "source": "天猫·富士官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5190,
+            "currency": "CNY",
+            "source": "天猫·富士官方旗舰店",
+            "url": "https://fujifilm.tmall.com/category-1106914229.htm",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 949.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09DTJQSCH",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 949.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf33mmf1-4-xf33mmf1-4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 58,
     "lensConfiguration": {
       "groups": 10,
@@ -6541,30 +6582,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3390,
-          "currency": "CNY",
-          "source": "天猫·富士官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3390,
+            "currency": "CNY",
+            "source": "天猫·富士官方旗舰店",
+            "url": "https://fujifilm.tmall.com/category-1106914229.htm",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 449.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B016S28I4S",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 449.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf35mmf2-xf35mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-43",
       "Lens rear cap RLCP-001",
@@ -6635,30 +6680,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3890,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3890,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33787100217.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B006UL00R6",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf35mmf1-4-r-lens-16240755/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -6737,30 +6786,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 9990,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 9990,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33782092981.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1699.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00NGFLO74",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1699.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf50-140mmf2-8-r-lm-ois-wr-lens-16443060/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Lens rear cap",
@@ -6835,30 +6888,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3590,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3590,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33782496055.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B01MS6WINK",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf50mmf2-xf50mmf2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-46",
       "Lens rear cap RLCP-001",
@@ -6927,30 +6984,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 10490,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 10490,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10021170089659.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1799.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08GX7RYD3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1799.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf50mmf1-0-xf50mmf1-0/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 9,
@@ -7021,30 +7082,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4370,
-          "currency": "CNY",
-          "source": "天猫·富士官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4370,
+            "currency": "CNY",
+            "source": "天猫·富士官方旗舰店",
+            "url": "https://fujifilm.tmall.com/category-1106901591.htm",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 849.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00CNZTPGA",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 849.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf55-200mmf3-5-4-8-xf55-200mmf3-5-4-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 10,
@@ -7106,22 +7171,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 1499.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00NF6ZGAA",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1499.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf56mmf1-2r-apd-xf56mmf1-2r-apd/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -7188,30 +7254,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6620,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 6620,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10060490640801.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1199.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BCR4STVP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1199.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf56mmf1-2-r-wr-xf56mmf1-2-r-wr/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-67 II",
       "Rear lens cap RLCP-001",
@@ -7288,22 +7358,23 @@
         }
       },
       "global": {
-        "new": {
-          "price": 999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00HK8Z9AG",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf56mmf1-2-xf56mmf1-2/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X"
     ],
@@ -7365,30 +7436,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4280,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4280,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33785721932.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 779.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B006ZSNU4O",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 779.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf60mmf2-4-xf60mmf2-4/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 39,
     "lensConfiguration": {
       "groups": 8,
@@ -7459,30 +7534,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5390,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5390,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10026515756821.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 849.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08TMZ59ZW",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 849.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf70-300mm-xf70-300mm/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 67,
     "lensConfiguration": {
       "groups": 12,
@@ -7541,30 +7620,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 7790,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 7790,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33782885268.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1399.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0759GMLVP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1399.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf80mmf2-8-xf80mmf2-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-62II",
       "Lens rear cap RLCP-002",
@@ -7637,30 +7720,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6320,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 6320,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33783537607.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1149.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B00XI4PAZ0",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1149.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf90mmf2-0-xf90mmf2-0/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 62,
     "lensConfiguration": {
       "groups": 8,
@@ -7730,30 +7817,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 12600,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 12600,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/33786122769.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2249.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07Z37HMXQ",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2249.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf100-400mmf4-5-5-6-xf100-400mmf4-5-5-6/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "filterMm": 77,
     "lensConfiguration": {
       "groups": 14,
@@ -7821,30 +7912,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 13500,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 13500,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10054683248070.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 2399.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0B2J6YKSH",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 2399.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf150-600mmf5-6-8-xf150-600mmf5-6-8/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-82",
       "Rear lens cap RLCP-001",
@@ -7920,30 +8015,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 33900,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 33900,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/35290356605.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 5999.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07FQB2T4F",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 5999.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf200mmf2-r-lm-ois-wr-lens-with-xf1-4x-tc-f2-wr-teleconverter-kit-16586343/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap FLCP-105",
       "Lens rear cap RLCP-001",
@@ -8016,30 +8115,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 21400,
-          "currency": "CNY",
-          "source": "京东·富士影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 21400,
+            "currency": "CNY",
+            "source": "京东·富士影像旗舰店",
+            "url": "https://item.jd.com/10126095152653.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 3599.95,
-          "currency": "USD",
-          "source": "FUJIFILM Shop USA",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DJQ1NB2H",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 3599.95,
+            "currency": "USD",
+            "source": "FUJIFILM Shop USA",
+            "url": "https://shopusa.fujifilm-x.com/xf500mmf5-6-r-lm-ois-wr-lens-white-16900408/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Front lens cap FLCP-95",
       "Rear lens cap RLCP-001",
@@ -8115,31 +8218,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1270,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1270,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=660081424807",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-4mm-f-2-8-mft/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-4mm-f-2-8-mft/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8214,19 +8315,17 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2480,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 2480,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=1048274219467",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -8307,31 +8406,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3469,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 3469,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=739462316342",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 549,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 549,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-8-16mm-f3-5-5-zoom-cf/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-8-16mm-f3-5-5-zoom-cf/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8388,20 +8485,27 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2960,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 2960,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=661581334014",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 399,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        },
+        "new": [
+          {
+            "price": 399,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/9mm/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ],
         "used": {
           "price": 274,
           "currency": "USD",
@@ -8410,15 +8514,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/9mm/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8479,20 +8574,27 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1870,
-          "currency": "CNY",
-          "source": "京东·老蛙官方旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 1870,
+            "currency": "CNY",
+            "source": "京东·老蛙官方旗舰店",
+            "url": "https://item.jd.com/10065178915755.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 299,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        },
+        "new": [
+          {
+            "price": 299,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-10mm-f-4-cookie/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ],
         "used": {
           "price": 249.95,
           "currency": "USD",
@@ -8501,15 +8603,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-10mm-f-4-cookie/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Sony E",
@@ -8580,31 +8673,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4950,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 4950,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=812226684927",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 699,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 699,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-12-24mm-f-5-6-zoom-shift-cf/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-12-24mm-f-5-6-zoom-shift-cf/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -8668,20 +8759,27 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2478,
-          "currency": "CNY",
-          "source": "京东·老蛙官方旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 2478,
+            "currency": "CNY",
+            "source": "京东·老蛙官方旗舰店",
+            "url": "https://item.jd.com/10062571224716.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 399,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        },
+        "new": [
+          {
+            "price": 399,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-65mm-f-2-8-2x-ultra-macro-apo/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ],
         "used": {
           "price": 354.99,
           "currency": "USD",
@@ -8690,15 +8788,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-65mm-f-2-8-2x-ultra-macro-apo/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8758,31 +8847,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3350,
-          "currency": "CNY",
-          "source": "天猫·老蛙旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 3350,
+            "currency": "CNY",
+            "source": "天猫·老蛙旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=687949432883",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 549,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 549,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-argus-25mm-f-0-95-apsc-apo/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-argus-25mm-f-0-95-apsc-apo/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -8843,20 +8930,27 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2960,
-          "currency": "CNY",
-          "source": "京东·老蛙官方旗舰店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 2960,
+            "currency": "CNY",
+            "source": "京东·老蛙官方旗舰店",
+            "url": "https://item.jd.com/10064835367273.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 449,
-          "currency": "USD",
-          "source": "venuslens.net",
-          "sampledAt": "2026-05-18"
-        },
+        "new": [
+          {
+            "price": 449,
+            "currency": "USD",
+            "source": "venuslens.net",
+            "url": "https://www.venuslens.net/product/laowa-argus-33mm-f-0-95-cf-apo/",
+            "channel": "official",
+            "sampledAt": "2026-05-18"
+          }
+        ],
         "used": {
           "price": 400,
           "currency": "USD",
@@ -8865,15 +8959,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://www.venuslens.net/product/laowa-argus-33mm-f-0-95-cf-apo/"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -8928,31 +9013,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 512,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 512,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10158405812933.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 125,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 125,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/aps-c-25mm-f1-8-%E8%87%AA%E5%8A%A8%E5%AF%B9%E7%84%A6%E9%95%9C%E5%A4%B4",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/aps-c-25mm-f1-8-%E8%87%AA%E5%8A%A8%E5%AF%B9%E7%84%A6%E9%95%9C%E5%A4%B4"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9013,31 +9096,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 799,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 799,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10124734591556.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/af-55mm-f1-8",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/af-55mm-f1-8"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": 58,
     "lensConfiguration": {
@@ -9093,31 +9174,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 568,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 568,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10100008898701.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 128,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 128,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-7-5mm-f2-8-aps-c-fisheye-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-7-5mm-f2-8-aps-c-fisheye-lens"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -9184,31 +9263,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 558,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 558,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10099680846804.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 138,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 138,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-12mm-f2-8-aps-c-ultra-wide-lens-copy",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-12mm-f2-8-aps-c-ultra-wide-lens-copy"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": "N/A",
     "lensConfiguration": {
@@ -9266,31 +9343,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 252,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 252,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10115511730826.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 59,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 59,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9356,31 +9431,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 309,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 309,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10136094933725.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 76,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 76,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-24mm-f6-3-full-frame-ultra-slim-pancake-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-24mm-f6-3-full-frame-ultra-slim-pancake-lens"
-      }
-    ],
     "compatibleMounts": [
       "Leica L",
       "Sony E",
@@ -9448,31 +9521,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 283,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 283,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10099370400666.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 78,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 78,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens-copy",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-18mm-f6-3-aps-c-ultra-slim-pancake-lens-copy"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9534,31 +9605,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 444,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 444,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10099455378783.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 98,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 98,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-35mm-f1-2-aps-c-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-35mm-f1-2-aps-c-lens"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9620,31 +9689,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 853,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 853,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10099433049702.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 228,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 228,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-35mm-f0-95-ultra-bright-aps-c-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-35mm-f0-95-ultra-bright-aps-c-lens"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9705,31 +9772,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 283,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 283,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10098959961168.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 68,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 68,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/mf-25mm-f2-8-aps-c-lens-copy",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/mf-25mm-f2-8-aps-c-lens-copy"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Micro Four Thirds",
@@ -9790,31 +9855,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 739,
-          "currency": "CNY",
-          "source": "京东·SGIMAGE影像旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 739,
+            "currency": "CNY",
+            "source": "京东·SGIMAGE影像旗舰店",
+            "url": "https://item.jd.com/10110017394939.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 192,
-          "currency": "USD",
-          "source": "sg-image.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 192,
+            "currency": "USD",
+            "source": "sg-image.com",
+            "url": "https://www.sg-image.com/products/50mm-f1-8-mf-full-frame-lens-with-shaped-aperture",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "ebay"
-      },
-      {
-        "channel": "official",
-        "url": "https://www.sg-image.com/products/50mm-f1-8-mf-full-frame-lens-with-shaped-aperture"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -9892,30 +9955,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5999,
-          "currency": "CNY",
-          "source": "天猫·sigma旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 5999,
+            "currency": "CNY",
+            "source": "天猫·sigma旗舰店",
+            "url": "https://detail.tmall.com/item.htm?id=960767113499",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 919,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FDH4RZN5",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 919,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/17-40mm-f1-8-dc-a",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -10007,30 +10074,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4288,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4288,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100072186956.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 679,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CJVRTY76",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 679,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/10-18mm-f2-8-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -10105,30 +10176,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3699,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3699,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100274443690.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 579,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FMLCR1DR",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 579,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/12mm-f1-4-dc-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Canon RF",
       "Fujifilm X",
@@ -10208,30 +10283,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3099,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3099,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100330541518.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 579,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0GQJ9TLX2",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 579,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/15mm-f1-4-dc-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Canon RF",
       "Fujifilm X",
@@ -10331,30 +10410,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4110,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 4110,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100172087733.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 694,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DYNPG9NQ",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 694,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/16-300mm-f3-5-6-7-dc-os-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -10436,30 +10519,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2699,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2699,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100021314769.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 464,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09T78KGRP",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 464,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/16mm-f1-4-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -10550,30 +10637,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3499,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3499,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100047896457.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 584,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BMD377VK",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 584,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/18-50mm-f2-8-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -10646,30 +10737,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2999,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2999,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100068628585.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 659,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0C1VKPXP6",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 659,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/23mm-f1-4-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon RF",
@@ -10742,30 +10837,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1799,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1799,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100021314771.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 344,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09T6N7HRT",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 344,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/30mm-f1-4-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -10839,30 +10938,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2143,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2143,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100037105170.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 484,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09T78FM8M",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 484,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/56mm-f1-4-dc-dn-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Canon EF-M",
@@ -10949,30 +11052,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5999,
-          "currency": "CNY",
-          "source": "京东·适马京东自营旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 5999,
+            "currency": "CNY",
+            "source": "京东·适马京东自营旗舰店",
+            "url": "https://item.jd.com/100067255806.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 999,
-          "currency": "USD",
-          "source": "sigmaphoto.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CH1JSJ6V",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 999,
+            "currency": "USD",
+            "source": "sigmaphoto.com",
+            "url": "https://www.sigmaphoto.com/100-400mm-f5-6-3-dg-dn-os-c",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "L-Mount",
       "Fujifilm X",
@@ -11060,30 +11167,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3680,
-          "currency": "CNY",
-          "source": "京东·腾龙官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3680,
+            "currency": "CNY",
+            "source": "京东·腾龙官方旗舰店",
+            "url": "https://item.jd.com/10031655006587.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 599,
-          "currency": "USD",
-          "source": "tamron-americas.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0C6R7DH31",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 599,
+            "currency": "USD",
+            "source": "tamron-americas.com",
+            "url": "https://tamron-americas.com/product/11-20mm-f-2-8-di-iii-a-rxd/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11168,30 +11279,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3690,
-          "currency": "CNY",
-          "source": "京东·腾龙官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3690,
+            "currency": "CNY",
+            "source": "京东·腾龙官方旗舰店",
+            "url": "https://item.jd.com/10054566167214.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 699,
-          "currency": "USD",
-          "source": "tamron-americas.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0B3MNLZH3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 699,
+            "currency": "USD",
+            "source": "tamron-americas.com",
+            "url": "https://tamron-americas.com/product/17-70mm-f-2-8-di-iii-a-vc-rxd/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -11281,30 +11396,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3490,
-          "currency": "CNY",
-          "source": "京东·腾龙官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3490,
+            "currency": "CNY",
+            "source": "京东·腾龙官方旗舰店",
+            "url": "https://item.jd.com/10037876010935.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 599,
-          "currency": "USD",
-          "source": "tamron-americas.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09M5D2NJC",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 599,
+            "currency": "USD",
+            "source": "tamron-americas.com",
+            "url": "https://tamron-americas.com/product/18-300mm-f-3-5-6-3-di-iii-a-vc-vxd/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -11396,30 +11515,34 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 9790,
-          "currency": "CNY",
-          "source": "京东·腾龙官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 9790,
+            "currency": "CNY",
+            "source": "京东·腾龙官方旗舰店",
+            "url": "https://item.jd.com/10034053993321.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 1199,
-          "currency": "USD",
-          "source": "tamron-americas.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BJ4939R1",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          },
+          {
+            "price": 1199,
+            "currency": "USD",
+            "source": "tamron-americas.com",
+            "url": "https://tamron-americas.com/product/150-500mm-f-5-6-7-di-iii-vc-vxd/",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Round-shaped hood",
       "Front cap",
@@ -11487,31 +11610,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1930,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1930,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10149469211240.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 380,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 380,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-cine-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-cine-lens"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11580,31 +11701,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1890,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1890,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10109344380987.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 339,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 339,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/100mm-f2-8macro",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/100mm-f2-8macro"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11667,31 +11786,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 610,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 610,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10143724226077.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 129,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 129,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-14mm-f3-5"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -11757,31 +11874,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 790,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 790,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10217000703513.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 148,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 148,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/af-17mm-f1-8-air",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/af-17mm-f1-8-air"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Sony E",
@@ -11839,31 +11954,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 630,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 630,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10135148137689.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 127,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 127,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DSBKLVM4",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-23mm-f1-8"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -11933,31 +12052,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 598,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 598,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10112537455275.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 160,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 160,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/af27",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BKJN5C79",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/af27"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12018,31 +12141,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 650,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 650,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10129438988687.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 125,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 125,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0F7HCHKLG",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-35mm-f1-8"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12114,31 +12241,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 698,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 698,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10093185168941.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 129,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 129,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/56mm",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CYX5CN5T",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/56mm"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12210,31 +12341,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1150,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 1150,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10173180170125.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-af-75mm-f2"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -12305,31 +12434,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 649,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 649,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10033949140156.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 139,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 139,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-7-5mm-f2",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0GTYF8QQB",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-7-5mm-f2"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12397,31 +12530,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 859,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 859,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10110060888492.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 169,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 169,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/102",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CPSQS3XN",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/102"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12489,31 +12626,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 483,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 483,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10041957148824.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 114,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 114,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09ND1RSNN",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-23mm-f1-4-black"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12579,31 +12720,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 364,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 364,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10028349066041.html",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 64,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 64,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-25mm-f2",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BCHX2G78",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-25mm-f2"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12663,31 +12808,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 364,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 364,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10028349066041.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 80,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 80,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-35mm-f1-4",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08KGNXN1P",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-35mm-f1-4"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12751,31 +12900,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 960,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 960,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10066384828041.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 210,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 210,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-35mm-f0-95",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-35mm-f0-95"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12843,31 +12990,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 547,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 547,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10037583292173.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 114,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 114,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-40mm-f2-8-marco"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -12927,31 +13072,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 547,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 547,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10035387713862.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 109,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 109,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B08QYVBLC3",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ttartisan-50mm-f1-2"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13012,31 +13161,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1056,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1056,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10052067280271.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 218,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 218,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/aps-c-50mm-f0-95",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/aps-c-50mm-f0-95"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13099,31 +13246,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1152,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1152,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10067041960631.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 229,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 229,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/tilt50mm",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/tilt50mm"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13189,31 +13334,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 940,
-          "currency": "CNY",
-          "source": "京东·铭匠官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 940,
+            "currency": "CNY",
+            "source": "京东·铭匠官方旗舰店",
+            "url": "https://item.jd.com/10154324990901.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 169,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 169,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/tilt-35mm-f1-4",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/tilt-35mm-f1-4"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13291,23 +13434,18 @@
         }
       },
       "global": {
-        "new": {
-          "price": 389,
-          "currency": "USD",
-          "source": "ttartisan.store",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 389,
+            "currency": "USD",
+            "source": "ttartisan.store",
+            "url": "https://ttartisan.store/products/ts100",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "official",
-        "url": "https://ttartisan.store/products/ts100"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Canon RF",
@@ -13387,31 +13525,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 989,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 989,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10191680555976.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 199,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 199,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/af-9mm-f2-8-xf",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FXMKDKLT",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/af-9mm-f2-8-xf"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -13465,31 +13607,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2499,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2499,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10043014538126.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 486,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 486,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B09TF3BDNN",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/13mm-f14-af-lens-for-fujifilm-x-mount-camera-models"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13568,31 +13714,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1169,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1169,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10168304095945.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 239,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 239,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/af-15mm-f1-7-xf",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FFMF6MRV",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/af-15mm-f1-7-xf"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -13650,31 +13800,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1399,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1399,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10051437102084.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 239,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 239,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-23mm-f14-xf-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -13749,31 +13897,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 889,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 889,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10134997624694.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 176,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 176,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/af-25mm-f1-7-x",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DS58QJPD",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/af-25mm-f1-7-x"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -13829,31 +13981,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3099,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3099,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10083825353058.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 578,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 578,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CFLCGSWH",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -13914,31 +14070,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 499,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 499,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10135735360417.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 99,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 99,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/af-28mm-f4-5-x",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DSVL8Q9V",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/af-28mm-f4-5-x"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": "N/A",
     "lensConfiguration": {
@@ -14003,31 +14163,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1299,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1299,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10020003359669.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 239,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 239,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-33mm-f14-xf-aps-c-lens"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -14086,31 +14244,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 889,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 889,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10130606883411.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 179,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 179,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0DP6YY71M",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-35mm-f1-7-aps-c-lens-for-fujifilm-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -14163,31 +14325,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 3459,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 3459,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10177532158029.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 580,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 580,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/af-56mm-f1-2-xf",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0FLY6529Q",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/af-56mm-f1-2-xf"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X"
@@ -14250,31 +14416,29 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1299,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1299,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10021830637202.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 239,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 239,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-56mm-f14-x-mount-lens"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Fujifilm X",
@@ -14334,31 +14498,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 889,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 889,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10099827998683.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 180,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 180,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CZKWLBV7",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-af-56mm-f1-7-xf-z"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Fujifilm X",
       "Nikon Z"
@@ -14411,31 +14579,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 2999,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 2999,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/10067505672155.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 580,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 580,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/75mm-f12-xf-lens",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B0BQXPK27P",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/75mm-f12-xf-lens"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "compatibleMounts": [
       "Sony E",
       "Nikon Z",
@@ -14499,31 +14671,35 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 1699,
-          "currency": "CNY",
-          "source": "京东·唯卓仕官方旗舰店",
-          "sampledAt": "2026-05-08"
-        }
+        "new": [
+          {
+            "price": 1699,
+            "currency": "CNY",
+            "source": "京东·唯卓仕官方旗舰店",
+            "url": "https://item.jd.com/43305473025.html",
+            "sampledAt": "2026-05-08"
+          }
+        ]
       },
       "global": {
-        "new": {
-          "price": 329,
-          "currency": "USD",
-          "source": "viltrox.com",
-          "sampledAt": "2026-05-09"
-        }
+        "new": [
+          {
+            "price": 329,
+            "currency": "USD",
+            "source": "viltrox.com",
+            "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount",
+            "channel": "official",
+            "sampledAt": "2026-05-09"
+          },
+          {
+            "source": "Amazon",
+            "url": "https://www.amazon.com/dp/B07Q4VS1XM",
+            "channel": "amazon",
+            "sampledAt": "2026-05-30"
+          }
+        ]
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "official",
-        "url": "https://viltrox.com/products/viltrox-85mm-f1-8-lens-of-lighter-weight-for-fuji-x-mount"
-      },
-      {
-        "channel": "bhphoto"
-      }
-    ],
     "lensMaterial": "Metal",
     "filterMm": 72,
     "lensConfiguration": {
@@ -14584,12 +14760,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4550,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 4550,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167218234611.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -14600,14 +14779,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -14676,12 +14847,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5098,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 5098,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167246193050.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -14692,14 +14866,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -14765,12 +14931,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 4550,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 4550,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167245025335.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -14781,14 +14950,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -14857,12 +15018,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6220,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 6220,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167249892207.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -14873,14 +15037,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -14949,12 +15105,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 13300,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 13300,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167247515385.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -14965,14 +15124,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -15042,12 +15193,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 5030,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 5030,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167246872016.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -15058,14 +15212,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",
@@ -15128,12 +15274,15 @@
     },
     "pricing": {
       "cn": {
-        "new": {
-          "price": 6380,
-          "currency": "CNY",
-          "source": "京东·福伦达摄影器材店",
-          "sampledAt": "2026-05-18"
-        }
+        "new": [
+          {
+            "price": 6380,
+            "currency": "CNY",
+            "source": "京东·福伦达摄影器材店",
+            "url": "https://item.jd.com/10167250353558.html",
+            "sampledAt": "2026-05-18"
+          }
+        ]
       },
       "global": {
         "used": {
@@ -15144,14 +15293,6 @@
         }
       }
     },
-    "purchaseChannels": [
-      {
-        "channel": "bhphoto"
-      },
-      {
-        "channel": "ebay"
-      }
-    ],
     "accessories": [
       "Lens cap",
       "Rear cap",

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
   "version": "2026.05.30",
-  "lastUpdated": "2026-05-30T13:02:34.350Z",
+  "lastUpdated": "2026-05-30T14:35:58.726Z",
   "lensCount": 196,
-  "buildNumber": 1
+  "buildNumber": 2
 }

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.25",
-  "lastUpdated": "2026-05-25T05:58:39.773Z",
+  "version": "2026.05.30",
+  "lastUpdated": "2026-05-30T13:02:34.350Z",
   "lensCount": 196,
   "buildNumber": 1
 }

--- a/src/lib/__tests__/collections.test.ts
+++ b/src/lib/__tests__/collections.test.ts
@@ -213,10 +213,12 @@ describe("price collections", () => {
     const enLenses = allLenses.filter((l) => col.filter(l, "en"));
     const zhLenses = allLenses.filter((l) => col.filter(l, "zh"));
     for (const l of enLenses) {
-      expect(l.pricing?.global?.new?.price).toBeLessThan(200);
+      const p = l.pricing?.global?.new?.find((e) => e.price != null)?.price;
+      expect(p).toBeLessThan(200);
     }
     for (const l of zhLenses) {
-      expect(l.pricing?.cn?.new?.price).toBeLessThan(1000);
+      const p = l.pricing?.cn?.new?.find((e) => e.price != null)?.price;
+      expect(p).toBeLessThan(1000);
     }
   });
 });

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -100,19 +100,19 @@ const FILTERS: Record<string, LensFilter> = {
   // --- Price ---
   "under-200": (lens, locale) => {
     if (locale === "zh") {
-      const p = lens.pricing?.cn?.new?.price;
+      const p = lens.pricing?.cn?.new?.find((e) => e.price != null)?.price;
       return xPhoto(lens) && p != null && p < 1000;
     }
-    const p = lens.pricing?.global?.new?.price;
+    const p = lens.pricing?.global?.new?.find((e) => e.price != null)?.price;
     return xPhoto(lens) && p != null && p < 200;
   },
 
   "under-400": (lens, locale) => {
     if (locale === "zh") {
-      const p = lens.pricing?.cn?.new?.price;
+      const p = lens.pricing?.cn?.new?.find((e) => e.price != null)?.price;
       return xPhoto(lens) && p != null && p < 2000;
     }
-    const p = lens.pricing?.global?.new?.price;
+    const p = lens.pricing?.global?.new?.find((e) => e.price != null)?.price;
     return xPhoto(lens) && p != null && p < 400;
   },
 

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,5 +1,6 @@
 import collectionsData from "../data/collections.json";
 import { isZoom, getLensesByMount } from "./lens";
+import { pickNewEntry } from "./lens-pricing";
 import type { Mount, Lens } from "./types";
 
 type LensFilter = (lens: Lens, locale: string) => boolean;
@@ -100,19 +101,19 @@ const FILTERS: Record<string, LensFilter> = {
   // --- Price ---
   "under-200": (lens, locale) => {
     if (locale === "zh") {
-      const p = lens.pricing?.cn?.new?.find((e) => e.price != null)?.price;
+      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
       return xPhoto(lens) && p != null && p < 1000;
     }
-    const p = lens.pricing?.global?.new?.find((e) => e.price != null)?.price;
+    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
     return xPhoto(lens) && p != null && p < 200;
   },
 
   "under-400": (lens, locale) => {
     if (locale === "zh") {
-      const p = lens.pricing?.cn?.new?.find((e) => e.price != null)?.price;
+      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
       return xPhoto(lens) && p != null && p < 2000;
     }
-    const p = lens.pricing?.global?.new?.find((e) => e.price != null)?.price;
+    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
     return xPhoto(lens) && p != null && p < 400;
   },
 

--- a/src/lib/lens-pricing.ts
+++ b/src/lib/lens-pricing.ts
@@ -3,14 +3,21 @@ import type { LensPriceEntry } from "@/lib/types";
 type Condition = "new" | "used";
 type Market = "cn" | "global";
 
+/** A price entry guaranteed to carry price + currency (what the UI renders). */
+export type PricedEntry = LensPriceEntry & { price: number; currency: "CNY" | "USD" };
+
 export interface PriceSelection {
-  entry: LensPriceEntry;
+  entry: PricedEntry;
   market: Market;
   condition: Condition;
 }
 
-type PricingBucket = { new?: LensPriceEntry; used?: LensPriceEntry };
+type PricingBucket = { new?: LensPriceEntry[]; used?: LensPriceEntry };
 type PricingData = { cn?: PricingBucket; global?: PricingBucket };
+
+function isPriced(e: LensPriceEntry): e is PricedEntry {
+  return e.price !== undefined && e.currency !== undefined;
+}
 
 // Translator is loosely typed so callers can pass next-intl's `t` function from
 // either useTranslations (client) or getTranslations (server) without coupling
@@ -38,10 +45,12 @@ export function pickPriceEntry(
 ): PriceSelection | null {
   const market: Market = locale === "zh" ? "cn" : "global";
   const bucket = pricing?.[market];
-  if (bucket?.new) {
-    return { entry: bucket.new, market, condition: "new" };
+  // new is a priority-ordered array; pick the first source that has a price.
+  const newEntry = bucket?.new?.find(isPriced);
+  if (newEntry) {
+    return { entry: newEntry, market, condition: "new" };
   }
-  if (bucket?.used) {
+  if (bucket?.used && isPriced(bucket.used)) {
     return { entry: bucket.used, market, condition: "used" };
   }
   return null;

--- a/src/lib/lens-pricing.ts
+++ b/src/lib/lens-pricing.ts
@@ -19,6 +19,16 @@ function isPriced(e: LensPriceEntry): e is PricedEntry {
   return e.price !== undefined && e.currency !== undefined;
 }
 
+/**
+ * The displayed price for a market's `new` array: the first priced source.
+ * The array is priority-ordered (publish sorts by storefront order), so this
+ * is the most-preferred source carrying a price. Single source of truth for
+ * "which new price do we show" — shared by pickPriceEntry and collections.
+ */
+export function pickNewEntry(entries: LensPriceEntry[] | undefined): PricedEntry | undefined {
+  return entries?.find(isPriced);
+}
+
 // Translator is loosely typed so callers can pass next-intl's `t` function from
 // either useTranslations (client) or getTranslations (server) without coupling
 // this module to next-intl. `raw(key)` returns the unprocessed message string
@@ -45,8 +55,7 @@ export function pickPriceEntry(
 ): PriceSelection | null {
   const market: Market = locale === "zh" ? "cn" : "global";
   const bucket = pricing?.[market];
-  // new is a priority-ordered array; pick the first source that has a price.
-  const newEntry = bucket?.new?.find(isPriced);
+  const newEntry = pickNewEntry(bucket?.new);
   if (newEntry) {
     return { entry: newEntry, market, condition: "new" };
   }

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -25,13 +25,23 @@ const minTStopSchema = createApertureSchema("minTStop");
 const opticalTraitSchema = z.enum(OPTICAL_TRAITS);
 export const specNaSchema = z.literal(SPEC_NA);
 const lensPriceEntrySchema = z.strictObject({
-  price: z.number().positive(),
-  currency: z.enum(["CNY", "USD"]),
+  // price/currency are optional: a source may contribute only a purchase link
+  // (e.g. Amazon ASIN with no sampled price). When price is present, currency
+  // is required and (in the pricing superRefine) must match the market.
+  price: z.number().positive().optional(),
+  currency: z.enum(["CNY", "USD"]).optional(),
   source: z.string().min(1),
+  url: z.url().optional(),
+  channel: z.enum(["official", "amazon", "jd", "tmall"]).optional(),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+}).refine((e) => e.price === undefined || e.currency !== undefined, {
+  message: "currency is required when price is present",
+  path: ["currency"],
 });
+// new is a multi-source array in priority order (new[0] = most preferred);
+// used stays single-source.
 const pricingMarketSchema = z.strictObject({
-  new: lensPriceEntrySchema.optional(),
+  new: lensPriceEntrySchema.array().optional(),
   used: lensPriceEntrySchema.optional(),
 });
 
@@ -116,43 +126,34 @@ const lensBaseShape = {
     cn: pricingMarketSchema.optional(),
     global: pricingMarketSchema.optional(),
   }).superRefine((value, ctx) => {
-    // Market → currency pairing (cn → CNY, global → USD) is enforced here at
-    // the validation layer on purpose, rather than baked into the schema/type.
-    // The schema deliberately keeps `currency` as the open CNY | USD union for
-    // both markets so it stays flexible: if a locale ever legitimately carries
-    // a different currency, we relax this single guard and handle conversion at
-    // presentation time — no schema or type migration needed. For now, one
-    // currency per market is sufficient. Upstream, the pipeline scripts and the
-    // data-collection agent already follow this rule; this guard is the runtime
-    // backstop that fails loudly if a row ever slips through, since the price
-    // filters compare raw amounts against currency-specific thresholds and
-    // trust this pairing. A type-level constraint cannot replace it anyway:
-    // the data is JSON validated at runtime and TS types are erased, so
-    // external data needs a runtime check regardless.
-    const requireCurrency = (
+    // Per-market currency (cn → CNY, global → USD) is enforced here at the
+    // validation layer rather than in the schema/type, so currency stays a
+    // flexible union and a future locale with a different currency only
+    // relaxes this one guard. `new` is a multi-source array — each entry is
+    // checked; only entries that carry a price are validated (price-less
+    // purchase-link-only sources have no currency).
+    const checkEntry = (
       market: "cn" | "global",
       slot: "new" | "used",
-      entry: { currency: string } | undefined,
+      entry: { price?: number; currency?: string } | undefined,
       currency: "CNY" | "USD",
+      path: (string | number)[],
     ) => {
-      if (entry && entry.currency !== currency) {
+      if (entry?.price !== undefined && entry.currency !== currency) {
         ctx.addIssue({
           code: "custom",
-          message: `pricing.${market}.${slot} must use ${currency}, got ${entry.currency}`,
-          path: [market, slot, "currency"],
+          message: `pricing.${market}.${slot} must use ${currency}, got ${entry.currency ?? "undefined"}`,
+          path,
         });
       }
     };
-    requireCurrency("cn", "new", value.cn?.new, "CNY");
-    requireCurrency("cn", "used", value.cn?.used, "CNY");
-    requireCurrency("global", "new", value.global?.new, "USD");
-    requireCurrency("global", "used", value.global?.used, "USD");
+    for (const [market, currency] of [["cn", "CNY"], ["global", "USD"]] as const) {
+      (value[market]?.new ?? []).forEach((entry, i) =>
+        checkEntry(market, "new", entry, currency, [market, "new", i, "currency"]),
+      );
+      checkEntry(market, "used", value[market]?.used, currency, [market, "used", "currency"]);
+    }
   }).optional(),
-  purchaseChannels: z.array(z.strictObject({
-    channel: z.enum(['official', 'amazon', 'ebay', 'bhphoto']),
-    url: nonEmptyStringSchema.optional(),
-    asin: nonEmptyStringSchema.optional(),
-  })).min(1).optional(),
   compatibleMounts: z.array(nonEmptyStringSchema).min(1).optional(),
   accessories: z.array(nonEmptyStringSchema).min(1).optional(),
   lensMaterial: optionalNonEmptyStringSchema,
@@ -401,7 +402,7 @@ export const KNOWN_DISTINCT_PAIRS = new Set([
 // Identifiers, human-readable labels, links, and freeform notes are excluded;
 // all measurable optical/physical fields are included automatically.
 const SIMILARITY_EXCLUDE = new Set([
-  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations", "searchAliases", "purchaseChannels",
+  "id", "brand", "model", "series", "officialLinks", "fieldNotes", "translations", "searchAliases", "pricing",
 ]);
 
 // Threshold above which two same-brand lenses are flagged as suspiciously similar.

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -32,7 +32,7 @@ const lensPriceEntrySchema = z.strictObject({
   currency: z.enum(["CNY", "USD"]).optional(),
   source: z.string().min(1),
   url: z.url().optional(),
-  channel: z.enum(["official", "amazon", "jd", "tmall"]).optional(),
+  purchasableChannel: z.enum(["official", "amazon", "jd", "tmall"]).optional(),
   sampledAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 }).refine((e) => e.price === undefined || e.currency !== undefined, {
   message: "currency is required when price is present",

--- a/src/lib/purchase-channel-priority.ts
+++ b/src/lib/purchase-channel-priority.ts
@@ -1,32 +1,26 @@
-import type { PurchaseChannel } from "@/lib/types";
+import type { PurchaseChannelType } from "@/lib/types";
 
-type ChannelType = PurchaseChannel["channel"];
-
-const BRAND_PRIORITY: Record<string, ChannelType[]> = {
-  "7artisans": ["official", "amazon", "ebay", "bhphoto"],
+// Per-brand channel display order (which channels to show + in what order).
+// Data-driven channels (official/amazon) only render when the lens's pricing
+// actually carries that channel; search-driven channels (ebay/bhphoto) always
+// render when listed here. Rationale: Obsidian affiliate-channel-registry.md.
+const BRAND_PRIORITY: Record<string, PurchaseChannelType[]> = {
+  "7artisans":  ["official", "amazon", "ebay", "bhphoto"],
   brightinstar: ["official", "amazon", "ebay", "bhphoto"],
-  ttartisan: ["amazon", "official", "ebay", "bhphoto"],
-  viltrox: ["amazon", "official", "ebay", "bhphoto"],
-  laowa: ["amazon", "official", "ebay", "bhphoto"],
-  fujifilm: ["amazon", "ebay", "bhphoto"],
-  sigma: ["amazon", "ebay", "bhphoto"],
-  tamron: ["amazon", "ebay", "bhphoto"],
-  voigtlander: ["amazon", "ebay", "bhphoto"],
-  sgimage: ["amazon", "official", "ebay"],
-  meike: ["amazon", "official", "ebay"],
-  sirui: ["amazon", "official", "ebay"],
+  ttartisan:    ["amazon", "official", "ebay", "bhphoto"],
+  viltrox:      ["amazon", "official", "ebay", "bhphoto"],
+  laowa:        ["amazon", "official", "ebay", "bhphoto"],
+  fujifilm:     ["amazon", "ebay", "bhphoto"],
+  sigma:        ["amazon", "ebay", "bhphoto"],
+  tamron:       ["amazon", "ebay", "bhphoto"],
+  voigtlander:  ["amazon", "ebay", "bhphoto"],
+  sgimage:      ["amazon", "official", "ebay"],
+  meike:        ["amazon", "official", "ebay"],
+  sirui:        ["amazon", "official", "ebay"],
 };
 
-const DEFAULT_PRIORITY: ChannelType[] = ["amazon", "official", "ebay", "bhphoto"];
+const DEFAULT_PRIORITY: PurchaseChannelType[] = ["amazon", "official", "ebay", "bhphoto"];
 
-export function sortPurchaseChannels(
-  channels: PurchaseChannel[],
-  brand: string,
-): PurchaseChannel[] {
-  const priority = BRAND_PRIORITY[brand.toLowerCase()] ?? DEFAULT_PRIORITY;
-  return [...channels].sort((a, b) => {
-    const ai = priority.indexOf(a.channel);
-    const bi = priority.indexOf(b.channel);
-    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
-  });
+export function getChannelPriority(brand: string): PurchaseChannelType[] {
+  return BRAND_PRIORITY[brand.toLowerCase()] ?? DEFAULT_PRIORITY;
 }

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -1,11 +1,14 @@
 import type { Lens, PurchaseChannelType } from "@/lib/types";
 import { getChannelPriority } from "@/lib/purchase-channel-priority";
 
-const AMAZON_TAG = "xglass0a-20";
 const EPN_CAMPAIGN_ID = "5339154376";
 const EPN_TOOL_ID = "10001";
 
-const DOMAIN_AFFILIATES: Record<string, string> = {
+// Affiliate query param to append to a product URL, keyed by hostname (no www).
+// Independent of channel — any purchase URL whose host is here gets its param.
+// Amazon (?tag) and the GoAffPro DTC stores (?ref) live in one table.
+const AFFILIATE_PARAMS: Record<string, string> = {
+  "amazon.com": "tag=xglass0a-20",
   "7artisans.store": "ref=omwzyqkn",
   "ttartisan.store": "ref=idncwfkb",
   "viltrox.com": "ref=owbtcyuk",
@@ -89,20 +92,20 @@ function appendQuery(url: string, param: string): string {
   return `${url}${sep}${param}`;
 }
 
-// Official DTC store URLs get an affiliate ref appended when the store's domain
-// has one registered; otherwise they pass through (still a valid buy link).
-function buildOfficialUrl(url: string): { url: string; isAffiliate: boolean } {
+// Append the affiliate param for a product URL's host, if registered. Channel-
+// agnostic: official (?ref) and amazon (?tag) both go through here.
+function applyAffiliate(url: string): { url: string; isAffiliate: boolean } {
   let hostname: string;
   try {
     hostname = new URL(url).hostname.replace(/^www\./, "");
   } catch {
     return { url, isAffiliate: false };
   }
-  const ref = DOMAIN_AFFILIATES[hostname];
-  if (!ref) {
+  const param = AFFILIATE_PARAMS[hostname];
+  if (!param) {
     return { url, isAffiliate: false };
   }
-  return { url: appendQuery(url, ref), isAffiliate: true };
+  return { url: appendQuery(url, param), isAffiliate: true };
 }
 
 export function isPurchaseLocale(locale: string): boolean {
@@ -128,8 +131,8 @@ export function buildPurchaseLinks(
   // dedup).
   const urlByChannel = new Map<string, string>();
   for (const entry of newEntries) {
-    if (entry.channel && entry.url && !urlByChannel.has(entry.channel)) {
-      urlByChannel.set(entry.channel, entry.url);
+    if (entry.purchasableChannel && entry.url && !urlByChannel.has(entry.purchasableChannel)) {
+      urlByChannel.set(entry.purchasableChannel, entry.url);
     }
   }
 
@@ -137,27 +140,16 @@ export function buildPurchaseLinks(
 
   for (const channel of getChannelPriority(lens.brand)) {
     switch (channel) {
-      case "official": {
-        const url = urlByChannel.get("official");
-        if (url) {
-          const official = buildOfficialUrl(url);
-          links.push({
-            channel: "official",
-            label: CHANNEL_LABELS.official,
-            url: official.url,
-            isAffiliate: official.isAffiliate,
-          });
-        }
-        break;
-      }
+      case "official":
       case "amazon": {
-        const url = urlByChannel.get("amazon");
+        const url = urlByChannel.get(channel);
         if (url) {
+          const aff = applyAffiliate(url);
           links.push({
-            channel: "amazon",
-            label: CHANNEL_LABELS.amazon,
-            url: appendQuery(url, `tag=${AMAZON_TAG}`),
-            isAffiliate: true,
+            channel,
+            label: CHANNEL_LABELS[channel],
+            url: aff.url,
+            isAffiliate: aff.isAffiliate,
           });
         }
         break;

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -1,5 +1,5 @@
-import type { Lens } from "@/lib/types";
-import { sortPurchaseChannels } from "@/lib/purchase-channel-priority";
+import type { Lens, PurchaseChannelType } from "@/lib/types";
+import { getChannelPriority } from "@/lib/purchase-channel-priority";
 
 const AMAZON_TAG = "xglass0a-20";
 const EPN_CAMPAIGN_ID = "5339154376";
@@ -36,8 +36,15 @@ const EBAY_MARKETS: Record<string, EbayMarket> = {
 
 const EBAY_DEFAULT_MARKET = EBAY_MARKETS.US;
 
+const CHANNEL_LABELS: Record<PurchaseChannelType, string> = {
+  official: "Official",
+  amazon: "Amazon",
+  ebay: "eBay",
+  bhphoto: "B&H",
+};
+
 export interface PurchaseLink {
-  channel: "official" | "amazon" | "ebay" | "bhphoto";
+  channel: PurchaseChannelType;
   label: string;
   url: string;
   isAffiliate: boolean;
@@ -72,32 +79,30 @@ function buildEbayUrl(
   return `${target}&${params.join("&")}`;
 }
 
-function buildAmazonUrl(asin: string): string {
-  return `https://www.amazon.com/dp/${asin}/?tag=${AMAZON_TAG}`;
-}
-
 function buildBhPhotoUrl(lens: Lens, locale: string): string {
   const query = getSearchQuery(lens, locale);
   return `https://www.bhphotovideo.com/c/search?Ntt=${encodeURIComponent(query)}`;
 }
 
-
-function getAffiliateParam(url: string): string | undefined {
-  try {
-    const hostname = new URL(url).hostname.replace(/^www\./, "");
-    return DOMAIN_AFFILIATES[hostname];
-  } catch {
-    return undefined;
-  }
+function appendQuery(url: string, param: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}${param}`;
 }
 
+// Official DTC store URLs get an affiliate ref appended when the store's domain
+// has one registered; otherwise they pass through (still a valid buy link).
 function buildOfficialUrl(url: string): { url: string; isAffiliate: boolean } {
-  const param = getAffiliateParam(url);
-  if (!param) {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.replace(/^www\./, "");
+  } catch {
     return { url, isAffiliate: false };
   }
-  const sep = url.includes("?") ? "&" : "?";
-  return { url: `${url}${sep}${param}`, isAffiliate: true };
+  const ref = DOMAIN_AFFILIATES[hostname];
+  if (!ref) {
+    return { url, isAffiliate: false };
+  }
+  return { url: appendQuery(url, ref), isAffiliate: true };
 }
 
 export function isPurchaseLocale(locale: string): boolean {
@@ -110,40 +115,57 @@ export function buildPurchaseLinks(
   countryCode: string,
   customId?: string,
 ): PurchaseLink[] {
-  if (!isPurchaseLocale(locale) || !lens.purchaseChannels) {
+  if (!isPurchaseLocale(locale)) {
     return [];
   }
 
-  const sorted = sortPurchaseChannels(lens.purchaseChannels, lens.brand);
+  const market = locale === "zh" ? "cn" : "global";
+  const newEntries = lens.pricing?.[market]?.new ?? [];
+
+  // Data-driven channels: first pricing entry per channel that carries a url.
+  // The array is priority-ordered (publish sorts by storefront order), so the
+  // first occurrence per channel is the preferred storefront (same-channel
+  // dedup).
+  const urlByChannel = new Map<string, string>();
+  for (const entry of newEntries) {
+    if (entry.channel && entry.url && !urlByChannel.has(entry.channel)) {
+      urlByChannel.set(entry.channel, entry.url);
+    }
+  }
+
   const links: PurchaseLink[] = [];
 
-  for (const ch of sorted) {
-    switch (ch.channel) {
-      case "official":
-        if (ch.url) {
-          const official = buildOfficialUrl(ch.url);
+  for (const channel of getChannelPriority(lens.brand)) {
+    switch (channel) {
+      case "official": {
+        const url = urlByChannel.get("official");
+        if (url) {
+          const official = buildOfficialUrl(url);
           links.push({
             channel: "official",
-            label: "Official",
+            label: CHANNEL_LABELS.official,
             url: official.url,
             isAffiliate: official.isAffiliate,
           });
         }
         break;
-      case "amazon":
-        if (ch.asin) {
+      }
+      case "amazon": {
+        const url = urlByChannel.get("amazon");
+        if (url) {
           links.push({
             channel: "amazon",
-            label: "Amazon",
-            url: buildAmazonUrl(ch.asin),
+            label: CHANNEL_LABELS.amazon,
+            url: appendQuery(url, `tag=${AMAZON_TAG}`),
             isAffiliate: true,
           });
         }
         break;
+      }
       case "ebay":
         links.push({
           channel: "ebay",
-          label: "eBay",
+          label: CHANNEL_LABELS.ebay,
           url: buildEbayUrl(lens, locale, countryCode, customId),
           isAffiliate: true,
         });
@@ -151,7 +173,7 @@ export function buildPurchaseLinks(
       case "bhphoto":
         links.push({
           channel: "bhphoto",
-          label: "B&H",
+          label: CHANNEL_LABELS.bhphoto,
           url: buildBhPhotoUrl(lens, locale),
           isAffiliate: false,
         });

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -4,15 +4,20 @@ import { getChannelPriority } from "@/lib/purchase-channel-priority";
 const EPN_CAMPAIGN_ID = "5339154376";
 const EPN_TOOL_ID = "10001";
 
-// Affiliate query param to append to a product URL, keyed by hostname (no www).
+// Cap how many purchase buttons render per lens. Links are priority-ordered, so
+// this keeps the top-ranked channels and drops the long tail.
+const MAX_PURCHASE_LINKS = 3;
+
+// Affiliate query param to set on a product URL, keyed by hostname (no www).
 // Independent of channel — any purchase URL whose host is here gets its param.
-// Amazon (?tag) and the GoAffPro DTC stores (?ref) live in one table.
-const AFFILIATE_PARAMS: Record<string, string> = {
-  "amazon.com": "tag=xglass0a-20",
-  "7artisans.store": "ref=omwzyqkn",
-  "ttartisan.store": "ref=idncwfkb",
-  "viltrox.com": "ref=owbtcyuk",
-  "brightinstar.com": "ref=mffdqyik",
+// Amazon (tag) and the GoAffPro DTC stores (ref) live in one table; each value
+// is a [key, value] pair fed straight to URLSearchParams.set.
+const AFFILIATE_PARAMS: Record<string, [string, string]> = {
+  "amazon.com": ["tag", "xglass0a-20"],
+  "7artisans.store": ["ref", "omwzyqkn"],
+  "ttartisan.store": ["ref", "idncwfkb"],
+  "viltrox.com": ["ref", "owbtcyuk"],
+  "brightinstar.com": ["ref", "mffdqyik"],
 };
 
 interface EbayMarket {
@@ -87,25 +92,21 @@ function buildBhPhotoUrl(lens: Lens, locale: string): string {
   return `https://www.bhphotovideo.com/c/search?Ntt=${encodeURIComponent(query)}`;
 }
 
-function appendQuery(url: string, param: string): string {
-  const sep = url.includes("?") ? "&" : "?";
-  return `${url}${sep}${param}`;
-}
-
-// Append the affiliate param for a product URL's host, if registered. Channel-
-// agnostic: official (?ref) and amazon (?tag) both go through here.
+// Set the affiliate param for a product URL's host, if registered. Channel-
+// agnostic: official (ref) and amazon (tag) both go through here.
 function applyAffiliate(url: string): { url: string; isAffiliate: boolean } {
-  let hostname: string;
+  let parsed: URL;
   try {
-    hostname = new URL(url).hostname.replace(/^www\./, "");
+    parsed = new URL(url);
   } catch {
     return { url, isAffiliate: false };
   }
-  const param = AFFILIATE_PARAMS[hostname];
+  const param = AFFILIATE_PARAMS[parsed.hostname.replace(/^www\./, "")];
   if (!param) {
     return { url, isAffiliate: false };
   }
-  return { url: appendQuery(url, param), isAffiliate: true };
+  parsed.searchParams.set(param[0], param[1]);
+  return { url: parsed.toString(), isAffiliate: true };
 }
 
 export function isPurchaseLocale(locale: string): boolean {
@@ -173,5 +174,5 @@ export function buildPurchaseLinks(
     }
   }
 
-  return links;
+  return links.slice(0, MAX_PURCHASE_LINKS);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -275,9 +275,10 @@ export interface LensPriceEntry {
   currency?: "CNY" | "USD";
   source: string;
   url?: string;
-  /** Data-driven purchase channels (price-source storefronts). ebay/bhphoto
-   *  are search-driven and never appear here. */
-  channel?: "official" | "amazon" | "jd" | "tmall";
+  /** When present, this source is a buyable purchase channel of the given
+   *  kind (its `url` becomes a purchase link). Absent = price-only source
+   *  (e.g. a brand info page). ebay/bhphoto are search-driven and never here. */
+  purchasableChannel?: "official" | "amazon" | "jd" | "tmall";
   /** ISO date YYYY-MM-DD when sampled. */
   sampledAt: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -263,26 +263,33 @@ export type FieldNoteKey = (typeof FIELD_NOTE_KEYS)[number];
  */
 export type Mount = "X" | "G";
 
-/** A single price observation — shared by new and used entries across all markets. */
+/**
+ * One retail source's price/purchase observation for a lens in one market.
+ * `price`/`currency` are optional: a source may contribute only a purchase
+ * link (e.g. Amazon ASIN with no sampled price). `url` is the product page
+ * (purchase-link base when `channel` is set). `channel`, when present, marks
+ * this source as a buyable purchase channel — derived at publish time.
+ */
 export interface LensPriceEntry {
-  price: number;
-  currency: "CNY" | "USD";
+  price?: number;
+  currency?: "CNY" | "USD";
   source: string;
+  url?: string;
+  /** Data-driven purchase channels (price-source storefronts). ebay/bhphoto
+   *  are search-driven and never appear here. */
+  channel?: "official" | "amazon" | "jd" | "tmall";
   /** ISO date YYYY-MM-DD when sampled. */
   sampledAt: string;
 }
+
+/** Purchase channels the frontend renders a buy button for. */
+export type PurchaseChannelType = "official" | "amazon" | "ebay" | "bhphoto";
 
 /** Translated user-facing fields for a single locale. */
 interface LensLocaleTranslations {
   fieldNotes?: Partial<Record<FieldNoteKey, string>>;
   lensMaterial?: string;
   accessories?: string[];
-}
-
-export interface PurchaseChannel {
-  channel: 'official' | 'amazon' | 'ebay' | 'bhphoto';
-  url?: string;
-  asin?: string;
 }
 
 /**
@@ -684,16 +691,14 @@ export interface Lens {
    */
   pricing?: {
     cn?: {
-      new?: LensPriceEntry;
+      new?: LensPriceEntry[];
       used?: LensPriceEntry;
     };
     global?: {
-      new?: LensPriceEntry;
+      new?: LensPriceEntry[];
       used?: LensPriceEntry;
     };
   };
-
-  purchaseChannels?: PurchaseChannel[];
 
   /**
    * Mount systems this lens is available for, as stated by the manufacturer.


### PR DESCRIPTION
## Summary

Unifies price data and purchase links onto one multi-source structure, replacing the separate `purchaseChannels`/`marketplace` field.

**Before:** `pricing.{market}.new` was a single object; purchase links lived in a separate `purchaseChannels` array (with Amazon ASINs stored ad-hoc).

**After:** `pricing.{market}.new` is a priority-ordered **array** — one entry per retail source, each carrying `url` + a derived `channel` (official/amazon). Purchase links are derived from this data; price and purchase share one source of truth.

## Key points

- `price`/`currency` are optional on a price entry: a source may contribute only a purchase link (e.g. Amazon ASIN with no sampled price).
- Array order = priority (publish sorts by storefront declaration order). Price selection and same-channel dedup both use "first matching entry".
- `pickPriceEntry` collapses the array to one `PriceSelection`, so all 7 price-display components are unchanged. `buildPurchaseLinks` keeps its signature, so the 4 UI callers are unchanged.
- ebay/bhphoto are search-driven (from searchAliases); official/amazon are data-driven (from pricing entries with a channel).
- `pricing` added to spec-similarity exclusion (array churn shouldn't perturb same-spec detection).

## Verification

- typecheck + lint clean; 306 unit tests pass.
- Lens id set vs main: no regressions (169 X + 27 G).
- Browser (dev server): viltrox detail shows $180 + Amazon→Official→eBay→B&H with correct affiliate params (`?tag=`, `?ref=`, EPN); fujifilm shows Amazon→eBay→B&H (no official).

Data regenerated via pipeline publish in the same PR (schema + data together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)