### PR TITLE
fix(mobile): drawer keyboard focus, results clearance, feedback overflow, share, swipe-close flash

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -186,6 +186,17 @@ export default function FeedbackDialog({
     description.trim().length > 0 || suggestedCorrection.trim().length > 0;
   const canSubmit = status !== "submitting";
 
+  // Closing via an in-drawer button (Cancel/Close) leaves focus on that button inside
+  // the popup. On the controlled-close path Base UI then returns focus mid-animation,
+  // which flashes the drawer back in just before it finishes closing on iOS (backdrop
+  // close doesn't — nothing focusable inside the popup holds focus). Blur synchronously
+  // before closing, ahead of Base UI's layout-effect focus handling, so focus is already
+  // out by the time the close is processed. An effect runs too late to beat it.
+  function handleClose() {
+    (document.activeElement as HTMLElement | null)?.blur();
+    onOpenChange(false);
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* max-h-none drops the shared drawer's 85svh cap: as the field picker expands,
@@ -377,7 +388,7 @@ export default function FeedbackDialog({
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={handleClose}
             >
               {t("close")}
             </Button>
@@ -386,7 +397,7 @@ export default function FeedbackDialog({
               <Button
                 type="button"
                 variant="ghost"
-                onClick={() => onOpenChange(false)}
+                onClick={handleClose}
               >
                 {t("cancel")}
               </Button>

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -186,17 +186,6 @@ export default function FeedbackDialog({
     description.trim().length > 0 || suggestedCorrection.trim().length > 0;
   const canSubmit = status !== "submitting";
 
-  // Closing via an in-drawer button (Cancel/Close) leaves focus on that button inside
-  // the popup. On the controlled-close path Base UI then returns focus mid-animation,
-  // which flashes the drawer back in just before it finishes closing on iOS (backdrop
-  // close doesn't — nothing focusable inside the popup holds focus). Blur synchronously
-  // before closing, ahead of Base UI's layout-effect focus handling, so focus is already
-  // out by the time the close is processed. An effect runs too late to beat it.
-  function handleClose() {
-    (document.activeElement as HTMLElement | null)?.blur();
-    onOpenChange(false);
-  }
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* max-h-none drops the shared drawer's 85svh cap: as the field picker expands,
@@ -388,7 +377,7 @@ export default function FeedbackDialog({
             <Button
               type="button"
               variant="outline"
-              onClick={handleClose}
+              onClick={() => onOpenChange(false)}
             >
               {t("close")}
             </Button>
@@ -397,7 +386,7 @@ export default function FeedbackDialog({
               <Button
                 type="button"
                 variant="ghost"
-                onClick={handleClose}
+                onClick={() => onOpenChange(false)}
               >
                 {t("cancel")}
               </Button>

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -188,9 +188,13 @@ export default function FeedbackDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* max-h-none drops the shared drawer's 85svh cap: as the field picker expands,
+          the drawer grows upward from its pinned bottom edge so the Cancel/Submit row
+          stays put, instead of the cap clipping the footer off the bottom. No inner
+          scroll region — the action row is always the bottom of the sheet. */}
       <DialogContent
         layerRef={dialogLayerRef}
-        className="max-w-md"
+        className="max-w-md max-h-none"
       >
         <DialogHeader>
           <DialogTitle>{t(titleKey)}</DialogTitle>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -69,17 +69,6 @@ export default function LensSearchDialog({
   const resultsId = useId();
   const deferredQuery = useDeferredValue(query);
 
-  // Auto-focus the input when the dialog opens
-  useEffect(() => {
-    if (open) {
-      const timer = setTimeout(() => {
-        inputRef.current?.focus();
-        inputRef.current?.select();
-      }, 0);
-      return () => clearTimeout(timer);
-    }
-  }, [open]);
-
   // Reset state on close
   useEffect(() => {
     if (!open) {
@@ -190,7 +179,12 @@ export default function LensSearchDialog({
       </button>
 
       <Dialog open={open} onOpenChange={setOpen}>
+        {/* Base UI focuses the popup (not the input) on touch-open to suppress the
+            keyboard; for a search box we want the keyboard, so we hand it the input
+            ref. Routing focus through the library's own open sequence (instead of a
+            post-open setTimeout) makes it deterministic on the first open too. */}
         <DialogContent
+          initialFocus={inputRef}
           className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
           showCloseButton={false}
         >

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
 import { useEffectiveMount } from "@/hooks/useMountParam";
+import { useKeyboardInset } from "@/hooks/useKeyboardInset";
 import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens-search";
 import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -68,6 +69,7 @@ export default function LensSearchDialog({
   const inputId = useId();
   const resultsId = useId();
   const deferredQuery = useDeferredValue(query);
+  const keyboardInset = useKeyboardInset();
 
   // Reset state on close
   useEffect(() => {
@@ -238,6 +240,8 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
+            // scrollPaddingBottom keeps arrow-key scrollIntoView landing above the keyboard
+            style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
             {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
@@ -323,6 +327,12 @@ export default function LensSearchDialog({
                   </FeedbackTrigger>
                 </p>
               </div>
+            )}
+            {/* Spacer that reserves the keyboard's height inside the scroll area so the
+                last result can be scrolled clear of the on-screen keyboard. Collapses to
+                0 when the keyboard is down. */}
+            {keyboardInset > 0 && (
+              <div aria-hidden style={{ height: keyboardInset }} />
             )}
           </div>
         </DialogContent>

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -240,14 +240,6 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
-            // In drawer mode the whole popup is a swipe-dismiss surface, so tapping a
-            // result engages Base UI's swipe tracking — it sets `transition: none` on
-            // the popup, which then lingers into the close that the same tap triggers
-            // (handleSelect → setOpen(false)) and makes the drawer flash back mid-exit
-            // on iOS. data-base-ui-swipe-ignore opts this region out of swipe tracking.
-            // (Visible in compare-add mode, where selecting closes the drawer in place;
-            // the navigate path hides it behind the route change.)
-            data-base-ui-swipe-ignore=""
             // scrollPaddingBottom keeps arrow-key scrollIntoView landing above the keyboard
             style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"

--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -240,6 +240,14 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
+            // In drawer mode the whole popup is a swipe-dismiss surface, so tapping a
+            // result engages Base UI's swipe tracking — it sets `transition: none` on
+            // the popup, which then lingers into the close that the same tap triggers
+            // (handleSelect → setOpen(false)) and makes the drawer flash back mid-exit
+            // on iOS. data-base-ui-swipe-ignore opts this region out of swipe tracking.
+            // (Visible in compare-add mode, where selecting closes the drawer in place;
+            // the navigate path hides it behind the route change.)
+            data-base-ui-swipe-ignore=""
             // scrollPaddingBottom keeps arrow-key scrollIntoView landing above the keyboard
             style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -364,13 +364,18 @@ export function ShareButton({ lenses, variant = "default", triggerClassName, ico
 
           {/* Action row */}
           <div className="flex gap-2">
-            <CustomizePopover
-              title={effectiveTitle}
-              slogan={effectiveSlogan}
-              onTitleChange={(v) => setTitleOverride(v || null)}
-              onSloganChange={(v) => setSloganOverride(v || null)}
-              titlePlaceholder={computedPosterTitle.join(" · ")}
-            />
+            {/* Customize (title/slogan) is a nested popover — desktop only. On mobile the
+                share surface is a drawer, where a nested popover-in-drawer is awkward, so
+                the entry point is dropped entirely. */}
+            {isDesktop && (
+              <CustomizePopover
+                title={effectiveTitle}
+                slogan={effectiveSlogan}
+                onTitleChange={(v) => setTitleOverride(v || null)}
+                onSloganChange={(v) => setSloganOverride(v || null)}
+                titlePlaceholder={computedPosterTitle.join(" · ")}
+              />
+            )}
 
             {canShareFile ? (
               <>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,19 +29,6 @@ function Dialog({
   const isDesktop = useBreakpoint("sm");
   const mode = responsive && !isDesktop ? "drawer" : "dialog";
 
-  // On mobile a focused input inside the drawer often keeps focus when its keyboard
-  // is only hidden (not blurred). If Base UI blurs it as part of its close sequence,
-  // iOS re-runs the keyboard machinery mid-animation and the drawer flashes back in
-  // just before it finishes closing. Blurring the moment we begin closing dismisses
-  // the keyboard before the exit animation runs, so the close stays smooth.
-  const wasOpen = React.useRef(open);
-  React.useEffect(() => {
-    if (mode === "drawer" && wasOpen.current && !open) {
-      (document.activeElement as HTMLElement | null)?.blur();
-    }
-    wasOpen.current = open;
-  }, [open, mode]);
-
   return (
     <DialogModeContext value={mode}>
       {mode === "drawer" ? (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -193,8 +193,14 @@ function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 
 function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
+    // data-base-ui-swipe-ignore: in drawer mode the whole popup is a swipe-dismiss
+    // surface, so tapping a footer button engages Base UI's swipe tracking (it sets
+    // `transition: none` + a transform on the popup). That lingers into the close the
+    // tap triggers and makes the drawer flash back in mid-exit on iOS. Excluding the
+    // footer from swipe tracking keeps the close animation clean. No effect on desktop.
     <div
       data-slot="dialog-footer"
+      data-base-ui-swipe-ignore=""
       className={cn("flex items-center justify-end gap-3 px-5 py-4 border-t border-zinc-200 dark:border-zinc-800", className)}
       {...props}
     />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,6 +29,19 @@ function Dialog({
   const isDesktop = useBreakpoint("sm");
   const mode = responsive && !isDesktop ? "drawer" : "dialog";
 
+  // On mobile a focused input inside the drawer often keeps focus when its keyboard
+  // is only hidden (not blurred). If Base UI blurs it as part of its close sequence,
+  // iOS re-runs the keyboard machinery mid-animation and the drawer flashes back in
+  // just before it finishes closing. Blurring the moment we begin closing dismisses
+  // the keyboard before the exit animation runs, so the close stays smooth.
+  const wasOpen = React.useRef(open);
+  React.useEffect(() => {
+    if (mode === "drawer" && wasOpen.current && !open) {
+      (document.activeElement as HTMLElement | null)?.blur();
+    }
+    wasOpen.current = open;
+  }, [open, mode]);
+
   return (
     <DialogModeContext value={mode}>
       {mode === "drawer" ? (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -141,7 +141,18 @@ const DialogContent = React.forwardRef<
             <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
               <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
             </div>
-            {children}
+            {/* The drag handle above is the only swipe-to-dismiss surface; everything
+                below is opted out of swipe tracking. Base UI treats the whole popup as a
+                swipe surface, so a *tap* on any in-drawer control (a Cancel button, a
+                search result) starts swipe tracking — it puts `transition: none` + a
+                transform on the popup that lingers into the close the same tap triggers,
+                flashing the drawer back mid-exit on iOS. display:contents keeps the flex
+                layout flat. NB: data-base-ui-swipe-ignore is the ONLY opt-out Base UI
+                honors on touch — `Drawer.Content` (data-drawer-content) is checked on the
+                pointer path only, so it does NOT fix this on real devices. */}
+            <div data-base-ui-swipe-ignore className="contents">
+              {children}
+            </div>
             {layerRef && <div ref={layerRef} />}
           </DrawerPrimitive.Popup>
         </DrawerPrimitive.Viewport>
@@ -193,14 +204,8 @@ function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 
 function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    // data-base-ui-swipe-ignore: in drawer mode the whole popup is a swipe-dismiss
-    // surface, so tapping a footer button engages Base UI's swipe tracking (it sets
-    // `transition: none` + a transform on the popup). That lingers into the close the
-    // tap triggers and makes the drawer flash back in mid-exit on iOS. Excluding the
-    // footer from swipe tracking keeps the close animation clean. No effect on desktop.
     <div
       data-slot="dialog-footer"
-      data-base-ui-swipe-ignore=""
       className={cn("flex items-center justify-end gap-3 px-5 py-4 border-t border-zinc-200 dark:border-zinc-800", className)}
       {...props}
     />

--- a/src/hooks/useKeyboardInset.ts
+++ b/src/hooks/useKeyboardInset.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Pixels the on-screen keyboard overlaps the bottom of the layout viewport (0 when
+// closed). iOS shrinks only the visual viewport when the keyboard opens, so this is
+// `innerHeight - visualViewport.height - offsetTop`. Intended for a narrow use: sizing
+// a bottom spacer inside a scroll region so its last rows can clear the keyboard. This
+// does NOT reposition any fixed element — see [[reference_ios_keyboard_fixed_overlay]]
+// for why driving a fixed overlay's position off visualViewport is a dead end.
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) {
+      return;
+    }
+
+    function update() {
+      const v = window.visualViewport;
+      if (!v) {
+        return;
+      }
+      setInset(Math.max(0, window.innerHeight - v.height - v.offsetTop));
+    }
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, []);
+
+  return inset;
+}


### PR DESCRIPTION
Mobile drawer fixes. Desktop is unchanged throughout.

## 1. Search keyboard misses on first open (iOS Chrome)
Base UI's drawer focuses the popup — not the input — on touch-open to suppress the keyboard. Our `setTimeout(0)` autofocus raced that and lost intermittently on the first open. Fix: hand Base UI `initialFocus={inputRef}` so focus happens deterministically inside its open sequence. (Fixes keyboard *appearance*; the separate iOS quirk where the first keyboard doesn't trigger native content-shift avoidance is a fixed-overlay limitation, intentionally left as-is.)

## 2. Search results occluded by the keyboard
Native iOS avoidance only scrolls the focused input into view; the results are a separate inner scroll container whose bottom sits behind the keyboard. Fix: append a spacer equal to the keyboard height at the end of the results scroll area (+ `scroll-padding-bottom` for arrow-key nav), from a contained `visualViewport` read (`useKeyboardInset`). Sizes a spacer only — does not reposition any fixed element. Collapses to 0 when the keyboard is down.

## 3. Feedback footer pushed off-screen
The shared drawer caps height at `max-h-[85svh]`; when the field picker expands past it, the Cancel/Submit row overflows below the pinned bottom. Fix: `max-h-none` so the drawer grows upward from its pinned bottom. No inner scroll region.

## 4. Share: drop the customize (title/slogan) entry on mobile
The customize control is a nested popover, awkward inside the mobile share drawer. Gate it on `isDesktop`; mobile drops the entry, desktop unchanged.

## 5. Drawer flashes back on close (iOS, Chrome + Safari)
In drawer mode the whole popup is a swipe-dismiss surface, so *tapping* an in-drawer control (Cancel button, search result) engages Base UI's swipe tracking, which puts `transition: none` + an inline `transform: translateY(0)` (the open position) on the popup. That lingers into the close the same tap triggers, so the drawer snaps back to the open position for a frame before sliding out — the flash. Backdrop close is outside the popup (no swipe); the search navigate path hides it behind the route change. Fix: wrap all drawer content in one `data-base-ui-swipe-ignore` region in the shared `DialogContent`, leaving only the drag handle swipe-draggable. Verified at the DOM level (Cancel/result taps no longer set `data-swiping`; handle still does).

NB: `Drawer.Content` is NOT used — it looks idiomatic but Base UI honors its swipe-exemption only on the pointer path; the touch handler (`onTouchStart`) checks only `data-base-ui-swipe-ignore`, so `Drawer.Content` would silently regress this on real devices (verified with a 3-way DOM probe).

## Non-obvious traps
- #1: "first open fails, second works" is a focus race against Base UI's intentional touch keyboard-suppression, not viewport math.
- #2: `scroll-padding-bottom` alone can't fix it — it doesn't add scroll extent; real spacer height is required.
- #5: the flash is swipe tracking, NOT focus. Two focus-based fixes were tried and reverted before the swipe attribute (`transition:none` on the popup) was found via DOM observation.

## Test plan
- [x] Local (Playwright, 390×667): feedback grows upward, footer stays in viewport, no drawer-level scroll.
- [x] Local: Search focuses input on open; results spacer (simulated visualViewport −290px) renders at 290px, scrollHeight grows, last row clears the keyboard line.
- [x] Local: share customize present on desktop, absent in mobile drawer.
- [x] Local (DOM-level): a footer-button tap no longer sets `data-swiping`/`transition:none` on the popup after the swipe-ignore fix.
- [x] On-device (user, iOS Chrome/Safari): #1 keyboard appears first open; #3 footer stays; #5 diagnosed (backdrop smooth, button flashes; focus fixes failed).
- [ ] On-device follow-up: confirm #5 flash gone with the swipe-ignore fix; #2 results clearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
