### PR TITLE
docs(readme): note the former X-Glass name under the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Atlens
 
+> Formerly X-Glass.
+
 Browse, filter, and compare Fujifilm X-mount lenses — native Fujifilm glass plus a growing set of third-party brands. G-mount (medium format) is also being added.
 
 **English**：[atlens.app/en](https://atlens.app/en)


### PR DESCRIPTION
Adds a single anchor line under the README title so visitors who knew the project as **X-Glass** — and search for that name — can confirm they're in the right place after the rename to Atlens.

```
# Atlens

> Formerly X-Glass.
```

Follow-up to #328. README prose otherwise stays focused on the product; this is the one place the former name is surfaced for discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)