### PR TITLE
fix: improve mobile drawer behavior

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -190,9 +190,9 @@ export default function FeedbackDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         layerRef={dialogLayerRef}
-        className="max-w-md"
+        className="max-h-[min(85svh,calc(100svh-2rem))] max-w-md overflow-hidden"
       >
-        <DialogHeader>
+        <DialogHeader className="shrink-0">
           <DialogTitle>{t(titleKey)}</DialogTitle>
           {status !== "success" && (
             <p className="text-xs text-zinc-400 dark:text-zinc-500">
@@ -221,7 +221,10 @@ export default function FeedbackDialog({
             </div>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 pb-4">
+          <form
+            onSubmit={handleSubmit}
+            className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-5 pb-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
+          >
             {lensHeader && (
               <div className="flex flex-col gap-0.5 border-b border-zinc-200 dark:border-zinc-800 pb-3">
                 <span className="text-[11px] font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
@@ -368,7 +371,7 @@ export default function FeedbackDialog({
           </form>
         )}
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           {status === "success" ? (
             <Button
               type="button"

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -14,7 +14,7 @@ import { Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
-import { useEffectiveMount } from "@/hooks/useMountParam";
+import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens-search";
 import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -59,7 +59,7 @@ export default function LensSearchDialog({
   const t = useTranslations("Search");
   const tBrand = useTranslations("Brands");
   const router = useRouter();
-  const mount = useEffectiveMount();
+  const isDesktop = useBreakpoint("sm");
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
@@ -69,16 +69,17 @@ export default function LensSearchDialog({
   const resultsId = useId();
   const deferredQuery = useDeferredValue(query);
 
-  // Auto-focus the input when the dialog opens
+  // Auto-focus only on desktop. Mobile browsers, especially iOS, require an
+  // explicit user tap before showing the software keyboard.
   useEffect(() => {
-    if (open) {
+    if (open && isDesktop) {
       const timer = setTimeout(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
       }, 0);
       return () => clearTimeout(timer);
     }
-  }, [open]);
+  }, [isDesktop, open]);
 
   // Reset state on close
   useEffect(() => {
@@ -244,7 +245,7 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
-            className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
+            className="h-[300px] overflow-y-auto px-3 py-3 pb-[32svh] scroll-pb-[32svh] sm:pb-3 sm:scroll-pb-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
             {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
               <div className="flex items-center justify-center py-16">


### PR DESCRIPTION
## Summary
- Stop auto-focusing the mobile search drawer input while keeping desktop autofocus.
- Add mobile bottom scroll buffer for search results so keyboard overlap is less likely.
- Keep feedback drawer actions visible by constraining height and scrolling the form body.

## Validation
- `npm run lint` (passes with existing warnings in untouched files)
- Mobile browser checks for search focus, search result bottom padding, and feedback drawer footer visibility
- `npx playwright test e2e/search.spec.ts --project=ios-safari --workers=1 --reporter=line` (4 passed, 2 failed due to existing mount-aware route assertion mismatch: `/en/lenses/x/{id}` vs `/en/lenses/{id}`)