### PR TITLE
fix(purchase): redact check-price channels + price figure, flush dropdown hover

### DIFF
--- a/src/components/PurchaseLinks.tsx
+++ b/src/components/PurchaseLinks.tsx
@@ -35,7 +35,7 @@ function PurchaseLinkList({ links, lensId, customId, className }: { links: Purch
           })}
           className={LINK_CLS}
         >
-          {link.label}
+          <span data-redact-hook="priceSource">{link.label}</span>
           <ArrowUpRight className="size-3" aria-hidden="true" />
         </a>
       ))}

--- a/src/components/RetailersDropdown.tsx
+++ b/src/components/RetailersDropdown.tsx
@@ -44,7 +44,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
             sits on one line; the chevron stays center-aligned via the trigger. */}
         <span className="inline-flex items-baseline gap-1.5">
           {t("buyAt")}
-          <span className="text-xs text-zinc-400 dark:text-zinc-500">
+          <span data-redact-hook="priceSource" className="text-xs text-zinc-400 dark:text-zinc-500">
             {preview}{extra}
           </span>
         </span>
@@ -57,7 +57,7 @@ export function RetailersDropdown({ lens, customId }: Props) {
               <DropdownItem key={link.channel} link={link} lensId={lens.id} customId={customId} />
             ))}
             {showDisclosure && (
-              <p className="mt-1 border-t border-zinc-100 px-3 py-2 text-[10px] leading-relaxed text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+              <p className="border-t border-zinc-100 px-3 py-2 text-[10px] leading-relaxed text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
                 <Info size={11} className="inline -mt-px mr-1 text-zinc-400 dark:text-zinc-500" aria-hidden="true" />
                 {t(purchaseDisclosureKey(locale))}
               </p>
@@ -83,7 +83,7 @@ function DropdownItem({ link, lensId, customId }: { link: PurchaseLink; lensId: 
       })}
       className="flex items-center justify-between px-3 py-2.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
     >
-      <span>{link.label}</span>
+      <span data-redact-hook="priceSource">{link.label}</span>
       <ArrowUpRight size={12} className="text-zinc-400" />
     </a>
   );

--- a/src/components/TestHookPanel.tsx
+++ b/src/components/TestHookPanel.tsx
@@ -12,6 +12,12 @@ import {
 } from "@/components/ui/select";
 import { TestHookContext } from "@/context/TestHookProvider";
 import { TESTHOOK_OPTION_DEFINITIONS } from "@/lib/testhook";
+import {
+  REDACTION_KEYS,
+  REDACTION_QUERY_KEY,
+  REDACTION_BLUR_QUERY_KEY,
+  DEFAULT_REDACTION_BLUR_PX,
+} from "@/lib/redaction";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const collectionsData = require("@/data/collections.json") as {
   collections: { slug: string; title: { en: string } }[];
@@ -126,6 +132,30 @@ export default function TestHookPanel() {
             ))}
           </div>
         )}
+      </div>
+
+      {/* Demo-mode redaction reference. Activated by URL query (read by the
+          Redaction component), so the recording session can blur sensitive
+          surfaces without touching code. Values come from the redaction
+          constants to stay in sync. */}
+      <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-800">
+        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+          Redaction (demo blur)
+        </span>
+        <div className="mt-2 space-y-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400 [&_code]:rounded [&_code]:bg-zinc-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] [&_code]:text-zinc-700 dark:[&_code]:bg-zinc-800 dark:[&_code]:text-zinc-300">
+          <p>
+            <code>?{REDACTION_QUERY_KEY}={REDACTION_KEYS.join(",")}</code> — blur surfaces
+          </p>
+          <p>
+            <code>&{REDACTION_BLUR_QUERY_KEY}={DEFAULT_REDACTION_BLUR_PX}</code> — blur px (default {DEFAULT_REDACTION_BLUR_PX})
+          </p>
+          <p>
+            <code>?{REDACTION_QUERY_KEY}=</code> — clear all
+          </p>
+          <p>
+            <code>priceSource</code> = buy channels + price source · <code>posterQr</code> = poster QR
+          </p>
+        </div>
       </div>
 
       <div className="mt-4 flex justify-end gap-2">


### PR DESCRIPTION
## What

Redaction + purchase-channel dropdown fixes.

### 1. Redact the "check price" channels
Demo-mode redaction (`data-redact-hook="priceSource"`) only covered the price-source line and poster QR. The **check-price surfaces added later** leaked channel names while screen-recording:
- **Detail page** — `RetailersDropdown`: trigger preview hint + each dropdown item label.
- **Compare page (desktop + mobile)** — `PurchaseLinksCompact` → `PurchaseLinkList`: every retailer label.

### 2. New `price` redact target
Added a third redaction key, `price`, that blurs the **price figure itself** (distinct from `priceSource`, which only blurs the channel/source name). Marked on every price render site: `PriceSection` (detail), `PriceCell` (compare), `LensCardPrice` (card), `SharePoster` (poster). So redaction now has 1 method (CSS blur) × 3 targets: `price`, `priceSource`, `posterQr`. Verified each is independently togglable via `?redact=`.

### 3. Flush the dropdown hover background
The retailer dropdown's disclosure footer carried a stray `mt-1`, leaving a 4px un-hoverable strip below the last item — its hover background stopped short of the divider. Removed it (separation already carried by `border-t` + `py-2`); measured flush (gap 0). Swept the other full-bleed hover menus (sort, mount, nav overflow) — all measure flush (edge gaps = 1px border); inset rounded-item menus are a different pattern by design.

### 4. Document internal params
Added a "Redaction (demo blur)" reference to `TestHookPanel` (sourced from the redaction constants, no drift). Anchored the internal/debug URL params and the `xg_internal` cookie to the Atlens "Internal params & cookies" Obsidian doc via `INTERNAL PARAM` comments at each source (`testhook`, `redaction`, `middleware`).

## Test plan
- `?redact=price` / `?redact=priceSource` / `?redact=posterQr` toggle independently; channel names and price figures blur; clearing restores.
- Detail check-price dropdown: hover the last option → background reaches the divider.
- `?testhook=1` (dev only) → panel shows the redaction reference incl. `price`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)