### PR TITLE
fix(collections): flesh out Chinese collection descriptions, reword AF short

### DIFF
--- a/src/data/collections.json
+++ b/src/data/collections.json
@@ -608,7 +608,7 @@
       },
       "description": {
         "en": "The manual-focus primes from Chinese makers like 7Artisans, TTArtisan and Brightin Star that open all the way to f/1.2–f/1.4. Mostly all-metal builds with a well-damped focus throw; wide open, they give you genuinely shallow depth of field and real low-light headroom. For anyone who wants the fast-aperture look and doesn't mind focusing by hand, it's an inexpensive way in.",
-        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦里，最大光圈做到 f/1.2–1.4 的一批。多为全金属机械手感，对焦阻尼讲究，开到最大光圈就有明显的浅景深和扎实的暗光余量。想低成本玩玩大光圈的虚化和氛围、又不介意手动对焦，这一档很合适。"
+        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦里，最大光圈做到 f/1.2–1.4 的一批。多为全金属机械手感，对焦阻尼讲究，开到最大光圈，浅景深明显，暗光下也更从容。想低成本玩玩大光圈的虚化和氛围、又不介意手动对焦，这一档很合适。"
       },
       "shortDescription": {
         "en": "Fast f/1.2–f/1.4 manual primes",

--- a/src/data/collections.json
+++ b/src/data/collections.json
@@ -592,12 +592,12 @@
         "zh": "国产自动对焦定焦"
       },
       "description": {
-        "en": "Native autofocus primes from Chinese makers like Viltrox, 7Artisans and TTArtisan. Backed by solid optics and aggressively competitive pricing, this corner of the market has grown fast, giving X-mount shooters far more AF choices than they used to have.",
-        "zh": "唯卓仕、七工匠、铭匠等国产品牌推出的原生自动对焦定焦合集。凭借扎实的光学素质与极具竞争力的定价，这类 AF 镜头正在快速壮大，为 X 卡口用户提供了远超以往的自动对焦选择。"
+        "en": "Native autofocus primes from Chinese makers like Viltrox, 7Artisans and TTArtisan. A few years ago this corner barely existed; today it spans featherweight everyday primes to flagship f/1.2 optics, with focus motors edging closer to first-party speed each generation. Backed by solid optics and competitive pricing, it gives X-mount shooters far more native AF choice than the first-party lineup alone.",
+        "zh": "唯卓仕、七工匠、铭匠等国产品牌推出的原生自动对焦定焦合集。从轻巧的日常定焦到 f/1.2 旗舰都已覆盖，对焦马达也在一代代逼近原厂。凭借扎实的光学素质与极具竞争力的定价，这类 AF 镜头正在快速壮大，为 X 卡口用户提供了远超以往的自动对焦选择。"
       },
       "shortDescription": {
-        "en": "Native AF glass from Chinese makers",
-        "zh": "国产副厂自动头"
+        "en": "From entry primes to flagship f/1.2",
+        "zh": "从入门到 f/1.2 旗舰"
       }
     },
     {
@@ -607,8 +607,8 @@
         "zh": "国产大光圈手动定焦"
       },
       "description": {
-        "en": "The manual primes from Chinese makers like 7Artisans, TTArtisan and Brightin Star that open to f/1.2–f/1.4 — mostly all-metal builds, with the shallow depth of field and low-light reach to match.",
-        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦里，最大光圈做到 f/1.2–1.4 的一批，多为全金属机械手感，浅景深与暗光表现都不缺。"
+        "en": "The manual-focus primes from Chinese makers like 7Artisans, TTArtisan and Brightin Star that open all the way to f/1.2–f/1.4. Mostly all-metal builds with a well-damped focus throw; wide open, they give you genuinely shallow depth of field and real low-light headroom. For anyone who wants the fast-aperture look and doesn't mind focusing by hand, it's an inexpensive way in.",
+        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦里，最大光圈做到 f/1.2–1.4 的一批。多为全金属机械手感，对焦阻尼讲究，开到最大光圈就有明显的浅景深和扎实的暗光余量。想低成本玩玩大光圈的虚化和氛围、又不介意手动对焦，这一档很合适。"
       },
       "shortDescription": {
         "en": "Fast f/1.2–f/1.4 manual primes",
@@ -622,8 +622,8 @@
         "zh": "国产超平价手动定焦"
       },
       "description": {
-        "en": "Manual primes from Chinese makers like 7Artisans, TTArtisan and Brightin Star, in every flavor — mostly all-metal mechanical builds at prices low enough to work through different focal lengths and rendering styles without much outlay.",
-        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦数量众多、风格各异，多为全金属机械手感，价格亲民——最适合用来低成本地把不同焦段和味道挨个玩一遍。"
+        "en": "Manual primes from Chinese makers like 7Artisans, TTArtisan and Brightin Star — and there are a lot of them, in every focal length and rendering style, mostly all-metal. Prices run low enough that picking up a focal length you've never shot, or a look you're curious about, costs very little. The easy, cheap way to work through different focal lengths and rendering styles by hand.",
+        "zh": "七工匠、铭匠、星曜这些国产品牌的手动定焦数量众多、风格各异，多为全金属机械手感，价格却低到可以随手入。焦段从超广到中长都有，几百块就能添一支没玩过的焦段或没试过的成像风格——最适合用来低成本地把不同焦段和味道挨个试一遍。"
       },
       "shortDescription": {
         "en": "A pure manual experience at a friendly price",


### PR DESCRIPTION
## What

Copy-only follow-up to #325 (the Chinese Lens Brands section).

### 1. Descriptions padded to peer length

The four Chinese-brand collections had noticeably shorter long descriptions than the rest of the catalog (en ~195–253 vs the usual ~320–405). Expanded three of them to comparable length, keeping the understated voice and adding real substance rather than filler:

- **chinese-af** — the range (entry primes → flagship f/1.2) and the focus-motor-improving-each-generation context
- **chinese-mf-fast** — what a fast manual prime is actually for (shallow DOF, low-light, deliberate manual focus)
- **chinese-mf-budget** — the "work through focal lengths cheaply, by hand" pitch, in the original value-mf voice

`chinese-mf-095` was already at peer length and is unchanged.

### 2. Short-description / phrasing fixes

- **chinese-af short**: `国产副厂自动头` merely restated the title (and dropped "定焦") → `从入门到 f/1.2 旗舰` / "From entry primes to flagship f/1.2", matching the value-prop style of its siblings.
- **chinese-mf-fast (zh)**: reworded the stiff `浅景深与暗光表现都不缺` into a more natural line.

All copy keeps the honest `多为全金属 / mostly all-metal` hedge (build material is unrecorded for most lenses; see #325).

## Test plan

- [x] `vitest` collections suite — 41 passed
- [x] JSON valid
- [x] Rendered zh locally: chinese-af card shows the new short; chinese-mf-fast detail page shows the reworded description

🤖 Generated with [Claude Code](https://claude.com/claude-code)