### PR TITLE
fix(filters): serve full lens pool from API, treat usage as a view mode

### DIFF
--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -48,6 +48,14 @@ export function GET(req: Request) {
   const allLenses = getLensesByMount(mount, locale);
 
   const filters = parseFilters(searchParams);
+  // parseFilters defaults `usage` to "photo" to match the client UI's default
+  // view. This endpoint is a full-pool feed, so an absent usage param means
+  // "no usage filter" here, not "photo" — otherwise cine lenses never reach the
+  // client, which filters locally. An explicit `u` param is still honoured for
+  // a future move to backend-driven filtering.
+  if (searchParams.get("u") === null) {
+    filters.usage = null;
+  }
   const filtered = filterLenses(allLenses, filters);
   const sorted = sortLenses(filtered, filters.sort, filters.sortDir);
 

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -47,11 +47,13 @@ export default function LensListClient() {
     return <LensesLoading />;
   }
 
+  // `usage` (photo/cine) is a view mode, not a filter dimension, so it is left
+  // out of the active-filter count and the reset trigger. Reset still returns
+  // usage to its default via defaultFilters below.
   const hasActiveFilters =
     filters.brands.length > 0 ||
     filters.typeFilter !== null ||
     filters.focusFilter !== null ||
-    filters.usage !== defaultFilters.usage ||
     filters.opticalTrait !== null ||
     filters.focusMotorClass !== null ||
     filters.focalCategories.length > 0 ||
@@ -61,7 +63,6 @@ export default function LensListClient() {
     filters.brands.length > 0,
     filters.typeFilter !== null,
     filters.focusFilter !== null,
-    filters.usage !== defaultFilters.usage,
     filters.opticalTrait !== null,
     filters.focusMotorClass !== null,
     filters.focalCategories.length > 0,


### PR DESCRIPTION
## Problem

Selecting **Cine** under the *Usage* filter returned **0 lenses**, even though the catalog has 10 cine lenses.

Root cause is a double-filtering mismatch:

- The list endpoint (`/api/lenses`) is a full-pool feed the client filters locally, but it ran `parseFilters` on a URL that carries no filter params. `usage` then fell back to its UI default `"photo"`, so the server pre-filtered the pool and **stripped all cine lenses before they reached the client**.
- The client received only photo lenses, so its own `usage: "cine"` filter had nothing to match → 0 results. Photo worked only because filtering a photo-only pool by photo is a no-op.

A secondary oddity: picking **Cine** spawned the *Reset* badge while **Photo** did not, because `usage` was counted as an active filter against its default.

## Changes

- **API** (`route.ts`): an absent `u` param now means *no usage filter* (serve the full pool), not *photo*. An explicit `u` is still honoured, so the server-side filter/sort/paginate pipeline stays intact for a future move to backend-driven filtering.
- **UI** (`LensListClient.tsx`): exclude `usage` (photo/cine) from the active-filter count and the reset trigger. It is a view mode, not a filter dimension. Reset still returns `usage` to its default.

The Cine toggle stays in the panel, so it keeps signalling that the site carries cinema lenses (discoverability).

## Test plan

Verified locally against `localhost:3000` (X mount):

| Action | Count | Reset badge |
| --- | --- | --- |
| Default (Photo) | 159 | hidden |
| Select Cine | **10** (was 0) | hidden |
| Cine + brand (Fuji) | — | "Reset 1" (brand only) |
| Click Reset | 159, back to Photo | hidden |

API responses: no param → 169 (incl. 10 cine); `u=cine` → 10; `u=photo` → 159.

`tsc`/`eslint` clean on the changed files (the pre-existing `api/track/route.ts` CloudflareEnv error is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)