### PR TITLE
feat(collections): order index sections by filter difficulty, add coverage link

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/page.tsx
@@ -56,16 +56,21 @@ export async function generateMetadata({
   };
 }
 
+// Ordered by how poorly the browse filters can reconstruct each category:
+// collections covering a dimension the filters lack entirely (price, weight,
+// aperture threshold, sub-brand series, multi-axis Chinese combos) lead, since
+// they are the only path to that set. Categories that a single filter toggle
+// reproduces (brand, weather/OIS traits, optical-trait dedicated optics) trail.
 const CATEGORIES = [
-  { id: "section-prime", key: "category_prime", slugs: PRIME_SLUGS, marker: ["PRIME"] },
-  { id: "section-zoom", key: "category_zoom", slugs: ZOOM_SLUGS, marker: ["ZOOM"] },
-  { id: "section-brand", key: "category_brand", slugs: BRAND_SLUGS, marker: ["BRAND"] },
-  { id: "section-series", key: "category_series", slugs: SERIES_SLUGS, marker: ["SERIES"] },
-  { id: "section-chinese", key: "category_chinese", slugs: CHINESE_SLUGS, marker: ["CN"] },
-  { id: "section-price", key: "category_price", slugs: PRICE_SLUGS, marker: ["$"] },
   { id: "section-portability", key: "category_portability", slugs: PORTABILITY_SLUGS, marker: ["G"] },
   { id: "section-aperture", key: "category_aperture", slugs: APERTURE_SLUGS, marker: ["ƒ"], markerItalic: true },
+  { id: "section-price", key: "category_price", slugs: PRICE_SLUGS, marker: ["$"] },
+  { id: "section-chinese", key: "category_chinese", slugs: CHINESE_SLUGS, marker: ["CN"] },
+  { id: "section-series", key: "category_series", slugs: SERIES_SLUGS, marker: ["SERIES"] },
+  { id: "section-prime", key: "category_prime", slugs: PRIME_SLUGS, marker: ["PRIME"] },
+  { id: "section-zoom", key: "category_zoom", slugs: ZOOM_SLUGS, marker: ["ZOOM"] },
   { id: "section-trait", key: "category_trait", slugs: TRAIT_SLUGS, marker: ["WR"] },
+  { id: "section-brand", key: "category_brand", slugs: BRAND_SLUGS, marker: ["BRAND"] },
   { id: "section-dedicated", key: "category_dedicated", slugs: DEDICATED_SLUGS, marker: ["✦"] },
 ] as const;
 
@@ -109,9 +114,20 @@ export default async function CollectionsIndexPage({
           convey — collection and lens counts — plus a short subtitle. */}
       <header id="collections-top" className="pb-3">
         <h1 className="sr-only">{t("indexTitle")}</h1>
-        <p className="text-[15px] font-medium text-zinc-900 dark:text-zinc-100">
-          {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
-        </p>
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+          <p className="text-[15px] font-medium text-zinc-900 dark:text-zinc-100">
+            {t("indexStats", { count: totalCollections, lensCount: totalLenses })}
+          </p>
+          {/* Mirror the browse view: surface coverage next to the count, where
+              users form the "is this complete?" judgment, instead of leaving it
+              buried in About. */}
+          <Link
+            href="/about#coverage"
+            className="whitespace-nowrap text-xs text-zinc-400 underline-offset-2 transition-colors hover:text-zinc-600 hover:underline dark:text-zinc-500 dark:hover:text-zinc-300"
+          >
+            {t("coverageLink")}
+          </Link>
+        </div>
         <p className="mt-1 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
           {t("indexSubtitle")}
         </p>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -524,6 +524,7 @@
     "indexDescription": "Curated lens collections for the Fujifilm X-mount system — organized by focal length, brand, aperture, and more.",
     "indexStats": "{count} collections · {lensCount} lenses",
     "indexSubtitle": "Organized by focal length, brand, aperture, and more.",
+    "coverageLink": "View lens coverage →",
     "category_prime": "Prime Lenses",
     "category_zoom": "Zoom Lenses",
     "category_brand": "By Brand",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -524,6 +524,7 @@
     "indexDescription": "富士 X 卡口镜头合集——按焦段、品牌、光圈等维度分类整理。",
     "indexStats": "共 {count} 个合集 · {lensCount} 支镜头",
     "indexSubtitle": "按焦段、品牌、光圈等维度分类整理",
+    "coverageLink": "查看收录范围 →",
     "category_prime": "定焦",
     "category_zoom": "变焦",
     "category_brand": "品牌",


### PR DESCRIPTION
## What

Two changes to the Collections Index page (`/lenses/[mount]/collections`):

1. **Reorder the section categories by filter difficulty.** Sections leading the page are now the ones the browse filters cannot reconstruct at all — each covers a dimension the filter vocabulary lacks:
   - Portability (no weight/length filter, only sort)
   - Aperture (no aperture-threshold or constant-aperture filter)
   - Price (no price filter at all)
   - Chinese (no nationality meta-filter; each entry is a multi-axis combo)
   - Series (brand filter is brand-level, can't isolate XF/XC, Air/Pro…)

   Sections a single filter toggle reproduces (Brand, Trait wr/ois, Dedicated optical-trait optics) move to the tail. Prime/Zoom sit in the middle — coarse focal buckets approximate but can't isolate exact focal lengths.

2. **Surface the "view lens coverage" link** next to the collection/lens count, mirroring the browse view. The completeness cue now sits where users form the "is this complete?" judgment instead of being buried in About. Adds a `Collection.coverageLink` i18n key (en/zh).

## Notes

- Order lives in a single source of truth (`CATEGORIES` in `collections/page.tsx`); the section nav and chip rail derive from it, so no other call site needed updating.
- Could not render locally to screenshot — this worktree is missing the `@opennextjs/cloudflare` dependency, so the dev server won't boot. The change is a literal array reorder plus a static link rendered by a direct `.map`, so the visual result is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)