### PR TITLE
feat(purchase): device-split zh JD/Taobao price-check domains

### DIFF
--- a/src/components/CompareMobileBuyPanel.tsx
+++ b/src/components/CompareMobileBuyPanel.tsx
@@ -7,6 +7,7 @@ import { pickPriceEntry } from "@/lib/lens-pricing";
 import { lensSubtitleLine } from "@/lib/lens.format";
 import { buildPurchaseLinks, shouldShowDisclosure } from "@/lib/purchase-links";
 import { useCountryCode } from "@/hooks/useCountryCode";
+import { useIsMobileDevice } from "@/hooks/useIsMobileDevice";
 import type { Lens } from "@/lib/types";
 
 interface Props {
@@ -18,11 +19,12 @@ export function CompareMobileBuyPanel({ lenses }: Props) {
   const locale = useLocale();
   const tBrand = useTranslations("Brands");
   const countryCode = useCountryCode();
+  const isMobileDevice = useIsMobileDevice();
 
   const lensLinks = lenses
     .map((lens) => ({
       lens,
-      links: buildPurchaseLinks(lens, locale, countryCode, "compare-mobile"),
+      links: buildPurchaseLinks(lens, locale, countryCode, "compare-mobile", isMobileDevice),
     }))
     .filter((entry) => entry.links.length > 0);
 

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -243,9 +243,8 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
   // Number of empty slot columns to render (search triggers filling up to minColumns)
   const emptySlotCount = Math.max(0, minColumns - orderedLenses.length);
 
-  const allPurchaseLinks = useMemo(
-    () => orderedLenses.flatMap((l) => buildPurchaseLinks(l, locale, countryCode, undefined, isMobileDevice)),
-    [orderedLenses, locale, countryCode, isMobileDevice],
+  const allPurchaseLinks = orderedLenses.flatMap((l) =>
+    buildPurchaseLinks(l, locale, countryCode, undefined, isMobileDevice),
   );
   const hasAnyPurchaseLinks = allPurchaseLinks.length > 0;
   const hasAffiliate = hasAnyPurchaseLinks && allPurchaseLinks.some((l) => l.isAffiliate);

--- a/src/components/CompareTable.tsx
+++ b/src/components/CompareTable.tsx
@@ -36,6 +36,7 @@ import { PriceCell } from "@/components/PriceCell";
 import { PurchaseLinksCompact, PurchaseDisclosureCaption } from "@/components/PurchaseLinks";
 import { buildPurchaseLinks, purchaseDisclosureKey, shouldShowDisclosure } from "@/lib/purchase-links";
 import { useCountryCode } from "@/hooks/useCountryCode";
+import { useIsMobileDevice } from "@/hooks/useIsMobileDevice";
 import { pickPriceEntry } from "@/lib/lens-pricing";
 import { lensDisplayName, lensSubtitleLine } from "@/lib/lens.format";
 
@@ -205,6 +206,7 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
   const tPurchase = useTranslations("Purchase");
   const locale = useLocale();
   const countryCode = useCountryCode();
+  const isMobileDevice = useIsMobileDevice();
   const { compareIds, reorder, remove, seed } = useCompare();
   const { onSelectLens, getResultState } = useCompareLensSearch();
   // Compare page is the only surface that projects compare state onto the
@@ -242,8 +244,8 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
   const emptySlotCount = Math.max(0, minColumns - orderedLenses.length);
 
   const allPurchaseLinks = useMemo(
-    () => orderedLenses.flatMap((l) => buildPurchaseLinks(l, locale, countryCode)),
-    [orderedLenses, locale, countryCode],
+    () => orderedLenses.flatMap((l) => buildPurchaseLinks(l, locale, countryCode, undefined, isMobileDevice)),
+    [orderedLenses, locale, countryCode, isMobileDevice],
   );
   const hasAnyPurchaseLinks = allPurchaseLinks.length > 0;
   const hasAffiliate = hasAnyPurchaseLinks && allPurchaseLinks.some((l) => l.isAffiliate);

--- a/src/components/PurchaseLinks.tsx
+++ b/src/components/PurchaseLinks.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { ArrowUpRight, Info } from "lucide-react";
 import { buildPurchaseLinks, purchaseDisclosureKey } from "@/lib/purchase-links";
@@ -50,10 +49,7 @@ export function PurchaseLinksCompact({ lens, customId, className }: Props) {
   const countryCode = useCountryCode();
   const isMobileDevice = useIsMobileDevice();
 
-  const links = useMemo(
-    () => buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice),
-    [lens, locale, countryCode, customId, isMobileDevice],
-  );
+  const links = buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice);
 
   if (links.length === 0) {
     return null;

--- a/src/components/PurchaseLinks.tsx
+++ b/src/components/PurchaseLinks.tsx
@@ -9,6 +9,7 @@ import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { track } from "@/lib/analytics";
 import { useCountryCode } from "@/hooks/useCountryCode";
+import { useIsMobileDevice } from "@/hooks/useIsMobileDevice";
 
 interface Props {
   lens: Lens;
@@ -47,10 +48,11 @@ function PurchaseLinkList({ links, lensId, customId, className }: { links: Purch
 export function PurchaseLinksCompact({ lens, customId, className }: Props) {
   const locale = useLocale();
   const countryCode = useCountryCode();
+  const isMobileDevice = useIsMobileDevice();
 
   const links = useMemo(
-    () => buildPurchaseLinks(lens, locale, countryCode, customId),
-    [lens, locale, countryCode, customId],
+    () => buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice),
+    [lens, locale, countryCode, customId, isMobileDevice],
   );
 
   if (links.length === 0) {

--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Popover } from "@base-ui/react/popover";
 import { ArrowUpRight, ChevronDown, Info } from "lucide-react";
@@ -24,10 +23,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
   const countryCode = useCountryCode();
   const isMobileDevice = useIsMobileDevice();
 
-  const links = useMemo(
-    () => buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice),
-    [lens, locale, countryCode, customId, isMobileDevice],
-  );
+  const links = buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice);
 
   if (links.length === 0) {
     return null;

--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -10,6 +10,7 @@ import type { Lens } from "@/lib/types";
 import { ACTION_OUTLINE_CLS, MENU_POPUP_CLS } from "@/lib/ui-tokens";
 import { track } from "@/lib/analytics";
 import { useCountryCode } from "@/hooks/useCountryCode";
+import { useIsMobileDevice } from "@/hooks/useIsMobileDevice";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -21,10 +22,11 @@ export function RetailersDropdown({ lens, customId }: Props) {
   const locale = useLocale();
   const t = useTranslations("Purchase");
   const countryCode = useCountryCode();
+  const isMobileDevice = useIsMobileDevice();
 
   const links = useMemo(
-    () => buildPurchaseLinks(lens, locale, countryCode, customId),
-    [lens, locale, countryCode, customId],
+    () => buildPurchaseLinks(lens, locale, countryCode, customId, isMobileDevice),
+    [lens, locale, countryCode, customId, isMobileDevice],
   );
 
   if (links.length === 0) {

--- a/src/hooks/useIsMobileDevice.ts
+++ b/src/hooks/useIsMobileDevice.ts
@@ -6,6 +6,12 @@ import { useSyncExternalStore } from "react";
 // viewport is still mobile. Purchase links use this to decide whether to target
 // the mobile H5 domains (native "open in app" handoff) or the desktop search
 // sites.
+//
+// The hand-rolled regex is deliberate: all we need is one mobile/desktop boolean
+// for a non-critical URL choice. If device classification ever gets more
+// demanding (precise OS/device, or handling UA spoofing like iPadOS posing as
+// macOS), reach for a maintained library (ua-parser-js) instead of growing this
+// regex.
 const MOBILE_UA = /Android|iPhone|iPad|iPod|Mobile|Windows Phone/i;
 
 function getSnapshot(): boolean {

--- a/src/hooks/useIsMobileDevice.ts
+++ b/src/hooks/useIsMobileDevice.ts
@@ -1,0 +1,30 @@
+import { useSyncExternalStore } from "react";
+
+// Phone/tablet user-agent test — a DEVICE check, deliberately distinct from
+// useBreakpoint, which is a VIEWPORT check. A desktop browser resized narrow is
+// still a desktop here (no native app to hand off to); a tablet in a wide
+// viewport is still mobile. Purchase links use this to decide whether to target
+// the mobile H5 domains (native "open in app" handoff) or the desktop search
+// sites.
+const MOBILE_UA = /Android|iPhone|iPad|iPod|Mobile|Windows Phone/i;
+
+function getSnapshot(): boolean {
+  return MOBILE_UA.test(navigator.userAgent);
+}
+
+// Desktop default on the server, so statically generated HTML carries desktop
+// URLs; the client swaps to the real value post-hydration. Same
+// useSyncExternalStore pattern as useCountryCode — keeps pages static (no
+// dynamic SSR) without a hydration mismatch. Device class is stable within a
+// session, so subscribe is a no-op.
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function subscribe(): () => void {
+  return () => {};
+}
+
+export function useIsMobileDevice(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -157,7 +157,7 @@ function buildJdUrl(lens: Lens, isMobileDevice: boolean): string {
 function buildTaobaoUrl(lens: Lens, isMobileDevice: boolean): string {
   const query = encodeURIComponent(getSearchQuery(lens, "zh"));
   return isMobileDevice
-    ? `https://main.m.taobao.com/search/index.html?pageType=3&q=${query}`
+    ? `https://main.m.taobao.com/search/index.html?q=${query}`
     : `https://s.taobao.com/search?q=${query}`;
 }
 

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -142,24 +142,28 @@ function buildBhPhotoUrl(lens: Lens, locale: string): string {
 // Mainland search-jump links. We can't run an affiliate program here (JD/Taobao
 // promotion filing requires an ICP-registered site), so these are plain search
 // URLs built from the lens's zh alias — a non-affiliate price-check convenience.
-// They target the mobile H5 domains (so.m.jd.com / s.m.taobao.com) so phones get
-// the native "open in app" handoff the platforms' own H5 pages provide, instead
-// of the desktop search site. (WeChat's in-app browser still blocks the app
-// handoff — a platform limitation we can't work around.)
-function buildJdUrl(lens: Lens): string {
-  const query = getSearchQuery(lens, "zh");
-  return `https://so.m.jd.com/ware/search.action?keyword=${encodeURIComponent(query)}`;
+// On phones we target the mobile H5 domains (so.m.jd.com / s.m.taobao.com) so the
+// platforms' own "open in app" handoff kicks in; on desktop we keep the regular
+// search site, which is laid out for a wide viewport. (WeChat's in-app browser
+// still blocks the app handoff — a platform limitation we can't work around.)
+function buildJdUrl(lens: Lens, isMobileDevice: boolean): string {
+  const query = encodeURIComponent(getSearchQuery(lens, "zh"));
+  return isMobileDevice
+    ? `https://so.m.jd.com/ware/search.action?keyword=${query}`
+    : `https://search.jd.com/Search?keyword=${query}&enc=utf-8`;
 }
 
-function buildTaobaoUrl(lens: Lens): string {
-  const query = getSearchQuery(lens, "zh");
-  return `https://s.m.taobao.com/h5?q=${encodeURIComponent(query)}`;
+function buildTaobaoUrl(lens: Lens, isMobileDevice: boolean): string {
+  const query = encodeURIComponent(getSearchQuery(lens, "zh"));
+  return isMobileDevice
+    ? `https://s.m.taobao.com/h5?q=${query}`
+    : `https://s.taobao.com/search?q=${query}`;
 }
 
-function buildCnSearchLinks(lens: Lens): PurchaseLink[] {
+function buildCnSearchLinks(lens: Lens, isMobileDevice: boolean): PurchaseLink[] {
   return [
-    { channel: "jd", label: CHANNEL_LABELS.jd, url: buildJdUrl(lens), isAffiliate: false },
-    { channel: "taobao", label: CHANNEL_LABELS.taobao, url: buildTaobaoUrl(lens), isAffiliate: false },
+    { channel: "jd", label: CHANNEL_LABELS.jd, url: buildJdUrl(lens, isMobileDevice), isAffiliate: false },
+    { channel: "taobao", label: CHANNEL_LABELS.taobao, url: buildTaobaoUrl(lens, isMobileDevice), isAffiliate: false },
   ];
 }
 
@@ -238,9 +242,10 @@ export function buildPurchaseLinks(
   locale: string,
   countryCode: string,
   customId?: string,
+  isMobileDevice = false,
 ): PurchaseLink[] {
   if (locale === "zh") {
-    return buildCnSearchLinks(lens);
+    return buildCnSearchLinks(lens, isMobileDevice);
   }
 
   const newEntries = lens.pricing?.global?.new ?? [];

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -142,14 +142,18 @@ function buildBhPhotoUrl(lens: Lens, locale: string): string {
 // Mainland search-jump links. We can't run an affiliate program here (JD/Taobao
 // promotion filing requires an ICP-registered site), so these are plain search
 // URLs built from the lens's zh alias — a non-affiliate price-check convenience.
+// They target the mobile H5 domains (so.m.jd.com / s.m.taobao.com) so phones get
+// the native "open in app" handoff the platforms' own H5 pages provide, instead
+// of the desktop search site. (WeChat's in-app browser still blocks the app
+// handoff — a platform limitation we can't work around.)
 function buildJdUrl(lens: Lens): string {
   const query = getSearchQuery(lens, "zh");
-  return `https://search.jd.com/Search?keyword=${encodeURIComponent(query)}&enc=utf-8`;
+  return `https://so.m.jd.com/ware/search.action?keyword=${encodeURIComponent(query)}`;
 }
 
 function buildTaobaoUrl(lens: Lens): string {
   const query = getSearchQuery(lens, "zh");
-  return `https://s.taobao.com/search?q=${encodeURIComponent(query)}`;
+  return `https://s.m.taobao.com/h5?q=${encodeURIComponent(query)}`;
 }
 
 function buildCnSearchLinks(lens: Lens): PurchaseLink[] {

--- a/src/lib/purchase-links.ts
+++ b/src/lib/purchase-links.ts
@@ -142,10 +142,11 @@ function buildBhPhotoUrl(lens: Lens, locale: string): string {
 // Mainland search-jump links. We can't run an affiliate program here (JD/Taobao
 // promotion filing requires an ICP-registered site), so these are plain search
 // URLs built from the lens's zh alias — a non-affiliate price-check convenience.
-// On phones we target the mobile H5 domains (so.m.jd.com / s.m.taobao.com) so the
-// platforms' own "open in app" handoff kicks in; on desktop we keep the regular
-// search site, which is laid out for a wide viewport. (WeChat's in-app browser
-// still blocks the app handoff — a platform limitation we can't work around.)
+// On phones we target the mobile H5 domains (so.m.jd.com / main.m.taobao.com) so
+// the platforms' own "open in app" handoff kicks in; on desktop we keep the
+// regular search site, which is laid out for a wide viewport. (WeChat's in-app
+// browser still blocks the app handoff — a platform limitation we can't work
+// around.)
 function buildJdUrl(lens: Lens, isMobileDevice: boolean): string {
   const query = encodeURIComponent(getSearchQuery(lens, "zh"));
   return isMobileDevice
@@ -156,7 +157,7 @@ function buildJdUrl(lens: Lens, isMobileDevice: boolean): string {
 function buildTaobaoUrl(lens: Lens, isMobileDevice: boolean): string {
   const query = encodeURIComponent(getSearchQuery(lens, "zh"));
   return isMobileDevice
-    ? `https://s.m.taobao.com/h5?q=${query}`
+    ? `https://main.m.taobao.com/search/index.html?pageType=3&q=${query}`
     : `https://s.taobao.com/search?q=${query}`;
 }
 


### PR DESCRIPTION
## What

zh price-check links now pick the JD/Taobao domain by **device**:

| | Desktop | Mobile |
|---|---|---|
| JD | `search.jd.com/Search?keyword=` | `so.m.jd.com/ware/search.action?keyword=` |
| Taobao | `s.taobao.com/search?q=` | `main.m.taobao.com/search/index.html?q=` |

## Why

On phones the mobile H5 pages carry the platforms' own native **"open in app"** handoff, which the desktop search site doesn't. Desktop keeps the wide-layout search site. (We don't hand-roll URL-scheme detection — keyword-search pages don't support it anyway, and the H5 pages do the handoff for us.)

## How — `useIsMobileDevice`

New hook: a **User-Agent device check**, intentionally separate from the existing `useBreakpoint` (a **viewport check** — its own JSDoc notes "not a device check"). A desktop browser resized narrow is still desktop here, because there's no native app to hand off to. App handoff is a device property, not a viewport one.

Same `useSyncExternalStore` + desktop-default-on-server pattern as `useCountryCode`: statically generated pages (lens detail / collections use `generateStaticParams`) stay static — server/build renders desktop URLs, the client swaps post-hydration, **no hydration mismatch and no forced dynamic SSR**.

## Known limitation
WeChat's in-app browser blocks the app handoff (Tencent/Alibaba mutual blocking) — unavoidable, noted in a source comment.

## Test plan
- [x] Desktop UA renders `search.jd.com` / `s.taobao.com`; isMobileDevice flows end-to-end
- [x] UA regex: iPhone/Android → true, macOS/Windows desktop → false
- [x] typecheck + eslint clean
- [ ] Real-device check (app handoff on a phone with JD/Taobao installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)