### PR TITLE
refactor(ui): unify popup surface across menus + selects

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -16,6 +16,7 @@ import { useNav } from "@/context/NavContext";
 import { usePwa } from "@/lib/usePwa";
 import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
+import { MENU_POPUP_CLS } from "@/lib/ui-tokens";
 import MountSwitcher from "@/components/MountSwitcher";
 import FeedbackDialog from "@/components/FeedbackDialog";
 import GitHubMark from "@/components/logos/GitHubMark";
@@ -188,7 +189,7 @@ export default function Nav() {
             </Menu.Trigger>
             <Menu.Portal>
               <Menu.Positioner side="bottom" align="end" sideOffset={6} className="z-50 sm:hidden">
-                <Menu.Popup className="w-36 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-lg shadow-zinc-950/10 overflow-hidden origin-(--transform-origin) duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+                <Menu.Popup className={cn(MENU_POPUP_CLS, "w-36")}>
                   <Menu.LinkItem
                     render={<Link href="/about" />}
                     className={mobileLinkCls(pathname === "/about")}

--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -7,9 +7,10 @@ import { ArrowUpRight, ChevronDown, Info } from "lucide-react";
 import { buildPurchaseLinks } from "@/lib/purchase-links";
 import type { PurchaseLink } from "@/lib/purchase-links";
 import type { Lens } from "@/lib/types";
-import { ACTION_OUTLINE_CLS } from "@/lib/ui-tokens";
+import { ACTION_OUTLINE_CLS, MENU_POPUP_CLS } from "@/lib/ui-tokens";
 import { track } from "@/lib/analytics";
 import { useCountryCode } from "@/hooks/useCountryCode";
+import { cn } from "@/lib/utils";
 
 interface Props {
   lens: Lens;
@@ -48,7 +49,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner side="bottom" align="start" sideOffset={6}>
-          <Popover.Popup className="w-[var(--anchor-width)] origin-(--transform-origin) overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 dark:border-zinc-700 dark:bg-zinc-900">
+          <Popover.Popup className={cn(MENU_POPUP_CLS, "w-[var(--anchor-width)]")}>
             {links.map((link) => (
               <DropdownItem key={link.channel} link={link} lensId={lens.id} customId={customId} />
             ))}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 
 import { cn } from "@/lib/utils";
+import { POPUP_SURFACE_CLS } from "@/lib/ui-tokens";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
 const Select = SelectPrimitive.Root;
@@ -91,7 +92,8 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto [scrollbar-width:thin] [scrollbar-color:rgb(212_212_216)_transparent] dark:[scrollbar-color:rgb(63_63_70)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-300/70 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700/70 rounded-lg border border-zinc-200 bg-white text-popover-foreground shadow-lg shadow-zinc-950/10 dark:border-zinc-800 dark:bg-zinc-950 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto [scrollbar-width:thin] [scrollbar-color:rgb(212_212_216)_transparent] dark:[scrollbar-color:rgb(63_63_70)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-300/70 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700/70 text-popover-foreground duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            POPUP_SURFACE_CLS,
             className
           )}
           {...props}

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -134,3 +134,23 @@ export const UTILITY_BTN_CLS =
   "inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs " +
   "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 " +
   "dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 transition-colors";
+
+/**
+ * Full-bleed dropdown / menu popup (base-ui `Menu.Popup` or `Popover.Popup`)
+ * whose children are edge-to-edge hoverable rows.
+ *
+ * `overflow-hidden` is REQUIRED and is the whole reason this is centralised:
+ * it clips the first/last row's hover background to the rounded corners. Pair
+ * it with rows that carry NO popup-level vertical padding — a `py-*` on the
+ * popup leaves a strip the row hover can never fill. Forgetting either is the
+ * recurring "hover doesn't reach the edge / full height" bug.
+ *
+ * Compose width / anchor sizing per call site via `cn()`. Does not apply to
+ * the inset rounded-pill item menu style (e.g. brand filter, select).
+ */
+export const MENU_POPUP_CLS =
+  "overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-lg " +
+  "origin-(--transform-origin) duration-100 " +
+  "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 " +
+  "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 " +
+  "dark:border-zinc-700 dark:bg-zinc-900";

--- a/src/lib/ui-tokens.ts
+++ b/src/lib/ui-tokens.ts
@@ -136,6 +136,15 @@ export const UTILITY_BTN_CLS =
   "dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 transition-colors";
 
 /**
+ * Shared visual surface for every popup / overlay — border, radius, fill,
+ * shadow, and their dark-mode equivalents. Single source so menus, selects,
+ * and tooltips can't drift apart (the dark shades in particular). Compose with
+ * each popup's own behaviour (overflow, scroll, animation, padding).
+ */
+export const POPUP_SURFACE_CLS =
+  "rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900";
+
+/**
  * Full-bleed dropdown / menu popup (base-ui `Menu.Popup` or `Popover.Popup`)
  * whose children are edge-to-edge hoverable rows.
  *
@@ -146,11 +155,10 @@ export const UTILITY_BTN_CLS =
  * recurring "hover doesn't reach the edge / full height" bug.
  *
  * Compose width / anchor sizing per call site via `cn()`. Does not apply to
- * the inset rounded-pill item menu style (e.g. brand filter, select).
+ * the inset rounded-pill item menu style (e.g. brand filter).
  */
 export const MENU_POPUP_CLS =
-  "overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-lg " +
-  "origin-(--transform-origin) duration-100 " +
+  POPUP_SURFACE_CLS + " " +
+  "overflow-hidden origin-(--transform-origin) duration-100 " +
   "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 " +
-  "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 " +
-  "dark:border-zinc-700 dark:bg-zinc-900";
+  "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";


### PR DESCRIPTION
Follow-up to #331 (the one-line fix). Rebased onto main now that #331 is merged.

## Why

The "hover doesn't fill the row / reach the rounded edge" bug keeps recurring because every dropdown hand-rolls its own popup className, so the recipe (`overflow-hidden` + no popup vertical padding) and the surface chrome have to be remembered each time — and they drift.

## What

Two shared tokens in `ui-tokens.ts`:

- **`POPUP_SURFACE_CLS`** — the visual surface every popup shares (border / radius / fill / shadow + dark equivalents).
- **`MENU_POPUP_CLS`** — `POPUP_SURFACE_CLS` + the full-bleed-menu behaviour (`overflow-hidden`, origin, zoom anims), with a doc comment on *why* `overflow-hidden` is mandatory.

Migrations:
- `RetailersDropdown` (Popover) and `Nav` mobile menu (Menu) → `MENU_POPUP_CLS`.
- `ui/select.tsx` `SelectContent` → composes `POPUP_SURFACE_CLS`, covering all four Select consumers in one shot: **MountSwitcher, LensSortControl (sort), FeedbackDialog, TestHookPanel**.

## What this fixes / normalizes

- The Select popup was the only real drift left: `dark:bg-zinc-950` / `dark:border-zinc-800` + a colored shadow, vs `zinc-900` / `zinc-700` everywhere else. Now unified.
- Nav popup normalized too (`rounded-lg` not `-xl`, dark colors, plain shadow).

Note: MountSwitcher and the sort control did **not** have the visible hover bug — they were already patched per-usage with `overflow-hidden` + `rounded-none` items (the sort control even carries a comment about it, which is itself evidence of the recurrence). This PR's value for them is surface consistency + a single source so it can't drift again.

Out of scope (different style, already dark-consistent): `BrandFilterMenu` and the tooltip popovers (`PriceSection`, `field-note-popover`).

## Test

Verified locally (1440px + 390px): RetailersDropdown hover fills row with clipped rounded corners; Nav mobile menu renders normalized; sort + mount-switcher select popups now carry `dark:bg-zinc-900` / `dark:border-zinc-700` (no `zinc-950/800`), keep their own radius/overflow, light mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)