### PR TITLE
fix(collections): gate collections on per-mount capability, stop GFX serving X data

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, Flag } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { COLLECTIONS, getCollectionStats, getRelatedCollectionsWithStats } from "@/lib/collections";
 import { getLensesByMount } from "@/lib/lens";
-import { urlSegmentToMount, mountSeoLabel } from "@/lib/mount";
+import { urlSegmentToMount, mountSeoLabel, mountHasCollections } from "@/lib/mount";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { ACTION_ESCAPE_CLS, UTILITY_BTN_CLS } from "@/lib/ui-tokens";
 import CollectionLensGrid from "@/components/CollectionLensGrid";
@@ -32,7 +32,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale, mount, slug } = await params;
   const resolvedMount = urlSegmentToMount(mount);
-  if (!resolvedMount) {
+  if (!resolvedMount || !mountHasCollections(resolvedMount)) {
     return {};
   }
   const stats = getCollectionStats(slug, resolvedMount, locale);
@@ -70,7 +70,7 @@ export default async function CollectionPage({
   setRequestLocale(locale);
 
   const resolvedMount = urlSegmentToMount(mount);
-  if (!resolvedMount) {
+  if (!resolvedMount || !mountHasCollections(resolvedMount)) {
     notFound();
   }
   const collectionStats = getCollectionStats(slug, resolvedMount, locale);

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { ArrowRight } from "lucide-react";
 import { Link } from "@/i18n/navigation";
@@ -16,7 +17,7 @@ import {
   VALUE_SLUGS,
 } from "@/lib/collections";
 import { getLensesByMount } from "@/lib/lens";
-import type { Mount } from "@/lib/types";
+import { urlSegmentToMount, mountHasCollections } from "@/lib/mount";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
 import { ACTION_PRIMARY_CLS, LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
 import LensSectionNav from "@/components/LensSectionNav";
@@ -34,6 +35,10 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { locale, mount } = await params;
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount || !mountHasCollections(resolvedMount)) {
+    return {};
+  }
   const t = await getTranslations({ locale, namespace: "Collection" });
 
   const title = t("indexTitle");
@@ -72,8 +77,13 @@ export default async function CollectionsIndexPage({
   const { locale, mount } = await params;
   setRequestLocale(locale);
 
+  const resolvedMount = urlSegmentToMount(mount);
+  if (!resolvedMount || !mountHasCollections(resolvedMount)) {
+    notFound();
+  }
+
   const t = await getTranslations({ locale, namespace: "Collection" });
-  const mountLenses = getLensesByMount(mount as Mount, locale);
+  const mountLenses = getLensesByMount(resolvedMount, locale);
 
   const countFor = (slug: string) => {
     const c = COLLECTIONS[slug];

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -7,14 +7,12 @@ import {
 } from "@/lib/lens";
 import { deriveSpecialty } from "@/lib/lens-specialty";
 import { parseFilters } from "@/lib/filter-params";
-import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
+import { urlSegmentToMount } from "@/lib/mount";
 import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { routing } from "@/i18n/routing";
 import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
-
-const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
 
 function computeAvailableOpticalTraits(lenses: { isCine?: boolean; opticalTraits?: OpticalTrait[] }[]): OpticalTrait[] {
   const present = new Set(
@@ -33,7 +31,8 @@ export function GET(req: Request) {
   const mountParam = searchParams.get("mount");
   const locale = searchParams.get("locale");
 
-  if (!mountParam || !VALID_MOUNTS.includes(mountParam)) {
+  const mount = urlSegmentToMount(mountParam);
+  if (!mount) {
     return NextResponse.json(
       { error: "invalid or missing 'mount' param (expected 'x' or 'gfx')" },
       { status: 400 },
@@ -46,7 +45,6 @@ export function GET(req: Request) {
     );
   }
 
-  const mount = urlSegmentToMount(mountParam as MountSegment)!;
   const allLenses = getLensesByMount(mount, locale);
 
   const filters = parseFilters(searchParams);

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -1,25 +1,24 @@
 import { NextResponse } from "next/server";
 import { getLensesByMount } from "@/lib/lens";
 import { buildLensSearchIndex, searchLensIndex, type LensSearchIndex } from "@/lib/lens-search";
-import { urlSegmentToMount, type MountSegment } from "@/lib/mount";
+import { urlSegmentToMount } from "@/lib/mount";
+import type { Mount } from "@/lib/types";
 import { routing } from "@/i18n/routing";
 import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
-const VALID_MOUNTS: readonly string[] = ["x", "gfx"];
 const MAX_QUERY_LENGTH = 200;
 const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 30;
 
 const indexCache = new Map<string, LensSearchIndex>();
 
-function getCachedIndex(mount: string, locale: string): LensSearchIndex {
+function getCachedIndex(mount: Mount, locale: string): LensSearchIndex {
   const key = `${mount}:${locale}`;
   let index = indexCache.get(key);
   if (!index) {
-    const resolvedMount = urlSegmentToMount(mount as MountSegment)!;
-    index = buildLensSearchIndex(getLensesByMount(resolvedMount, locale));
+    index = buildLensSearchIndex(getLensesByMount(mount, locale));
     indexCache.set(key, index);
   }
   return index;
@@ -36,7 +35,8 @@ export function GET(req: Request) {
   const locale = searchParams.get("locale");
   const query = searchParams.get("q");
 
-  if (!mountParam || !VALID_MOUNTS.includes(mountParam)) {
+  const mount = urlSegmentToMount(mountParam);
+  if (!mount) {
     return NextResponse.json(
       { error: "invalid or missing 'mount' param (expected 'x' or 'gfx')" },
       { status: 400 },
@@ -66,7 +66,7 @@ export function GET(req: Request) {
     ? Math.max(1, Math.min(MAX_LIMIT, parseInt(limitParam, 10) || DEFAULT_LIMIT))
     : DEFAULT_LIMIT;
 
-  const index = getCachedIndex(mountParam, locale);
+  const index = getCachedIndex(mount, locale);
   const results = searchLensIndex(index, query.trim(), limit);
 
   return NextResponse.json(

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,25 +2,36 @@ import type { MetadataRoute } from "next";
 import { SITE } from "@/config/site";
 import { routing } from "@/i18n/routing";
 import { COLLECTIONS } from "@/lib/collections";
+import { MOUNTS, mountToUrlSegment, mountHasCollections } from "@/lib/mount";
+import type { Mount } from "@/lib/types";
 import xLensesData from "@/data/lenses.json";
 import gfxLensesData from "@/data/lenses-gfx.json";
 
 const LOCALES = routing.locales;
+
+// Lens catalogs keyed by mount, so the per-mount loops below stay data-driven
+// rather than hardcoding one branch per mount.
+const LENS_DATA: Record<Mount, { id: string }[]> = {
+  X: xLensesData as { id: string }[],
+  G: gfxLensesData as { id: string }[],
+};
 
 function url(path: string): string {
   return `${SITE.url}${path}`;
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const staticPaths = [
-    "/lenses/x/browse",
-    "/lenses/x/compare",
-    "/lenses/gfx/browse",
-    "/lenses/gfx/compare",
-    "/lenses/x/collections",
-    "/about",
-    "/get",
-  ];
+  // Per-mount index paths: browse + compare always, collections only where the
+  // mount actually has them (gated by the same flag as the routes/tab).
+  const mountPaths = MOUNTS.flatMap((mount) => {
+    const seg = mountToUrlSegment(mount);
+    const paths = [`/lenses/${seg}/browse`, `/lenses/${seg}/compare`];
+    if (mountHasCollections(mount)) {
+      paths.push(`/lenses/${seg}/collections`);
+    }
+    return paths;
+  });
+  const staticPaths = [...mountPaths, "/about", "/get"];
 
   const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) => [
     {
@@ -35,32 +46,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })),
   ]);
 
-  const xLensEntries: MetadataRoute.Sitemap = (xLensesData as { id: string }[]).flatMap(
-    (lens) =>
+  const lensEntries: MetadataRoute.Sitemap = MOUNTS.flatMap((mount) => {
+    const seg = mountToUrlSegment(mount);
+    return LENS_DATA[mount].flatMap((lens) =>
       LOCALES.map((locale) => ({
-        url: url(`/${locale}/lenses/x/${lens.id}`),
+        url: url(`/${locale}/lenses/${seg}/${lens.id}`),
         changeFrequency: "monthly" as const,
         priority: 0.6,
       }))
+    );
+  });
+
+  const collectionEntries: MetadataRoute.Sitemap = MOUNTS.filter(mountHasCollections).flatMap(
+    (mount) => {
+      const seg = mountToUrlSegment(mount);
+      return Object.keys(COLLECTIONS).flatMap((slug) =>
+        LOCALES.map((locale) => ({
+          url: url(`/${locale}/lenses/${seg}/collections/${slug}`),
+          changeFrequency: "weekly" as const,
+          priority: 0.7,
+        }))
+      );
+    }
   );
 
-  const gfxLensEntries: MetadataRoute.Sitemap = (gfxLensesData as { id: string }[]).flatMap(
-    (lens) =>
-      LOCALES.map((locale) => ({
-        url: url(`/${locale}/lenses/gfx/${lens.id}`),
-        changeFrequency: "monthly" as const,
-        priority: 0.6,
-      }))
-  );
-
-  const collectionEntries: MetadataRoute.Sitemap = Object.keys(COLLECTIONS).flatMap(
-    (slug) =>
-      LOCALES.map((locale) => ({
-        url: url(`/${locale}/lenses/x/collections/${slug}`),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      }))
-  );
-
-  return [...staticEntries, ...collectionEntries, ...xLensEntries, ...gfxLensEntries];
+  return [...staticEntries, ...collectionEntries, ...lensEntries];
 }

--- a/src/components/LensSectionNav.tsx
+++ b/src/components/LensSectionNav.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
 import { useEffectiveMount } from "@/hooks/useMountParam";
-import { mountToUrlSegment } from "@/lib/mount";
+import { mountToUrlSegment, mountHasCollections } from "@/lib/mount";
 import { cn } from "@/lib/utils";
 
 /**
@@ -16,13 +16,19 @@ import { cn } from "@/lib/utils";
 export default function LensSectionNav() {
   const t = useTranslations("Nav");
   const pathname = usePathname();
-  const seg = mountToUrlSegment(useEffectiveMount());
+  const mount = useEffectiveMount();
+  const seg = mountToUrlSegment(mount);
   const active = pathname.includes("/collections") ? "collections" : "browse";
 
+  // Collections is an X-only view for now; mounts without it (GFX) show just
+  // the lens list and never surface a tab that would dead-end. mountHasCollections
+  // is the single switch that re-enables this when GFX collections ship.
   const tabs = [
     { key: "browse", label: t("allLenses"), href: `/lenses/${seg}/browse` },
-    { key: "collections", label: t("collections"), href: `/lenses/${seg}/collections` },
-  ] as const;
+    ...(mountHasCollections(mount)
+      ? [{ key: "collections", label: t("collections"), href: `/lenses/${seg}/collections` }]
+      : []),
+  ];
 
   return (
     <nav

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -528,7 +528,7 @@ describe("filterLenses", () => {
 // getFocalCategoriesOf
 // ---------------------------------------------------------------------------
 function newPrime(fl: number) {
-  return { focalLengthMin: fl, focalLengthMax: fl };
+  return { focalLengthMin: fl, focalLengthMax: fl, mount: "X" as const };
 }
 
 describe("getFocalCategoriesOf", () => {
@@ -557,6 +557,7 @@ describe("getFocalCategoriesOf", () => {
     const cats = getFocalCategoriesOf({
       focalLengthMin: 18,
       focalLengthMax: 55,
+      mount: "X",
     });
     expect(cats).toEqual(["wide", "standard", "mediumTele"]);
   });
@@ -566,6 +567,7 @@ describe("getFocalCategoriesOf", () => {
     const cats = getFocalCategoriesOf({
       focalLengthMin: 16,
       focalLengthMax: 300,
+      mount: "X",
     });
     expect(cats).toEqual([
       "wide",
@@ -580,6 +582,7 @@ describe("getFocalCategoriesOf", () => {
     const cats = getFocalCategoriesOf({
       focalLengthMin: 8,
       focalLengthMax: 16,
+      mount: "X",
     });
     expect(cats).toEqual(["ultrawide", "wide"]);
   });
@@ -589,6 +592,7 @@ describe("getFocalCategoriesOf", () => {
     const cats = getFocalCategoriesOf({
       focalLengthMin: 50,
       focalLengthMax: 140,
+      mount: "X",
     });
     expect(cats).toEqual(["mediumTele", "superTele"]);
   });

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -30,7 +30,15 @@ function getResolved(base: Lens[], locale: string): Lens[] {
 }
 
 export function getLensesByMount(mount: Mount, locale: string): Lens[] {
-  return getResolved(mount === "G" ? gfxLenses : xLenses, locale);
+  if (mount === "X") {
+    return getResolved(xLenses, locale);
+  }
+  if (mount === "G") {
+    return getResolved(gfxLenses, locale);
+  }
+  // Exhaustive: a non-X/G value can only arrive via an unsafe cast upstream.
+  // Throw loudly here instead of silently serving X lenses.
+  throw new Error(`getLensesByMount: unsupported mount ${JSON.stringify(mount)}`);
 }
 
 export function getAllLenses(locale: string): Lens[] {
@@ -103,9 +111,9 @@ export type FocalCategory = (typeof FOCAL_CATEGORIES)[number]["key"];
 export function getFocalCategoriesOf(lens: {
   focalLengthMin: number;
   focalLengthMax: number;
-  mount?: Mount;
+  mount: Mount;
 }): FocalCategory[] {
-  const cropFactor = CROP_FACTOR[lens.mount ?? "X"];
+  const cropFactor = CROP_FACTOR[lens.mount];
   const lensEquivMin = lens.focalLengthMin * cropFactor;
   const lensEquivMax = lens.focalLengthMax * cropFactor;
 

--- a/src/lib/mount.ts
+++ b/src/lib/mount.ts
@@ -2,7 +2,12 @@ import type { Mount } from "@/lib/types";
 
 export type MountSegment = "x" | "gfx";
 
-export function urlSegmentToMount(seg: string | undefined): Mount | null {
+// Canonical list of all mounts, in display order. The single source to iterate
+// over when a surface needs to enumerate mounts (sitemap, param validation), so
+// adding a mount is a one-line change here rather than a hunt across files.
+export const MOUNTS: readonly Mount[] = ["X", "G"];
+
+export function urlSegmentToMount(seg: string | null | undefined): Mount | null {
   if (seg === "x") {
     return "X";
   }
@@ -14,6 +19,20 @@ export function urlSegmentToMount(seg: string | undefined): Mount | null {
 
 export function mountToUrlSegment(mount: Mount): MountSegment {
   return mount === "X" ? "x" : "gfx";
+}
+
+// Per-mount feature availability. Collections exist only for X today: the
+// collection filters in lib/collections.ts match X-mount lenses. When GFX
+// collections are built (filters made mount-aware), flip `collections` to true
+// here and the section tab, routes, and sitemap all light up together — no
+// scattered mount checks to hunt down.
+const MOUNT_CAPABILITIES: Record<Mount, { collections: boolean }> = {
+  X: { collections: true },
+  G: { collections: false },
+};
+
+export function mountHasCollections(mount: Mount): boolean {
+  return MOUNT_CAPABILITIES[mount].collections;
 }
 
 /**


### PR DESCRIPTION
## Problem

`/lenses/gfx/collections` rendered the **X** catalog instead of GFX content (and never 404'd). Root cause was a silent fallback chain:

- The collections index page resolved its mount with `getLensesByMount(mount as Mount, ...)`, passing the URL segment `"gfx"` through an unsafe cast.
- `getLensesByMount` used a non-exhaustive ternary (`mount === "G" ? gfx : x`), so any non-`"G"` value silently fell back to X.

The bug stayed invisible until a user clicked into it — exactly the failure mode silent fallbacks produce.

## Approach

Collections are X-only today (the filters in `lib/collections.ts` match X-mount lenses). Instead of hardcoding `if (gfx)` checks, this introduces a single capability flag so future GFX collections re-enable everything by flipping one boolean — the door is left open, not bricked shut.

### Fix + future-proofing
- **`mount.ts`**: add `mountHasCollections` (backed by `MOUNT_CAPABILITIES`) and `MOUNTS`; broaden `urlSegmentToMount` to accept `null`.
- **collections index + `[slug]`**: resolve via `urlSegmentToMount`, `notFound()` when the mount lacks collections — drops the `as Mount` cast that caused the bug. `/gfx/collections` now returns a clean 404.
- **`LensSectionNav`**: hide the Collections tab for mounts without collections, so GFX is a browse-only view rather than a dead-end tab.
- **`sitemap`**: drive per-mount + collection URLs off `MOUNTS`/`mountHasCollections` instead of hardcoded segments, keeping GFX collections out of the sitemap until they exist.

### Harden the fallback class
- **`getLensesByMount`**: exhaustive — throws on an unknown mount instead of defaulting to X.
- **`getFocalCategoriesOf`**: require `mount`, drop the `?? "X"` default (would silently apply APS-C crop to a mountless lens).

### Dedupe API validation
- Both `/api/lenses` routes drop their duplicated `VALID_MOUNTS` arrays plus the `as MountSegment` casts and `!` non-null assertions, validating through `urlSegmentToMount` (single source of truth).

## When GFX collections ship
Make the filters in `lib/collections.ts` mount-aware, then flip `G: { collections: true }` in `MOUNT_CAPABILITIES` — the tab, routes, and sitemap all light up together.

## Test plan
- `npm test` — 350 pass (added `mount: "X"` to `getFocalCategoriesOf` call sites)
- typecheck/lint clean on touched files
- Verified locally: `/gfx/collections` → 404, `/gfx/browse` → single tab, `/x/collections` → 42 collections intact, `/x/browse` → both tabs
- API: `mount=gfx`/`mount=x` → 200, invalid `mount=G`/`mount=ef` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)