### PR TITLE
feat(feedback): distinguishable issue titles + broader success copy

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -20,7 +20,25 @@ interface FeedbackPayload {
 
 const MAX_DESCRIPTION_LENGTH = 2000;
 
+// Max length (in code points) of the description snippet used as an issue title.
+const TITLE_SNIPPET_MAX = 60;
+
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 5 });
+
+// Collapse a (possibly multi-line) description into a single-line title snippet,
+// truncating at a word boundary with an ellipsis when it exceeds the limit.
+// Returns "" for a blank description so the caller can fall back to a label.
+function titleSnippet(description: string): string {
+  const oneLine = description.replace(/\s+/g, " ").trim();
+  const chars = Array.from(oneLine);
+  if (chars.length <= TITLE_SNIPPET_MAX) {
+    return oneLine;
+  }
+  const cut = chars.slice(0, TITLE_SNIPPET_MAX).join("");
+  const lastSpace = cut.lastIndexOf(" ");
+  const trimmed = lastSpace > TITLE_SNIPPET_MAX * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return `${trimmed.trimEnd()}…`;
+}
 
 function buildIssue(payload: FeedbackPayload): {
   title: string;
@@ -72,10 +90,13 @@ function buildIssue(payload: FeedbackPayload): {
     title = context?.field
       ? `[Data] ${base} — ${context.field}`
       : `[Data] ${base}`;
+  } else if (context?.searchQuery) {
+    title = `[Feedback] Missing lens: ${context.searchQuery}`;
   } else {
-    title = context?.searchQuery
-      ? `[Feedback] Missing lens: ${context.searchQuery}`
-      : `[Feedback] General feedback`;
+    // Use a one-line snippet of the description so general-feedback issues are
+    // distinguishable in the list instead of all sharing one title.
+    const snippet = titleSnippet(description);
+    title = snippet ? `[Feedback] ${snippet}` : `[Feedback] General feedback`;
   }
 
   const labels = ["user-feedback", `feedback:${type}`];

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -467,7 +467,7 @@
     "cancel": "Cancel",
     "close": "Close",
     "success": "Got it — thank you!",
-    "successBody": "Every piece of feedback helps me make the data more accurate and complete.",
+    "successBody": "Every piece of feedback helps me make Atlens better.",
     "error": "Something went wrong. Please try again in a bit.",
     "emailLabel": "Atlens official email"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -467,7 +467,7 @@
     "cancel": "取消",
     "close": "关闭",
     "success": "收到了，谢谢！",
-    "successBody": "每一条反馈都在帮助我让数据更准确、更完整。",
+    "successBody": "每一条反馈都在帮助我把 Atlens 做得更好。",
     "error": "提交时出了点问题，请稍后再试。",
     "emailLabel": "Atlens 官方邮箱"
   },


### PR DESCRIPTION
## Problem

- Every general-feedback GitHub issue was titled `[Feedback] General feedback`, so they're indistinguishable in the issue list.
- The post-submit thank-you said feedback helps make "the data more accurate and complete" — too narrow, since the same form explicitly invites ideas, bugs, and feature requests.

## Changes

- **Issue title** (`api/feedback/route.ts`): for general feedback without a search query, derive the title from a one-line, word-boundary-truncated snippet of the description (≤60 code points, `…` when cut). Multi-line descriptions collapse to a single line; a blank description falls back to the old `[Feedback] General feedback` label. Missing-lens and data-issue titles are unchanged.
- **Success copy** (`zh.json` / `en.json`): "…make the data more accurate and complete" → "…make Atlens better" (zh: 保留原句式，仅替换过窄的尾巴).

## Test

`titleSnippet` verified on short / long-English / Chinese / multi-line / empty inputs (word-boundary cut, whitespace collapse, blank → fallback). Both message files parse; route lints and typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)