### PR TITLE
feat(drawer): keep content above the keyboard via visualViewport padding

### DIFF
--- a/src/components/LensSearchDialog.tsx
+++ b/src/components/LensSearchDialog.tsx
@@ -15,7 +15,6 @@ import { useTranslations } from "next-intl";
 import { useRouter, Link } from "@/i18n/navigation";
 import { mountToUrlSegment } from "@/lib/mount";
 import { useEffectiveMount } from "@/hooks/useMountParam";
-import { useKeyboardInset } from "@/hooks/useKeyboardInset";
 import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens-search";
 import type { Lens } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -69,7 +68,6 @@ export default function LensSearchDialog({
   const inputId = useId();
   const resultsId = useId();
   const deferredQuery = useDeferredValue(query);
-  const keyboardInset = useKeyboardInset();
 
   // Reset state on close
   useEffect(() => {
@@ -248,8 +246,6 @@ export default function LensSearchDialog({
             // scroll through with the keyboard up. This region is natively scrollable, so
             // the browser still contains the drag.
             data-base-ui-swipe-ignore=""
-            // scrollPaddingBottom keeps arrow-key scrollIntoView landing above the keyboard
-            style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
             {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
@@ -335,12 +331,6 @@ export default function LensSearchDialog({
                   </FeedbackTrigger>
                 </p>
               </div>
-            )}
-            {/* Spacer that reserves the keyboard's height inside the scroll area so the
-                last result can be scrolled clear of the on-screen keyboard. Collapses to
-                0 when the keyboard is down. */}
-            {keyboardInset > 0 && (
-              <div aria-hidden style={{ height: keyboardInset }} />
             )}
           </div>
         </DialogContent>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -117,14 +117,17 @@ const DialogContent = React.forwardRef<
 ) {
   const mode = useDialogMode();
   // iOS only shrinks the visual viewport for the keyboard; a `fixed; bottom: 0` drawer
-  // stays anchored to the layout viewport, i.e. behind the keyboard, and iOS's native
-  // scroll-into-view of the focused input is unreliable on the first open. Lift the whole
-  // drawer above the keyboard ourselves by its height (visualViewport-derived). Only
-  // `bottom` — not `max-height` — so a no-inner-scroll drawer (feedback) keeps its footer
-  // above the keyboard and clips at the top instead of pushing the footer back behind it.
-  // base-ui owns `transform` (slide/swipe), so driving `bottom` doesn't fight it.
+  // stays anchored to the layout viewport (behind the keyboard) and iOS's native
+  // scroll-into-view of the focused input is unreliable on the first open. Lift the
+  // CONTENT above the keyboard with padding-bottom = keyboard height (visualViewport-
+  // derived) — NOT by moving the box up via `bottom`. Keeping the box at `bottom: 0`
+  // means its background still fills the full height down to the screen edge, so nothing
+  // shows through behind the keyboard; and because the box still tops out at max-h-[85svh]
+  // rather than being pushed up, the input/header don't clip off the top. The padding
+  // replaces the safe-area bottom inset, which is irrelevant while the keyboard covers it.
+  // base-ui owns `transform` (slide/swipe), so driving padding/`bottom` doesn't fight it.
   const keyboardInset = useKeyboardInset();
-  const drawerLiftStyle = keyboardInset > 0 ? { bottom: keyboardInset } : undefined;
+  const drawerKeyboardStyle = keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined;
 
   if (mode === "drawer") {
     return (
@@ -146,7 +149,7 @@ const DialogContent = React.forwardRef<
               className,
               "rounded-t-2xl rounded-b-none"
             )}
-            style={drawerLiftStyle}
+            style={drawerKeyboardStyle}
             {...(props as Omit<typeof props, "style">)}
           >
             <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { FROSTED_OVERLAY_CHROME_CLS, ICON_CLOSE_BTN_CLS } from "@/lib/ui-tokens";
 import { Z } from "@/config/ui";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
+import { useKeyboardInset } from "@/hooks/useKeyboardInset";
 
 const DialogModeContext = React.createContext<"dialog" | "drawer">("dialog");
 function useDialogMode() {
@@ -115,6 +116,15 @@ const DialogContent = React.forwardRef<
   ref
 ) {
   const mode = useDialogMode();
+  // iOS only shrinks the visual viewport for the keyboard; a `fixed; bottom: 0` drawer
+  // stays anchored to the layout viewport, i.e. behind the keyboard, and iOS's native
+  // scroll-into-view of the focused input is unreliable on the first open. Lift the whole
+  // drawer above the keyboard ourselves by its height (visualViewport-derived). Only
+  // `bottom` — not `max-height` — so a no-inner-scroll drawer (feedback) keeps its footer
+  // above the keyboard and clips at the top instead of pushing the footer back behind it.
+  // base-ui owns `transform` (slide/swipe), so driving `bottom` doesn't fight it.
+  const keyboardInset = useKeyboardInset();
+  const drawerLiftStyle = keyboardInset > 0 ? { bottom: keyboardInset } : undefined;
 
   if (mode === "drawer") {
     return (
@@ -136,6 +146,7 @@ const DialogContent = React.forwardRef<
               className,
               "rounded-t-2xl rounded-b-none"
             )}
+            style={drawerLiftStyle}
             {...(props as Omit<typeof props, "style">)}
           >
             <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">


### PR DESCRIPTION
## What
Drive keyboard avoidance ourselves instead of relying on iOS's flaky native scroll-into-view. iOS shrinks only the visual viewport for the keyboard; a `fixed; bottom: 0` drawer stays anchored to the layout viewport (behind the keyboard). Read the keyboard height from `visualViewport` (the existing `useKeyboardInset` hook) and apply it as **`padding-bottom`** on the drawer popup, so the content (footer / results) is pushed up to the keyboard line. Deterministic on the first open.

Why padding-bottom and not `bottom`: keeping the box anchored at `bottom: 0` means its background still fills the full height behind the keyboard (no page background bleeding through above the keyboard), and the box still tops out at `max-h-[85svh]` rather than being lifted off the top — so the input/header stay on screen. (An earlier revision moved the box up via `bottom`; that left a background gap above the keyboard and clipped the input on short screens.)

- Driving padding doesn't fight base-ui (it owns `transform` for slide/swipe).
- Removes the search results keyboard spacer (#352) — pushing the content above the keyboard subsumes it.

## Confirmed conclusion (web-grounded)
iOS has no native/CSS keyboard avoidance for a fixed overlay: VirtualKeyboard API isn't in WebKit, `interactive-widget` is Chromium/Firefox only, the iOS keyboard resizes only the visual viewport. `visualViewport`-driven JS is the only deterministic lever. The residual visual-viewport **pan** (overlay drifting while focused) is irreducible for a fixed overlay and is out of scope.

## Verified (simulated visualViewport −290px on a 667px viewport)
- Popup `bottom` stays `0` and reaches the screen bottom → no background bleed-through.
- `padding-bottom` = 290; footer / content sits at the keyboard line.
- Search input fully visible (was clipped when the box was lifted).

## Test plan
- [ ] **On-device / preview (iOS Chrome + Safari):** first-open avoidance fires reliably; no background strip above the keyboard; search input fully visible; feedback footer above the keyboard.
- [ ] No regression to the close-flash / scroll-guard fixes (#352/#355).

Note: a very tall feedback form on a short screen can still clip a px or two of the top chrome (feedback opts out of the height cap so its footer stays pinned) — minor, flagged for eyeballing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)