### PR TITLE
fix(filters): keep the +N count visible on the mobile brand trigger

### DIFF
--- a/src/components/LensFilters.tsx
+++ b/src/components/LensFilters.tsx
@@ -43,19 +43,20 @@ export default function LensFilters({
   const tBrand = useTranslations("Brands");
   const [secondaryOpen, setSecondaryOpen] = useState(false);
 
+  // The mobile dropdown lists up to BRAND_PREVIEW_LIMIT selected brand names;
+  // any beyond that collapse into a separate "+N" badge (rendered outside the
+  // truncating label in BrandFilterMenu) so the count is never clipped. Once a
+  // brand is chosen the label drops the "Brand:" prefix — the filled pill plus
+  // its position already read as the brand filter, and the names get the room.
   const BRAND_PREVIEW_LIMIT = 2;
   const brandJoiner = t("brandSeparator");
   const brandNames = Object.fromEntries(available.brands.map((b) => [b, tBrand(b)]));
   const selectedBrandNames = filters.brands.map((b) => brandNames[b] ?? b);
+  const brandExtraCount = Math.max(0, selectedBrandNames.length - BRAND_PREVIEW_LIMIT);
   const brandTriggerLabel =
     selectedBrandNames.length === 0
       ? t("brand")
-      : selectedBrandNames.length <= BRAND_PREVIEW_LIMIT
-        ? t("brandTriggerLabel", { names: selectedBrandNames.join(brandJoiner) })
-        : t("brandTriggerLabelMore", {
-            names: selectedBrandNames.slice(0, BRAND_PREVIEW_LIMIT).join(brandJoiner),
-            extra: selectedBrandNames.length - BRAND_PREVIEW_LIMIT,
-          });
+      : selectedBrandNames.slice(0, BRAND_PREVIEW_LIMIT).join(brandJoiner);
 
   useFiltersTelemetry(filters);
 
@@ -253,6 +254,7 @@ export default function LensFilters({
                 brandLabels={brandNames}
                 allLabel={allOptionLabel}
                 triggerLabel={brandTriggerLabel}
+                extraCount={brandExtraCount}
                 onToggle={(brand) =>
                   updateFilters("brands", toggleMultiFilter(filters.brands, brand, available.brands))
                 }

--- a/src/components/lens-filters/BrandFilterMenu.tsx
+++ b/src/components/lens-filters/BrandFilterMenu.tsx
@@ -25,6 +25,7 @@ interface BrandFilterMenuProps {
   brandLabels: Record<string, string>;
   allLabel: string;
   triggerLabel: string;
+  extraCount: number;
   onToggle: (brand: string) => void;
   onClear: () => void;
 }
@@ -35,6 +36,7 @@ export default function BrandFilterMenu({
   brandLabels,
   allLabel,
   triggerLabel,
+  extraCount,
   onToggle,
   onClear,
 }: BrandFilterMenuProps) {
@@ -44,14 +46,21 @@ export default function BrandFilterMenu({
     <Menu.Root>
       <Menu.Trigger
         className={cn(
-          "inline-flex h-9 min-w-36 max-w-[60%] items-center justify-between gap-1.5 rounded-full border px-3.5 text-[12px] shadow-sm shadow-zinc-950/[0.02] transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 sm:min-w-28",
+          // max-w-full (not a fraction): the trigger grows to fit the selected
+          // brand names up to the row's width, then the label truncates. A
+          // fractional cap could fall below min-w on a narrow phone, which pins
+          // the trigger to min-w and forces truncation even when there's room.
+          "inline-flex h-9 min-w-36 max-w-full items-center justify-between gap-1.5 rounded-full border px-3.5 text-[12px] shadow-sm shadow-zinc-950/[0.02] transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 sm:min-w-28",
           hasSelection
             ? "border-transparent bg-zinc-900 font-medium text-white hover:border-zinc-800 hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-zinc-200"
             : "border-zinc-200 bg-zinc-50 font-medium text-zinc-700 hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300 dark:hover:border-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-100",
         )}
       >
-        <span className="truncate">{triggerLabel}</span>
-        <ChevronDown className="size-3.5 shrink-0 transition-transform duration-200 data-[popup-open]:rotate-180" />
+        <span className="min-w-0 truncate text-left">{triggerLabel}</span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {extraCount > 0 ? <span className="tabular-nums">+{extraCount}</span> : null}
+          <ChevronDown className="size-3.5 transition-transform duration-200 data-[popup-open]:rotate-180" />
+        </span>
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner side="bottom" align="start" sideOffset={6}>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -69,8 +69,6 @@
     "metaDescX": "Fujifilm X-mount lens database. {count} lenses across {brandCount} brands. Normalized specs, cross-brand comparison.",
     "metaDescG": "Fujifilm GFX medium-format lens database. {count} GF lens specs, parameters and side-by-side comparison.",
     "brand": "Brand",
-    "brandTriggerLabel": "Brand: {names}",
-    "brandTriggerLabelMore": "Brand: {names} +{extra}",
     "brandSeparator": ", ",
     "lensType": "Type",
     "allTypes": "All",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -69,8 +69,6 @@
     "metaDescX": "富士 X 卡口镜头数据库，{count} 只镜头覆盖 {brandCount} 个品牌。规格统一标准，跨品牌横向对比。",
     "metaDescG": "富士 GFX 中画幅镜头数据库，{count} 只 GF 镜头规格、参数与横向对比。",
     "brand": "品牌",
-    "brandTriggerLabel": "品牌：{names}",
-    "brandTriggerLabelMore": "品牌：{names} +{extra}",
     "brandSeparator": "、",
     "lensType": "类型",
     "allTypes": "全部",


### PR DESCRIPTION
## Bug

On mobile, the brand filter dropdown trigger collapsed `Brand: {names} +N` into a single truncating label. Long Latin brand names ("Fujifilm, Sigma") pushed the **`+N` past the ellipsis so it disappeared** — the most important part (the overflow count) was the thing getting clipped. It read as "the +N overflow stopped working." Chinese was less obviously broken only because its brand names are short (富士/适马).

Root cause was twofold:
1. The `+N` lived *inside* the truncating label.
2. `max-w-[60%]` of the narrow filter row resolved to ~134px, **below** `min-w-36` (144px). When `min-width > max-width`, CSS pins to min-width — so the trigger was stuck at its minimum and truncated even when the row had room.

## Fix

- Render `+N` as a `shrink-0` badge **outside** the truncating label → always visible; only the names truncate.
- Drop the `Brand:` prefix once a brand is selected — the filled pill already reads as the brand filter, freeing room for the names.
- `max-w-full` instead of a fraction, so the trigger grows to fit the selection (up to the row width) and only truncates past that.
- Keep `BRAND_PREVIEW_LIMIT = 2`.

Removed the now-unused `brandTriggerLabel` / `brandTriggerLabelMore` i18n keys.

## Verification (Playwright, 390px, both locales)

| State | Result |
|---|---|
| en, 2–3 brands | `Fujifilm, Sigma +1` — no truncation, +1 visible (152px) |
| en, two long names | `Voigtländer, Brightin Star +1` — fits the row (211px), +1 visible |
| zh, 3 brands | `富士、适马 +1` — fits, +1 visible |
| empty | `Brand` — unchanged |

Mobile-only (`sm:hidden`); desktop uses the inline chip group, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)