### PR TITLE
refactor(hooks): React hooks hygiene — drop cheap memos, migrate browser-source hooks to useSyncExternalStore

### DIFF
--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useCallback } from "react";
+import { useRef, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { useCompare } from "@/context/CompareProvider";
@@ -31,13 +31,9 @@ export default function CompareBar({ allLenses }: { allLenses: Lens[] }) {
   const { onSelectLens, getResultState } = useCompareLensSearch();
   const clearCompareWithUndo = useClearCompareWithUndo();
 
-  const selectedLenses = useMemo(
-    () =>
-      compareIds
-        .map((id) => allLenses.find((l) => l.id === id))
-        .filter((lens) => lens !== undefined),
-    [compareIds, allLenses]
-  );
+  const selectedLenses = compareIds
+    .map((id) => allLenses.find((l) => l.id === id))
+    .filter((lens) => lens !== undefined);
 
   const chipsRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useCallback } from "react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { useCompare } from "@/context/CompareProvider";
 import { useCompareLensSearch } from "@/hooks/useCompareLensSearch";
@@ -25,7 +25,6 @@ export default function CompareBar({ allLenses }: { allLenses: Lens[] }) {
   const tBrand = useTranslations("Brands");
   const tCompare = useTranslations("Compare");
   const router = useRouter();
-  const locale = useLocale();
   const mount = useEffectiveMount();
   const { compareIds, remove } = useCompare();
   const { onSelectLens, getResultState } = useCompareLensSearch();

--- a/src/components/ComparePageHeader.tsx
+++ b/src/components/ComparePageHeader.tsx
@@ -28,13 +28,9 @@ export default function ComparePageHeader({ allLenses }: { allLenses: Lens[] }) 
   const locale = useLocale();
   const lang = locale === "zh" ? "zh" : "en";
 
-  const activeLenses = useMemo(
-    () =>
-      compareIds
-        .map((id) => allLenses.find((l) => l.id === id))
-        .filter((l): l is Lens => l !== undefined),
-    [compareIds, allLenses],
-  );
+  const activeLenses = compareIds
+    .map((id) => allLenses.find((l) => l.id === id))
+    .filter((l): l is Lens => l !== undefined);
 
   // Reverse-derive the matching curated preset (if any) from the current
   // compare state. `?ids=` is the URL's single source of truth, so a preset

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,11 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 // Tailwind v4 exposes every @theme breakpoint as a CSS custom property
 // (e.g. --breakpoint-sm: 40rem) on :root, so Tailwind's config stays the
 // single source of truth for both CSS and JS.
 type Breakpoint = "sm" | "md" | "lg" | "xl" | "2xl";
+
+function getMediaQuery(bp: Breakpoint): MediaQueryList | null {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--breakpoint-${bp}`)
+    .trim();
+  return value ? window.matchMedia(`(min-width: ${value})`) : null;
+}
 
 /**
  * Returns whether the viewport is at least as wide as the given Tailwind
@@ -13,24 +20,31 @@ type Breakpoint = "sm" | "md" | "lg" | "xl" | "2xl";
  * CSS variable, so changing the Tailwind theme propagates automatically.
  *
  * Note: this is a viewport check, not a device check. A desktop browser
- * resized to 400px will read as below `sm`.
+ * resized to 400px reads as below `sm`. (For a device check, see
+ * useIsMobileDevice.)
+ *
+ * matchMedia is a live, mutable browser source (resize / orientation), so this
+ * uses useSyncExternalStore — the same pattern as useCountryCode — for a
+ * tear-free, hydration-safe read.
  */
 export function useBreakpoint(bp: Breakpoint): boolean {
-  const [matches, setMatches] = useState(false);
+  // bp is captured in the closures, so memoize them — a fresh identity each
+  // render would make useSyncExternalStore re-subscribe every time.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const mq = getMediaQuery(bp);
+      if (!mq) {
+        return () => {};
+      }
+      mq.addEventListener("change", onChange);
+      return () => mq.removeEventListener("change", onChange);
+    },
+    [bp],
+  );
 
-  useEffect(() => {
-    const value = getComputedStyle(document.documentElement)
-      .getPropertyValue(`--breakpoint-${bp}`)
-      .trim();
-    if (!value) {
-      return;
-    }
-    const mq = window.matchMedia(`(min-width: ${value})`);
-    setMatches(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, [bp]);
+  const getSnapshot = useCallback(() => getMediaQuery(bp)?.matches ?? false, [bp]);
 
-  return matches;
+  // false during SSR + hydration (no matchMedia on the server), corrected on the
+  // client right after hydration.
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }

--- a/src/hooks/useKeyboardInset.ts
+++ b/src/hooks/useKeyboardInset.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 // Pixels the on-screen keyboard overlaps the bottom of the layout viewport (0 when
 // closed). iOS shrinks only the visual viewport when the keyboard opens, so this is
@@ -8,31 +8,36 @@ import { useEffect, useState } from "react";
 // a bottom spacer inside a scroll region so its last rows can clear the keyboard. This
 // does NOT reposition any fixed element — see [[reference_ios_keyboard_fixed_overlay]]
 // for why driving a fixed overlay's position off visualViewport is a dead end.
+//
+// visualViewport is a live, mutable browser source (fires resize/scroll as the
+// keyboard animates), so this uses useSyncExternalStore for a tear-free read.
+
+function subscribe(onChange: () => void): () => void {
+  const vv = window.visualViewport;
+  if (!vv) {
+    return () => {};
+  }
+  vv.addEventListener("resize", onChange);
+  vv.addEventListener("scroll", onChange);
+  return () => {
+    vv.removeEventListener("resize", onChange);
+    vv.removeEventListener("scroll", onChange);
+  };
+}
+
+function getSnapshot(): number {
+  const vv = window.visualViewport;
+  if (!vv) {
+    return 0;
+  }
+  return Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+}
+
+// No keyboard on the server; 0 during SSR + hydration.
+function getServerSnapshot(): number {
+  return 0;
+}
+
 export function useKeyboardInset(): number {
-  const [inset, setInset] = useState(0);
-
-  useEffect(() => {
-    const vv = window.visualViewport;
-    if (!vv) {
-      return;
-    }
-
-    function update() {
-      const v = window.visualViewport;
-      if (!v) {
-        return;
-      }
-      setInset(Math.max(0, window.innerHeight - v.height - v.offsetTop));
-    }
-
-    update();
-    vv.addEventListener("resize", update);
-    vv.addEventListener("scroll", update);
-    return () => {
-      vv.removeEventListener("resize", update);
-      vv.removeEventListener("scroll", update);
-    };
-  }, []);
-
-  return inset;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/lib/usePwa.ts
+++ b/src/lib/usePwa.ts
@@ -1,11 +1,26 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+const STANDALONE = "(display-mode: standalone)";
+
+function subscribe(onChange: () => void): () => void {
+  const mq = window.matchMedia(STANDALONE);
+  mq.addEventListener("change", onChange);
+  return () => mq.removeEventListener("change", onChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(STANDALONE).matches;
+}
+
+// Browser (non-PWA) default during SSR + hydration — no matchMedia on the
+// server. Corrected on the client right after hydration, which removes the
+// post-mount flash the previous useState(false)+useEffect version had.
+function getServerSnapshot(): boolean {
+  return false;
+}
 
 export function usePwa(): boolean {
-  const [isPwa, setIsPwa] = useState(false);
-  useEffect(() => {
-    setIsPwa(window.matchMedia("(display-mode: standalone)").matches);
-  }, []);
-  return isPwa;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
A small hooks-hygiene pass surfaced by an audit of the codebase. Two independent cleanups, no behaviour change.

## A. Drop cheap `useMemo`
`activeLenses` / `selectedLenses` in the compare header/bar map a `≤ MAX_COMPARE (4)`-item id list through `find + filter` — cheap, and the result is only read in-render (`.length` / `.map`), never passed to a `React.memo` child or used in a hook dependency array. The memo earned nothing, so it's now a direct call.

- `ComparePageHeader.tsx` — `activeLenses` (kept the file's other, justified `matchedPreset` memo)
- `CompareBar.tsx` — `selectedLenses`

## B. Migrate live browser-source hooks to `useSyncExternalStore`
These three each mirrored a **live, mutable browser source** into `useState` via `useEffect` — exactly what `useSyncExternalStore` is for (tear-free reads + an explicit `getServerSnapshot`). This matches the pattern already established by `useCountryCode` / `useIsMobileDevice`.

| hook | source |
|---|---|
| `useBreakpoint` | `matchMedia(min-width …)` (resize / orientation) |
| `usePwa` | `matchMedia(display-mode: standalone)` |
| `useKeyboardInset` | `visualViewport` resize/scroll |

`getServerSnapshot` also closes the post-mount flash `usePwa` had (`useState(false)` → effect).

## Scope notes
- `useHorizontalScrollAffordance` was intentionally left alone — it returns two derived booleans off a per-element ResizeObserver, which doesn't map cleanly to a single snapshot.
- Also removed a pre-existing unused `locale` (+ its `useLocale` import) in `CompareBar.tsx` while in the file.

## Test plan
- [x] typecheck + eslint fully clean
- [x] `useBreakpoint`: resize 1280→390 flips `sm` and collapses the nav (subscribe fires, behaviour matches the old version)
- [x] Compare header/bar render at both desktop and mobile widths
- [ ] `useKeyboardInset` real-device check (iOS keyboard) — can't be exercised on desktop; logic is unchanged, only the subscription mechanism moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)