### PR TITLE
feat(seo): year suffix in collection titles + ItemList JSON-LD

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -44,7 +44,11 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "Collection" });
   const title = localized(stats.collection.title, locale);
   const mountLabel = t("mountLabel", { mount: mountSeoLabel(resolvedMount) });
-  const seoTitle = `${title} — ${mountLabel}`;
+  const baseTitle = `${title} — ${mountLabel}`;
+  // Current-year suffix lives only in the SERP <title> as a freshness/CTR cue;
+  // resolved at build time, so it rolls forward on the next deploy. The on-page
+  // <h1> and collection cards render the bare title, never this string.
+  const seoTitle = t("seoTitleYear", { base: baseTitle, year: String(new Date().getFullYear()) });
   const description = localized(stats.collection.description, locale);
 
   const prefix = t("metaPrefix", { count: stats.lensCount, brandCount: stats.brandCount });
@@ -54,7 +58,8 @@ export async function generateMetadata({
     title: seoTitle,
     description: metaDesc,
     openGraph: {
-      title: `${seoTitle} | Atlens`,
+      // OG title stays year-free — a shared social card has no freshness intent.
+      title: `${baseTitle} | Atlens`,
       description: metaDesc,
       images: defaultOgImages(),
     },

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -7,7 +7,11 @@ import { COLLECTIONS, getCollectionStats, getRelatedCollectionsWithStats } from 
 import { getLensesByMount } from "@/lib/lens-data";
 import { urlSegmentToMount, mountSeoLabel, mountHasCollections } from "@/lib/mount";
 import { buildAlternates, defaultOgImages } from "@/lib/seo";
+import { buildCollectionItemListSchema } from "@/lib/lens-seo";
+import { lensDisplayName } from "@/lib/lens.format";
+import { SITE } from "@/config/site";
 import { ACTION_ESCAPE_CLS, UTILITY_BTN_CLS } from "@/lib/ui-tokens";
+import JsonLd from "@/components/JsonLd";
 import CollectionLensGrid from "@/components/CollectionLensGrid";
 import RelatedCollectionCard from "@/components/RelatedCollectionCard";
 import BackToTopButton from "@/components/BackToTopButton";
@@ -88,6 +92,7 @@ export default async function CollectionPage({
   const { collection, lenses, lensCount, brandCount } = collectionStats;
   const t = await getTranslations({ locale, namespace: "Collection" });
   const tNav = await getTranslations({ locale, namespace: "Nav" });
+  const tBrand = await getTranslations({ locale, namespace: "Brands" });
 
   const title = localized(collection.title, locale);
   const mountLabel = t("mountLabel", { mount: mountSeoLabel(resolvedMount) });
@@ -95,8 +100,22 @@ export default async function CollectionPage({
   const statsLabel = t("stats", { count: lensCount, brandCount });
   const relatedWithStats = getRelatedCollectionsWithStats(slug, mountLenses, locale);
 
+  // ItemList schema: declares this page as an ordered list of lenses, each
+  // pointing at its own detail page. URLs mirror the lens-detail canonical so
+  // the list resolves to the same entities Google already knows.
+  const itemListSchema = buildCollectionItemListSchema({
+    name: title,
+    description,
+    url: `${SITE.url}/${locale}/lenses/${mount}/collections/${slug}`,
+    items: lenses.map((lens) => ({
+      name: lensDisplayName(tBrand(lens.brand), lens.series, lens.model),
+      url: `${SITE.url}/${locale}/lenses/${mount}/${lens.id}`,
+    })),
+  });
+
   return (
     <>
+      <JsonLd data={itemListSchema} />
       <main className="mx-auto max-w-6xl px-4 py-8 pb-[max(10rem,calc(var(--compare-bar-height,0px)+8rem))]">
         <header className="mb-8">
           <div className="mb-4 flex items-center justify-between gap-3">

--- a/src/lib/lens-seo.ts
+++ b/src/lib/lens-seo.ts
@@ -139,3 +139,35 @@ export function buildLensProductSchema(args: {
     additionalProperty: props,
   };
 }
+
+/**
+ * Build the schema.org ItemList JSON-LD for a collection page.
+ *
+ * A collection is a curated list of lenses, so the summary-page ItemList form
+ * is used: each ListItem points (by url) at the lens's own canonical detail
+ * page rather than embedding a full Product, keeping this payload light and the
+ * authoritative Product schema in one place (the detail page). Carries no date
+ * — freshness is deliberately not asserted here.
+ */
+export function buildCollectionItemListSchema(args: {
+  name: string;
+  description: string;
+  url: string;
+  items: { name: string; url: string }[];
+}) {
+  const { name, description, url, items } = args;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name,
+    description,
+    url,
+    numberOfItems: items.length,
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: item.url,
+      name: item.name,
+    })),
+  };
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -545,6 +545,7 @@
     "feedbackLink": "Tell me",
     "reportIssue": "Report an issue",
     "mountLabel": "Fujifilm {mount}-Mount",
+    "seoTitleYear": "{base} ({year})",
     "shareText": "Found a nice collection on Atlens: {title} ({mount})"
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -545,6 +545,7 @@
     "feedbackLink": "告诉我",
     "reportIssue": "反馈问题",
     "mountLabel": "富士 {mount} 卡口",
+    "seoTitleYear": "{base}（{year} 年）",
     "shareText": "在 Atlens 发现一份不错的合集：{title}（{mount}）"
   }
 }


### PR DESCRIPTION
## What

Two SEO additions to Fujifilm-mount collection pages:

1. **Current-year suffix in the SERP `<title>`** — a freshness/CTR cue, added via a locale-aware i18n key (`Collection.seoTitleYear`: `(2026)` in EN, `（2026 年）` in ZH).
2. **`ItemList` JSON-LD** — declares each collection page as an ordered list of its member lenses, complementing the existing `Product` schema on lens detail pages and the site-wide `Organization`/`WebSite` schema.

## Non-obvious notes

- The year lives **only** in the `<title>`. The on-page `<h1>`, the collection-index cards, and the OG title all keep the bare title — the year never renders in body content or social cards.
- The year is resolved at **build time**, so it rolls forward on the next deploy, not at midnight on Jan 1. Trigger a build around year-end if no deploy is scheduled.
- `ItemList` uses the summary-page form: each `ListItem` points by `url` at the lens's own canonical detail page (URL mirrors the lens-detail canonical exactly), carrying `name` + `position`. The authoritative `Product` schema stays on the detail page; no Product is embedded here.
- No date is asserted in the structured data — freshness signals (`dateModified`/sitemap `lastmod`) are intentionally deferred until a real catalog-change timestamp exists.

## Test plan

- [x] `tsc` clean on touched files
- [x] Dev server: EN + ZH `<title>` carries year, `<h1>` does not, OG title year-free
- [x] Dev server: collection-index cards show no year leak
- [x] Dev server: `ItemList` JSON-LD renders with correct name/count/member display names and absolute canonical URLs (EN + ZH)
- [ ] Post-deploy: validate `ItemList` against Google Rich Results Test on a live URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)