### PR TITLE
fix(retailers): clip dropdown hover to rounded corners, fill full row

### DIFF
--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -48,7 +48,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner side="bottom" align="start" sideOffset={6}>
-          <Popover.Popup className="w-[var(--anchor-width)] origin-(--transform-origin) rounded-lg border border-zinc-200 bg-white py-1 shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
+          <Popover.Popup className="w-[var(--anchor-width)] origin-(--transform-origin) overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
             {links.map((link) => (
               <DropdownItem key={link.channel} link={link} lensId={lens.id} customId={customId} />
             ))}


### PR DESCRIPTION
## Bug

In the retailers \"Buy at\" dropdown, hovering the first/last item left a white strip above/below the gray hover background, and the square hover rectangle bled past the popup's rounded corners.

## Root cause

`Popover.Popup` had `rounded-lg` + `py-1` but **no `overflow-hidden`**:
- `py-1` inset the first/last item ~4px from the popup edge, so the hover bg never reached the top/bottom edge.
- without `overflow-hidden`, the item's square hover rectangle was not clipped to the rounded corners.

## Fix

Drop `py-1` (items sit flush to the popup edge) and add `overflow-hidden`, so the hover background fills the full row and is clipped to the rounded corners. This matches `Nav` and `MountSwitcher`, which already pair their rounded menu popup with `overflow-hidden`.

## Why this keeps recurring

There is no shared menu/menu-item primitive — every dropdown hand-rolls its own popup className, so the correct `overflow-hidden` (+ flush items) has to be remembered each time. Most menus have it; this one didn't. The durable fix is a shared menu-popup token/component; tracked separately.

## Test

Verified locally (GeoIP cookie + real hover): first item now flush to popup top (1px border only), `overflow: hidden`, hover gray fills the full 40px row with rounded top corners clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)