### PR TITLE
feat(data): publish lens data 2026.05.31 build 1

### DIFF
--- a/src/data/lenses.json
+++ b/src/data/lenses.json
@@ -11849,7 +11849,7 @@
     "af": true,
     "ois": false,
     "wr": false,
-    "apertureRing": true,
+    "apertureRing": false,
     "powerZoom": false,
     "focusMotor": "STM",
     "weightG": [
@@ -11932,7 +11932,7 @@
     "af": true,
     "ois": false,
     "wr": false,
-    "apertureRing": true,
+    "apertureRing": false,
     "powerZoom": false,
     "focusMotor": "STM+Lead screw",
     "weightG": 210,
@@ -12116,7 +12116,7 @@
     "af": true,
     "ois": false,
     "wr": false,
-    "apertureRing": true,
+    "apertureRing": false,
     "powerZoom": false,
     "focusMotor": "STM+Lead screw",
     "weightG": [
@@ -12216,7 +12216,7 @@
     "af": true,
     "ois": false,
     "wr": false,
-    "apertureRing": true,
+    "apertureRing": false,
     "powerZoom": false,
     "focusMotor": "STM+Lead screw",
     "weightG": [

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026.05.30",
-  "lastUpdated": "2026-05-30T14:35:58.726Z",
+  "version": "2026.05.31",
+  "lastUpdated": "2026-05-31T14:16:51.926Z",
   "lensCount": 196,
-  "buildNumber": 2
+  "buildNumber": 1
 }


### PR DESCRIPTION
## Summary

Automated publish from `atlens-pipeline`.

- **Version**: `2026.05.31` build 1
- **X-mount lenses** (`lenses.json`): 169
- **G-mount lenses** (`lenses-gfx.json`): 27
- **Blocked** (validation gate failures, see pipeline logs): 19

## Test plan

- [ ] CI green (typecheck, tests, build)
- [ ] Vercel preview renders without runtime errors
- [ ] Spot-check a few changed lens detail pages

🤖 Generated by `tsx scripts/cli.ts publish`