### PR TITLE
feat(feedback): warmer success copy + tighter spacing

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -211,12 +211,14 @@ export default function FeedbackDialog({
         {status === "success" ? (
           <div className="flex flex-col items-center gap-3 px-5 py-6">
             <Iris config={IRIS_FEEDBACK} uid="feedback-iris" />
-            <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">
-              {t("success")}
-            </p>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400 text-center leading-relaxed">
-              {t("successBody")}
-            </p>
+            <div className="flex flex-col items-center gap-1">
+              <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                {t("success")}
+              </p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 text-center leading-relaxed">
+                {t("successBody")}
+              </p>
+            </div>
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-4">

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -466,8 +466,8 @@
     "submitting": "Submitting…",
     "cancel": "Cancel",
     "close": "Close",
-    "success": "Thanks for the great suggestion!",
-    "successBody": "Every piece of your feedback helps make Atlens better, together.",
+    "success": "Thanks for the awesome feedback!",
+    "successBody": "Every bit of feedback helps me make Atlens better.",
     "error": "Something went wrong. Please try again in a bit.",
     "emailLabel": "Atlens official email"
   },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -466,8 +466,8 @@
     "submitting": "Submitting…",
     "cancel": "Cancel",
     "close": "Close",
-    "success": "Got it — thank you!",
-    "successBody": "Every piece of feedback helps me make Atlens better.",
+    "success": "Thanks for the great suggestion!",
+    "successBody": "Every piece of your feedback helps make Atlens better, together.",
     "error": "Something went wrong. Please try again in a bit.",
     "emailLabel": "Atlens official email"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -466,8 +466,8 @@
     "submitting": "提交中…",
     "cancel": "取消",
     "close": "关闭",
-    "success": "收到了，谢谢！",
-    "successBody": "每一条反馈都在帮助我把 Atlens 做得更好。",
+    "success": "感谢你的超棒建议！",
+    "successBody": "你的每一条反馈，都在和我一起让 Atlens 变得更好。",
     "error": "提交时出了点问题，请稍后再试。",
     "emailLabel": "Atlens 官方邮箱"
   },


### PR DESCRIPTION
## Changes

- **Copy** (zh/en): warmer, collaborative post-submit confirmation. zh chosen by maintainer (`感谢你的超棒建议！` / `你的每一条反馈，都在和我一起让 Atlens 变得更好。`); en mirrors it.
- **Spacing**: the success block used `gap-3` for Iris + title + subtitle, leaving the title 12px from the subtitle. Wrapped the two text lines in their own `gap-1` group so they read as one pair (Iris-to-text spacing unchanged).

## Test

Verified locally: forced the success state (mocked the POST), confirmed the new copy renders and the title→subtitle gap is now 4px (was 12px). Both message files parse; component lints + typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)