### PR TITLE
fix(drawer): scope swipe-ignore to controls so the header keeps its scroll guard

### DIFF
--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -240,6 +240,14 @@ export default function LensSearchDialog({
 
           <div
             ref={scrollContainerRef}
+            // data-base-ui-swipe-ignore: tapping a result triggers close (handleSelect →
+            // setOpen(false)); without it the tap starts Base UI swipe tracking and flashes
+            // the drawer mid-close on iOS. Scoped to the results region, not the header, on
+            // purpose — the attribute also turns off Base UI's background-scroll guard, so
+            // swipe-ignoring the non-scrollable header would let the overlay pan / the page
+            // scroll through with the keyboard up. This region is natively scrollable, so
+            // the browser still contains the drag.
+            data-base-ui-swipe-ignore=""
             // scrollPaddingBottom keeps arrow-key scrollIntoView landing above the keyboard
             style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -141,18 +141,7 @@ const DialogContent = React.forwardRef<
             <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
               <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
             </div>
-            {/* The drag handle above is the only swipe-to-dismiss surface; everything
-                below is opted out of swipe tracking. Base UI treats the whole popup as a
-                swipe surface, so a *tap* on any in-drawer control (a Cancel button, a
-                search result) starts swipe tracking — it puts `transition: none` + a
-                transform on the popup that lingers into the close the same tap triggers,
-                flashing the drawer back mid-exit on iOS. display:contents keeps the flex
-                layout flat. NB: data-base-ui-swipe-ignore is the ONLY opt-out Base UI
-                honors on touch — `Drawer.Content` (data-drawer-content) is checked on the
-                pointer path only, so it does NOT fix this on real devices. */}
-            <div data-base-ui-swipe-ignore className="contents">
-              {children}
-            </div>
+            {children}
             {layerRef && <div ref={layerRef} />}
           </DrawerPrimitive.Popup>
         </DrawerPrimitive.Viewport>
@@ -204,8 +193,17 @@ function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 
 function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
+    // data-base-ui-swipe-ignore stops a TAP on these buttons from starting Base UI's
+    // swipe tracking, which puts `transition: none` on the popup and flashes the drawer
+    // back mid-close on iOS. Keep it scoped to close-triggering controls — do NOT swipe-
+    // ignore the whole popup/header: the same attribute also disables Base UI's
+    // background-scroll guard for that element (its document touchmove handler early-
+    // returns on `ignoreTouchSwipeRef`), and on the non-scrollable header that lets the
+    // overlay pan + the page scroll through when the keyboard is up. The header must stay
+    // swipe-active so the guard keeps protecting it.
     <div
       data-slot="dialog-footer"
+      data-base-ui-swipe-ignore=""
       className={cn("flex items-center justify-end gap-3 px-5 py-4 border-t border-zinc-200 dark:border-zinc-800", className)}
       {...props}
     />


### PR DESCRIPTION
Follow-up to #352.

## Problem
#352 fixed the iOS close-flash by wrapping the **entire** drawer content in one `data-base-ui-swipe-ignore` region. Too broad: Base UI's document-level touchmove guard (the thing that stops the background from scrolling) early-returns on swipe-ignored elements —

```js
function handleNativeTouchMove(event) {
  if (ignoreTouchSwipeRef.current) return; // no preventDefault → background scrolls
  ...
}
```

So swipe-ignoring the non-scrollable header turned off penetration protection there. With the keyboard up, dragging the header (or search box) panned the whole overlay and scrolled the lens list behind it.

## Fix
Narrow the swipe-ignore back to the **close-triggering controls only** — the `DialogFooter` and the search results region — and leave the header/chrome swipe-active so Base UI's guard keeps protecting it.

- Close flash: still fixed (taps on Cancel / a result don't start swipe tracking).
- Header: no longer leaks scroll to the background (guard runs again).
- Residual: the iOS visual-viewport **pan** (overlay drifting while the keyboard is up) is the inherent fixed-overlay limitation — `preventDefault` can't cancel it — and is out of scope here.

## Test plan
- [x] Local (DOM probe): a touch tap on Cancel and on a search result no longer sets `data-swiping` (flash fixed); the header is no longer inside a swipe-ignore region, and a header drag engages Base UI swipe (guard active).
- [ ] On-device (iOS): close flash still gone; dragging the header with the keyboard up no longer scrolls the background list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)