### PR TITLE
docs(readme): surface Curated Collections in the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Browse, filter, and compare Fujifilm X-mount lenses — native Fujifilm glass pl
 - **Growing lens database** — focused on X-mount: full coverage of Fujifilm's first-party lineup plus a curated set of third-party brands (Sigma, Tamron, Viltrox, TTArtisan, 7Artisans, Brightin Star, SG Image), with more brands under evaluation. G-mount (medium format) coverage is also under way for Fujifilm's first-party GF lineup.
 - **Clean, focused UI** — distraction-free interface designed around the comparison workflow
 - **Filter and sort** — multi-axis filtering (focal length, aperture, AF, OIS, weather resistance, specialty tags) combined with flexible sorting
+- **Curated collections** — hand-picked themed groupings (compact primes, budget autofocus, and more) for when you don't know exactly what to search for, each on its own browsable page
 - **Side-by-side comparison** of up to 4 lenses
 - **Normalized data** — specs from different manufacturers use inconsistent formats and terminology; Atlens maps everything to a consistent schema so comparisons are fair and objective
 - **Pipeline-backed accuracy** — every spec originates from official manufacturer sources and goes through a staged pipeline with human review at every step

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Browse, filter, and compare Fujifilm X-mount lenses — native Fujifilm glass pl
 - **Growing lens database** — focused on X-mount: full coverage of Fujifilm's first-party lineup plus a curated set of third-party brands (Sigma, Tamron, Viltrox, TTArtisan, 7Artisans, Brightin Star, SG Image), with more brands under evaluation. G-mount (medium format) coverage is also under way for Fujifilm's first-party GF lineup.
 - **Clean, focused UI** — distraction-free interface designed around the comparison workflow
 - **Filter and sort** — multi-axis filtering (focal length, aperture, AF, OIS, weather resistance, specialty tags) combined with flexible sorting
-- **Curated collections** — hand-picked themed groupings (compact primes, budget autofocus, and more) for when you don't know exactly what to search for, each on its own browsable page
+- **Curated collections** — hand-picked themes (compact primes, budget autofocus, and more), each defined by filter criteria rather than a hand-picked lens list, so the lineup stays current as the catalog grows — for when you don't know exactly what to search for
 - **Side-by-side comparison** of up to 4 lenses
 - **Normalized data** — specs from different manufacturers use inconsistent formats and terminology; Atlens maps everything to a consistent schema so comparisons are fair and objective
 - **Pipeline-backed accuracy** — every spec originates from official manufacturer sources and goes through a staged pipeline with human review at every step


### PR DESCRIPTION
Collections shipped recently but the README feature list never mentioned it. Adds one bullet (alongside Filter and sort) so the curated-discovery angle is visible to anyone scanning the repo. README-only.