### PR TITLE
feat: scope all browse filters to photo-cine view + surface coverage link

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/browse/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/browse/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import { getOrderedUniqueBrands, getAvailableOpticalTraits } from "@/lib/lens";
 import { getLensesByMount } from "@/lib/lens-data";
 import { urlSegmentToMount } from "@/lib/mount";
 import LensListClient from "@/components/LensListClient";
@@ -58,8 +57,6 @@ export default async function LensesPage({ params }: { params: Params }) {
   const h1Title = resolvedMount === "X" ? t("metaTitleX") : t("metaTitleG");
 
   const allLenses = getLensesByMount(resolvedMount, locale);
-  const brands = getOrderedUniqueBrands(allLenses);
-  const availableOpticalTraits = getAvailableOpticalTraits(allLenses);
 
   return (
     <>
@@ -70,11 +67,7 @@ export default async function LensesPage({ params }: { params: Params }) {
           anchor. */}
       <h1 className="sr-only">{h1Title}</h1>
       <Suspense fallback={<LensesLoading />}>
-        <LensListClient
-          lenses={allLenses}
-          brands={brands}
-          availableOpticalTraits={availableOpticalTraits}
-        />
+        <LensListClient lenses={allLenses} />
       </Suspense>
     </>
   );

--- a/src/components/LensFilters.tsx
+++ b/src/components/LensFilters.tsx
@@ -4,8 +4,8 @@ import { useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown, RotateCcw, SlidersHorizontal } from "lucide-react";
 import { FEATURE_ICONS } from "@/lib/feature-icons";
-import { FILTER_FEATURE_KEYS, FOCAL_CATEGORIES, LENS_TYPES } from "@/lib/lens";
-import type { FilterState, FocusFilter, FocusMotorClass, LensType } from "@/lib/lens";
+import { FOCAL_CATEGORIES } from "@/lib/lens";
+import type { AvailableFilterOptions, FilterState, FocusFilter, FocusMotorClass, LensType } from "@/lib/lens";
 import type { OpticalTrait } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { TEXT_LINK_CLS } from "@/lib/ui-tokens";
@@ -19,8 +19,8 @@ import { useFiltersTelemetry } from "./LensFilters.telemetry";
 
 interface Props {
   filters: FilterState;
-  brands: string[];
-  availableOpticalTraits: OpticalTrait[];
+  /** Option values present in the current scope; every control narrows to these. */
+  available: AvailableFilterOptions;
   onFiltersChange: (filters: FilterState) => void;
   hasActiveFilters: boolean;
   activeFilterCount: number;
@@ -31,8 +31,7 @@ interface Props {
 
 export default function LensFilters({
   filters,
-  brands,
-  availableOpticalTraits,
+  available,
   onFiltersChange,
   hasActiveFilters,
   activeFilterCount,
@@ -46,7 +45,7 @@ export default function LensFilters({
 
   const BRAND_PREVIEW_LIMIT = 2;
   const brandJoiner = t("brandSeparator");
-  const brandNames = Object.fromEntries(brands.map((b) => [b, tBrand(b)]));
+  const brandNames = Object.fromEntries(available.brands.map((b) => [b, tBrand(b)]));
   const selectedBrandNames = filters.brands.map((b) => brandNames[b] ?? b);
   const brandTriggerLabel =
     selectedBrandNames.length === 0
@@ -84,9 +83,27 @@ export default function LensFilters({
     return next.length === 0 || next.length === allValues.length ? [] : next;
   }
 
+  // Label maps keyed by value, so option lists can be built by narrowing the
+  // scope-available values to those actually present (rather than hardcoding
+  // the full set and leaving dead choices behind).
+  const motorLabels: Record<FocusMotorClass, string> = {
+    linear: t("motorLinear"),
+    stepping: t("motorStepping"),
+    dc: t("motorDc"),
+    other: t("motorOther"),
+  };
+  const focusLabels: Record<FocusFilter, string> = {
+    auto: t("focusAuto"),
+    manual: t("focusManual"),
+  };
+  const mobileFocusLabels: Record<FocusFilter, string> = {
+    auto: t("focusAutoMobile"),
+    manual: t("focusManualMobile"),
+  };
+
   const typeOptions = [
     { value: null, label: t("allTypes") },
-    ...LENS_TYPES.map((type) => ({
+    ...available.types.map((type) => ({
       value: type,
       label: t(type === "prime" ? "primes" : "zooms"),
     })),
@@ -94,7 +111,7 @@ export default function LensFilters({
 
   const opticalTraitOptions = [
     { value: null as OpticalTrait | null, label: t("allTypes") },
-    ...availableOpticalTraits.map((trait) => ({
+    ...available.opticalTraits.map((trait) => ({
       value: trait as OpticalTrait | null,
       label: tBadge(trait),
     })),
@@ -102,21 +119,17 @@ export default function LensFilters({
 
   const focusMotorOptions = [
     { value: null, label: t("allTypes") },
-    { value: "linear" as FocusMotorClass, label: t("motorLinear") },
-    { value: "stepping" as FocusMotorClass, label: t("motorStepping") },
-    { value: "dc" as FocusMotorClass, label: t("motorDc") },
-    { value: "other" as FocusMotorClass, label: t("motorOther") },
+    ...available.focusMotorClasses.map((motor) => ({ value: motor, label: motorLabels[motor] })),
   ] as { value: FocusMotorClass | null; label: string }[];
 
   const focusOptions = [
     { value: null, label: t("allTypes") },
-    { value: "auto" as FocusFilter, label: t("focusAuto") },
-    { value: "manual" as FocusFilter, label: t("focusManual") },
+    ...available.focusModes.map((mode) => ({ value: mode, label: focusLabels[mode] })),
   ] as { value: FocusFilter | null; label: string }[];
 
   const mobileTypeOptions = [
     { value: null, label: t("allTypes") },
-    ...LENS_TYPES.map((type) => ({
+    ...available.types.map((type) => ({
       value: type,
       label: t(type === "prime" ? "primesMobile" : "zoomsMobile"),
     })),
@@ -124,8 +137,7 @@ export default function LensFilters({
 
   const mobileFocusOptions = [
     { value: null, label: t("allTypes") },
-    { value: "auto" as FocusFilter, label: t("focusAutoMobile") },
-    { value: "manual" as FocusFilter, label: t("focusManualMobile") },
+    ...available.focusModes.map((mode) => ({ value: mode, label: mobileFocusLabels[mode] })),
   ] as { value: FocusFilter | null; label: string }[];
 
   const moreFiltersCount =
@@ -136,15 +148,17 @@ export default function LensFilters({
 
   const allOptionLabel = t("allTypes");
 
-  const brandOptions = brands.map((brand) => ({
+  const brandOptions = available.brands.map((brand) => ({
     key: brand,
     label: tBrand(brand),
     selected: filters.brands.includes(brand),
     onClick: () =>
-      updateFilters("brands", toggleMultiFilter(filters.brands, brand, brands)),
+      updateFilters("brands", toggleMultiFilter(filters.brands, brand, available.brands)),
   }));
 
-  const focalOptions = FOCAL_CATEGORIES.map((category) => ({
+  const focalOptions = FOCAL_CATEGORIES.filter((category) =>
+    available.focalCategories.includes(category.key),
+  ).map((category) => ({
     key: category.key,
     label: t(`category-${category.key}`),
     hint: t(`category-${category.key}Hint`),
@@ -155,12 +169,12 @@ export default function LensFilters({
         toggleMultiFilter(
           filters.focalCategories,
           category.key,
-          FOCAL_CATEGORIES.map((item) => item.key),
+          available.focalCategories,
         ),
       ),
   }));
 
-  const featureOptions = FILTER_FEATURE_KEYS.map((key) => ({
+  const featureOptions = available.features.map((key) => ({
     key,
     label: featureMeta[key].label,
     icon: featureMeta[key].icon,
@@ -234,13 +248,13 @@ export default function LensFilters({
           <div className="min-w-0 flex-1">
             <div className="sm:hidden">
               <BrandFilterMenu
-                brands={brands}
+                brands={available.brands}
                 selected={filters.brands}
                 brandLabels={brandNames}
                 allLabel={allOptionLabel}
                 triggerLabel={brandTriggerLabel}
                 onToggle={(brand) =>
-                  updateFilters("brands", toggleMultiFilter(filters.brands, brand, brands))
+                  updateFilters("brands", toggleMultiFilter(filters.brands, brand, available.brands))
                 }
                 onClear={() => updateFilters("brands", [])}
               />
@@ -315,20 +329,24 @@ export default function LensFilters({
       >
         <div className="min-h-0 overflow-hidden">
           <div className="flex flex-col gap-3.5 pt-3 pb-1 sm:gap-3">
-            <FilterRow label={t("focalRange")}>
-              <MultiSelectChipGroup
-                allLabel={allOptionLabel}
-                allSelected={filters.focalCategories.length === 0}
-                onSelectAll={() => updateFilters("focalCategories", [])}
-                options={focalOptions}
-              />
-            </FilterRow>
+            {available.focalCategories.length > 0 && (
+              <FilterRow label={t("focalRange")}>
+                <MultiSelectChipGroup
+                  allLabel={allOptionLabel}
+                  allSelected={filters.focalCategories.length === 0}
+                  onSelectAll={() => updateFilters("focalCategories", [])}
+                  options={focalOptions}
+                />
+              </FilterRow>
+            )}
 
-            <FilterRow label={t("features")}>
-              <FeatureToggleGroup options={featureOptions} />
-            </FilterRow>
+            {available.features.length > 0 && (
+              <FilterRow label={t("features")}>
+                <FeatureToggleGroup options={featureOptions} />
+              </FilterRow>
+            )}
 
-            {availableOpticalTraits.length > 0 && (
+            {available.opticalTraits.length > 0 && (
               <FilterRow label={t("opticalTraitFilter")}>
                 <TypeSegmentedControl
                   ariaLabel={t("opticalTraitFilter")}
@@ -344,20 +362,22 @@ export default function LensFilters({
               </FilterRow>
             )}
 
-            <FilterRow label={t("focusMotorFilter")}>
-              <TypeSegmentedControl
-                ariaLabel={t("focusMotorFilter")}
-                options={focusMotorOptions}
-                value={filters.focusMotorClass}
-                onChange={(v) => updateFilters("focusMotorClass", v)}
-                wrap
-                mobileLabelOverrides={{
-                  linear: t("motorLinearMobile"),
-                  stepping: t("motorSteppingMobile"),
-                  dc: t("motorDcMobile"),
-                }}
-              />
-            </FilterRow>
+            {available.focusMotorClasses.length > 0 && (
+              <FilterRow label={t("focusMotorFilter")}>
+                <TypeSegmentedControl
+                  ariaLabel={t("focusMotorFilter")}
+                  options={focusMotorOptions}
+                  value={filters.focusMotorClass}
+                  onChange={(v) => updateFilters("focusMotorClass", v)}
+                  wrap
+                  mobileLabelOverrides={{
+                    linear: t("motorLinearMobile"),
+                    stepping: t("motorSteppingMobile"),
+                    dc: t("motorDcMobile"),
+                  }}
+                />
+              </FilterRow>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/LensListClient.tsx
+++ b/src/components/LensListClient.tsx
@@ -8,11 +8,13 @@ import { useTranslations } from "next-intl";
 import {
   filterLenses,
   sortLenses,
+  selectByUsage,
+  getAvailableFilterOptions,
   defaultFilters,
   MAX_COMPARE,
   type FilterState,
 } from "@/lib/lens";
-import type { Lens, OpticalTrait } from "@/lib/types";
+import type { Lens } from "@/lib/types";
 import { serializeFilters, parseFilters } from "@/lib/filter-params";
 import { useCompare } from "@/context/CompareProvider";
 import { useUiHookAttr } from "@/context/TestHookProvider";
@@ -27,11 +29,9 @@ import FeedbackTrigger from "./FeedbackTrigger";
 
 interface LensListClientProps {
   lenses: Lens[];
-  brands: string[];
-  availableOpticalTraits: OpticalTrait[];
 }
 
-export default function LensListClient({ lenses, brands, availableOpticalTraits }: LensListClientProps) {
+export default function LensListClient({ lenses }: LensListClientProps) {
   const t = useTranslations("LensList");
   const tSearch = useTranslations("Search");
   const hookAttr = useUiHookAttr();
@@ -39,6 +39,16 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
   const pathname = usePathname();
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
+
+  // Every filter control narrows to the current photo/cine view, so a Cine
+  // view never offers a brand, feature, or focus-motor option that has no cine
+  // lenses behind it. Derived from the already-in-memory lenses, so this costs
+  // a memo, not a fetch.
+  const scopedLenses = useMemo(
+    () => selectByUsage(lenses, filters.usage),
+    [lenses, filters.usage],
+  );
+  const available = useMemo(() => getAvailableFilterOptions(scopedLenses), [scopedLenses]);
 
   const displayed = useMemo(
     () =>
@@ -89,7 +99,18 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
         navRightSlot={
           <LensUsageSwitch
             value={filters.usage}
-            onChange={(usage) => updateFilters((current) => ({ ...current, usage }))}
+            onChange={(usage) =>
+              // Switching the photo/cine view enters a different scope, so it
+              // resets refinements to a clean slate — only the chosen sort
+              // order carries over. This also sidesteps stale brand selections
+              // that no longer exist in the new view.
+              updateFilters((current) => ({
+                ...defaultFilters,
+                usage,
+                sort: current.sort,
+                sortDir: current.sortDir,
+              }))
+            }
           />
         }
         className="pb-[max(6rem,calc(var(--compare-bar-height,0px)+2rem))]"
@@ -97,8 +118,7 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
         <div className="pt-4">
           <LensFilters
             filters={filters}
-            brands={brands}
-            availableOpticalTraits={availableOpticalTraits}
+            available={available}
             onFiltersChange={updateFilters}
             hasActiveFilters={hasActiveFilters}
             activeFilterCount={activeFilterCount}
@@ -117,17 +137,28 @@ export default function LensListClient({ lenses, brands, availableOpticalTraits 
         </div>
 
         <div className="border-t border-zinc-100 dark:border-zinc-800/50 mt-4 pt-4 mb-2 sm:mb-3">
-          <div className="flex items-center justify-between">
-            <p className="whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400">
-              {t.rich("resultsCount", {
-                count: displayed.length,
-                b: (chunks) => (
-                  <strong className="font-medium text-zinc-700 dark:text-zinc-300">
-                    {chunks}
-                  </strong>
-                ),
-              })}
-            </p>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex min-w-0 flex-col gap-0.5 sm:flex-row sm:items-center sm:gap-2.5">
+              <p className="whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400">
+                {t.rich("resultsCount", {
+                  count: displayed.length,
+                  b: (chunks) => (
+                    <strong className="font-medium text-zinc-700 dark:text-zinc-300">
+                      {chunks}
+                    </strong>
+                  ),
+                })}
+              </p>
+              {/* Coverage is otherwise buried in About; surfacing it next to the
+                  count puts it where users form the "is this complete?" judgment,
+                  not only on the dead-end empty state. */}
+              <Link
+                href="/about#coverage"
+                className="whitespace-nowrap text-xs text-zinc-400 underline-offset-2 transition-colors hover:text-zinc-600 hover:underline dark:text-zinc-500 dark:hover:text-zinc-300"
+              >
+                {t("coverageLink")}
+              </Link>
+            </div>
 
             <LensSortControl
               sort={filters.sort}

--- a/src/lib/lens.ts
+++ b/src/lib/lens.ts
@@ -248,11 +248,77 @@ export function getAvailableOpticalTraits(lenses: { isCine?: boolean; opticalTra
   return OPTICAL_TRAITS.filter((trait) => present.has(trait));
 }
 
+// Partition lenses by the photo/cine view. This is the scope axis the brand
+// and optical-trait controls narrow to, so switching the usage view surfaces
+// only the brands/traits that actually exist in that universe. `null` = no
+// partition (the union escape hatch).
+export function selectByUsage(lenses: Lens[], usage: UsageFilter): Lens[] {
+  if (usage === null) {
+    return lenses;
+  }
+  return lenses.filter((lens) => {
+    const { isCine } = deriveSpecialty(lens);
+    return usage === "cine" ? isCine : !isCine;
+  });
+}
+
 export function getOrderedUniqueBrands(lenses: Lens[]): string[] {
   const present = new Set(lenses.map((l) => l.brand));
   const ordered = BRAND_DISPLAY_ORDER.filter((b) => present.has(b));
   const rest = [...present].filter((b) => !BRAND_DISPLAY_ORDER.includes(b)).sort();
   return [...ordered, ...rest];
+}
+
+export interface AvailableFilterOptions {
+  brands: string[];
+  opticalTraits: OpticalTrait[];
+  features: FilterFeatureKey[];
+  focusMotorClasses: FocusMotorClass[];
+  focalCategories: FocalCategory[];
+  types: LensType[];
+  focusModes: FocusFilter[];
+}
+
+const FOCUS_MOTOR_ORDER: FocusMotorClass[] = ["linear", "stepping", "dc", "other"];
+
+// Which control values actually occur in a given lens set, in display order.
+// Every browse filter narrows to these so a scope (e.g. the cine view) never
+// shows a control whose every value yields zero results — cine lenses carry no
+// AF motor and none of the photo feature flags, so those whole rows drop out
+// rather than sitting there dead.
+export function getAvailableFilterOptions(lenses: Lens[]): AvailableFilterOptions {
+  const features = new Set<FilterFeatureKey>();
+  const motors = new Set<FocusMotorClass>();
+  const focals = new Set<FocalCategory>();
+  const types = new Set<LensType>();
+  const focusModes = new Set<FocusFilter>();
+
+  for (const lens of lenses) {
+    for (const field of FILTER_FEATURE_KEYS) {
+      if (lens[field]) {
+        features.add(field);
+      }
+    }
+    const motor = classifyFocusMotor(lens);
+    if (motor) {
+      motors.add(motor);
+    }
+    for (const cat of getFocalCategoriesOf(lens)) {
+      focals.add(cat);
+    }
+    types.add(isZoom(lens) ? "zoom" : "prime");
+    focusModes.add(lens.af ? "auto" : "manual");
+  }
+
+  return {
+    brands: getOrderedUniqueBrands(lenses),
+    opticalTraits: getAvailableOpticalTraits(lenses),
+    features: FILTER_FEATURE_KEYS.filter((f) => features.has(f)),
+    focusMotorClasses: FOCUS_MOTOR_ORDER.filter((m) => motors.has(m)),
+    focalCategories: FOCAL_CATEGORIES.map((c) => c.key).filter((k) => focals.has(k)),
+    types: LENS_TYPES.filter((t) => types.has(t)),
+    focusModes: (["auto", "manual"] as const).filter((m) => focusModes.has(m)),
+  };
 }
 
 // Returns the locale-appropriate official link with no fallback:


### PR DESCRIPTION
Follow-up to the photo/cine view switch (#345). Two related fixes around how the browse list communicates catalog scope.

## 1. Every filter control narrows to the photo/cine view

Only the displayed list reacted to the view; the filter controls were built from the full mount (brand, optical trait) or from hardcoded constants (type, focus, focal range, features, focus motor). So the **Cine** view still offered every brand, an "auto" focus, all four features, and a whole focus-motor row — none of which have cine lenses behind them. Every one was a dead end.

Now all controls derive their options from the usage-scoped lenses, client-side (a `useMemo` over the `lenses` already in memory — no fetch). A control whose every value is empty in the current view drops out entirely; otherwise it shows only the present values. In Cine, for example: brands narrow to the 3 with cine glass, the focus-motor row disappears, "auto" focus drops, and Features collapses to just the one option a cine lens actually has (aperture ring).

Switching the view also **resets refinements** to a clean slate (keeping only sort), matching the mental model of entering a different scope and avoiding stale selections that don't exist in the new view.

This is scope narrowing (mount + usage), deliberately **not** full faceted narrowing where every active filter hides the others' options — that's heavier and disorienting. Usage/mount = "which catalog"; brand/type/focal = "refine within it".

## 2. Surface lens coverage where completeness is judged

The `/about#coverage` table was only linked from the dead-end empty state, so users who just see a short list (and assume the catalog is weak) never find it. Added a quiet **View lens coverage** link next to the result count — inline on desktop, a subtitle line on mobile so it never collides with the sort control.

## Notes
- `LensListClient` derives options from its `lenses` prop and passes them to `LensFilters`; `browse/page.tsx` no longer computes/passes brands or traits.
- New `selectByUsage()` and `getAvailableFilterOptions()` in `lens.ts`.
- Reset button (in the filter panel) still preserves the view, as before.

## Test plan
- `npm run typecheck`, `npm run lint` (0 errors), `npm test` (360 passing)
- Cine: brand row → 3 brands; focus-motor row hidden; focus → 全部/手动; features → aperture ring only; focal narrowed. Photo unchanged (and a previously-dead "other" motor option that no lens has is now also gone).
- Switching from a filtered photo view (`?b=fujifilm`) lands on a clean `?u=cine` with the reset button gone
- Coverage link: inline w/ count on desktop, stacked subtitle on mobile (390px, zh + en) — no collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)