### PR TITLE
refactor: photo/cine as a section-nav view switch, not a filter

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -19,8 +19,8 @@ import {
 import { getLensesByMount } from "@/lib/lens-data";
 import { urlSegmentToMount, mountHasCollections } from "@/lib/mount";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
-import { ACTION_PRIMARY_CLS, LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
-import LensSectionNav from "@/components/LensSectionNav";
+import { ACTION_PRIMARY_CLS } from "@/lib/ui-tokens";
+import LensIndexShell from "@/components/LensIndexShell";
 import CollectionChipRail from "@/components/CollectionChipRail";
 
 type Params = Promise<{ locale: string; mount: string }>;
@@ -100,27 +100,21 @@ export default async function CollectionsIndexPage({
   const totalLenses = mountLenses.length;
 
   return (
-    <main className={`${LENS_INDEX_SHELL_CLS} pt-4 pb-16 sm:pt-8`}>
-      {/* Switcher + summary. The switcher is the first child and shares the
-          page's top padding, so it lands at the same position as the browse
-          tabs. The summary sits closer to the chip rail it describes than to
-          the tab divider above. The descriptive, keyword-rich title stays as
-          an sr-only h1 for SEO (mirroring the browse page); the visible header
-          is a one-line summary the tab label can't convey — collection and
-          lens counts — plus a short categorization subtitle. */}
-      <header id="collections-top" className="flex flex-col gap-5 pb-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <LensSectionNav />
-        </div>
-        <div>
-          <h1 className="sr-only">{t("indexTitle")}</h1>
-          <p className="text-[15px] font-medium text-zinc-900 dark:text-zinc-100">
-            {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
-          </p>
-          <p className="mt-1 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-            {t("indexSubtitle")}
-          </p>
-        </div>
+    <LensIndexShell className="pb-16">
+      <main className="pt-5">
+      {/* The section nav and its position are owned by LensIndexShell, so the
+          tab row lands identically to the browse view. The summary keeps the
+          keyword-rich title as an sr-only h1 for SEO (mirroring the browse
+          page); the visible header is a one-line summary the tab label can't
+          convey — collection and lens counts — plus a short subtitle. */}
+      <header id="collections-top" className="pb-3">
+        <h1 className="sr-only">{t("indexTitle")}</h1>
+        <p className="text-[15px] font-medium text-zinc-900 dark:text-zinc-100">
+          {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
+        </p>
+        <p className="mt-1 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+          {t("indexSubtitle")}
+        </p>
       </header>
 
       {/* Sticky chip rail */}
@@ -203,6 +197,7 @@ export default async function CollectionsIndexPage({
           <ArrowRight size={15} aria-hidden="true" />
         </Link>
       </footer>
-    </main>
+      </main>
+    </LensIndexShell>
   );
 }

--- a/src/components/LensFilters.tsx
+++ b/src/components/LensFilters.tsx
@@ -4,8 +4,8 @@ import { useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown, RotateCcw, SlidersHorizontal } from "lucide-react";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
-import { defaultFilters, FILTER_FEATURE_KEYS, FOCAL_CATEGORIES, LENS_TYPES } from "@/lib/lens";
-import type { FilterState, FocusFilter, FocusMotorClass, LensType, UsageFilter } from "@/lib/lens";
+import { FILTER_FEATURE_KEYS, FOCAL_CATEGORIES, LENS_TYPES } from "@/lib/lens";
+import type { FilterState, FocusFilter, FocusMotorClass, LensType } from "@/lib/lens";
 import type { OpticalTrait } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { TEXT_LINK_CLS } from "@/lib/ui-tokens";
@@ -92,11 +92,6 @@ export default function LensFilters({
     })),
   ] as { value: LensType | null; label: string }[];
 
-  const usageOptions = [
-    { value: "photo" as UsageFilter, label: t("usagePhoto") },
-    { value: "cine" as UsageFilter, label: t("usageCine") },
-  ] as { value: UsageFilter; label: string }[];
-
   const opticalTraitOptions = [
     { value: null as OpticalTrait | null, label: t("allTypes") },
     ...availableOpticalTraits.map((trait) => ({
@@ -134,7 +129,6 @@ export default function LensFilters({
   ] as { value: FocusFilter | null; label: string }[];
 
   const moreFiltersCount =
-    (filters.usage !== defaultFilters.usage ? 1 : 0) +
     (filters.focalCategories.length > 0 ? 1 : 0) +
     (filters.features.length > 0 ? 1 : 0) +
     (filters.opticalTrait !== null ? 1 : 0) +
@@ -332,19 +326,6 @@ export default function LensFilters({
 
             <FilterRow label={t("features")}>
               <FeatureToggleGroup options={featureOptions} />
-            </FilterRow>
-
-            <FilterRow label={t("usage")} labelOn="desktop">
-              <TypeSegmentedControl
-                ariaLabel={t("usage")}
-                options={usageOptions}
-                value={filters.usage}
-                onChange={(v) => updateFilters("usage", v)}
-                mobileLabelOverrides={{
-                  photo: t("usagePhotoMobile"),
-                  cine: t("usageCineMobile"),
-                }}
-              />
             </FilterRow>
 
             {availableOpticalTraits.length > 0 && (

--- a/src/components/LensIndexShell.tsx
+++ b/src/components/LensIndexShell.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
+import { cn } from "@/lib/utils";
+import LensSectionNav from "./LensSectionNav";
+
+/**
+ * Shared outer shell for the two tab-bearing lens index views (All Lenses and
+ * Collections). It owns the section nav's position — horizontal width/padding
+ * and top offset — in a single place, so the tab row sits at the exact same
+ * spot on both routes and never shifts when the user switches tabs. Each page
+ * passes its own bottom padding via `className` and renders its page-specific
+ * content (filters, summaries, grids) as children below the nav, where
+ * differing spacing is harmless because it cannot move the nav.
+ */
+export default function LensIndexShell({
+  navRightSlot,
+  className,
+  children,
+}: {
+  navRightSlot?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn(`${LENS_INDEX_SHELL_CLS} flex flex-col pt-4 sm:pt-8`, className)}>
+      <LensSectionNav rightSlot={navRightSlot} />
+      {children}
+    </div>
+  );
+}

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -19,9 +19,9 @@ import { useUiHookAttr } from "@/context/TestHookProvider";
 import BackToTopButton from "@/components/BackToTopButton";
 import LensCard from "./LensCard";
 import LensFilters from "./LensFilters";
-import LensSectionNav from "./LensSectionNav";
+import LensIndexShell from "./LensIndexShell";
+import LensUsageSwitch from "./LensUsageSwitch";
 import LensSortControl from "./LensSortControl";
-import { LENS_INDEX_SHELL_CLS } from "@/lib/ui-tokens";
 import LensSearchDialog from "./LensSearchDialog";
 import FeedbackTrigger from "./FeedbackTrigger";
 
@@ -77,14 +77,24 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
   }
 
   function clearAllFilters() {
-    updateFilters(defaultFilters);
+    // Reset clears refinements but preserves the photo/cine view mode — usage
+    // is a view partition, not a filter, so leaving the current view intact
+    // mirrors how switching tabs would not reset the user's filters.
+    updateFilters((current) => ({ ...defaultFilters, usage: current.usage }));
   }
 
   return (
     <>
-      <div className={`${LENS_INDEX_SHELL_CLS} flex flex-col pt-4 pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))] sm:pt-8`}>
-        <div className="flex flex-col gap-4">
-          <LensSectionNav />
+      <LensIndexShell
+        navRightSlot={
+          <LensUsageSwitch
+            value={filters.usage}
+            onChange={(usage) => updateFilters((current) => ({ ...current, usage }))}
+          />
+        }
+        className="pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))]"
+      >
+        <div className="pt-4">
           <LensFilters
             filters={filters}
             brands={brands}
@@ -187,7 +197,7 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
             </motion.div>
           )}
         </AnimatePresence>
-      </div>
+      </LensIndexShell>
 
       <BackToTopButton />
     </>

--- a/src/components/LensSectionNav.tsx
+++ b/src/components/LensSectionNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
 import { useEffectiveMount } from "@/hooks/useMountParam";
@@ -12,8 +13,13 @@ import { cn } from "@/lib/utils";
  * tabs sitting on a full-width divider — a deliberately different component
  * type from the filter pills below, so page-level view switching reads as
  * navigation, not as another refinement control.
+ *
+ * `rightSlot` rides the right edge of the same divider for view-mode controls
+ * that belong at the navigation tier rather than among the filters (e.g. the
+ * photo/cine switch). It shares the tab row's baseline but stays visually
+ * distinct from the refinement pills below.
  */
-export default function LensSectionNav() {
+export default function LensSectionNav({ rightSlot }: { rightSlot?: ReactNode }) {
   const t = useTranslations("Nav");
   const pathname = usePathname();
   const mount = useEffectiveMount();
@@ -33,29 +39,32 @@ export default function LensSectionNav() {
   return (
     <nav
       aria-label={t("lenses")}
-      className="flex w-full items-center gap-6 border-b border-zinc-200 dark:border-zinc-800"
+      className="flex w-full items-center border-b border-zinc-200 dark:border-zinc-800"
     >
-      {tabs.map((tab) => {
-        const selected = tab.key === active;
-        return (
-          <Link
-            key={tab.key}
-            href={tab.href}
-            aria-current={selected ? "page" : undefined}
-            className={cn(
-              // -mb-px pulls the 2px active indicator down to overlap the
-              // nav's 1px bottom border, so the underline reads as the tab's
-              // own indicator rather than a doubled rule.
-              "relative -mb-px flex items-center border-b-2 pb-3 pt-0.5 text-[15px] font-semibold transition-colors",
-              selected
-                ? "border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-50"
-                : "border-transparent text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
-            )}
-          >
-            {tab.label}
-          </Link>
-        );
-      })}
+      <div className="flex items-center gap-6">
+        {tabs.map((tab) => {
+          const selected = tab.key === active;
+          return (
+            <Link
+              key={tab.key}
+              href={tab.href}
+              aria-current={selected ? "page" : undefined}
+              className={cn(
+                // -mb-px pulls the 2px active indicator down to overlap the
+                // nav's 1px bottom border, so the underline reads as the tab's
+                // own indicator rather than a doubled rule.
+                "relative -mb-px flex items-center border-b-2 pb-3 pt-0.5 text-[15px] font-semibold transition-colors",
+                selected
+                  ? "border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-50"
+                  : "border-transparent text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
+              )}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+      {rightSlot ? <div className="ml-auto pb-2 pl-4">{rightSlot}</div> : null}
     </nav>
   );
 }

--- a/src/components/LensUsageSwitch.tsx
+++ b/src/components/LensUsageSwitch.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Camera, Video, type LucideIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import type { UsageFilter } from "@/lib/lens";
+
+/**
+ * Photo/Cine view-mode switch that rides the section-nav row, not the filter
+ * panel. Photo and cine are two largely-separate product universes — a top
+ * partition of the catalog, not a refinement — so this reads as a light text
+ * toggle (icon + label, divided by a hairline), deliberately quieter than the
+ * filter pills below. Both options carry their own icon at all times; the
+ * active one is emphasized by colour rather than a heavy pill.
+ */
+const OPTIONS: {
+  value: Exclude<UsageFilter, null>;
+  labelKey: string;
+  Icon: LucideIcon;
+}[] = [
+  { value: "photo", labelKey: "usagePhoto", Icon: Camera },
+  { value: "cine", labelKey: "usageCine", Icon: Video },
+];
+
+export default function LensUsageSwitch({
+  value,
+  onChange,
+}: {
+  value: UsageFilter;
+  onChange: (value: UsageFilter) => void;
+}) {
+  const t = useTranslations("LensList");
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t("usage")}
+      className="inline-flex items-center text-[12px]"
+    >
+      {OPTIONS.map((opt, index) => {
+        const selected = value === opt.value;
+        return (
+          <div key={opt.value} className="flex items-center">
+            {index > 0 && (
+              <span
+                aria-hidden="true"
+                className="mx-2 h-3 w-px bg-zinc-200 dark:bg-zinc-700"
+              />
+            )}
+            <button
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onChange(opt.value)}
+              className={cn(
+                "inline-flex items-center gap-1 font-medium transition-colors",
+                selected
+                  ? "text-zinc-900 dark:text-zinc-100"
+                  : "text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300",
+              )}
+            >
+              <opt.Icon className="size-3.5" aria-hidden="true" />
+              {t(opt.labelKey)}
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Photo/cine is a top partition of the catalog (a view mode), not a filter refinement — its default is non-null and selecting it never counted toward the active-filter badge. It nonetheless lived inside the filter panel, which muddied the semantics: it was excluded from the active-filter count yet included in the more-filters badge.

This moves the photo/cine control out of the filter panel onto the right edge of the **section-nav tab row** (next to All Lenses / Collections), styled as a small, muted view-mode toggle that reads differently from the filter pills.

## How

- **`usage` stays in `FilterState`** — filtering logic and `?u=` URL serialization are unchanged. Only the control's location and the more-filters count change, so the diff stays minimal.
- New **`LensUsageSwitch`** — a lightweight, de-emphasized photo/cine toggle (deliberately quieter than filter pills; the header is already control-heavy on mobile).
- New **`LensIndexShell`** — owns the tab row's position (horizontal shell width + top offset) in one place, shared by the All Lenses and Collections views, so the tab row sits at the exact same spot on both and never shifts when switching tabs. Previously the position was maintained by convention across two files (drift-prone).
- `LensFilters` drops the Usage row and the `usage` term from the more-filters count.
- Reset now **preserves the current view mode** (resetting filters shouldn't kick a user out of cine), consistent with treating usage as a view, not a filter.

The shared shell component (rather than hoisting the nav into the `(browse)` route-group layout) is the right granularity: that group also wraps the lens-detail and single-collection pages, which must not show the tabs.

## Test plan

- `npm run typecheck`, `npm run lint` (0 errors), `npm test` (360 passing)
- Nav position byte-identical across both views: desktop `{top:88,left:96.5,width:1232}`, mobile `{top:72,left:20,width:335}`
- Switch fits without wrap across mobile/desktop × zh/en
- Cine toggle filters the list (196→cine subset) and serializes to `?u=cine`
- Usage row absent from both the primary and secondary filter panels
- Switch shown only on browse, not on collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)