### PR TITLE
feat(redaction): add "price" redact target, anchor internal params to docs

### DIFF
--- a/src/components/LensCardPrice.tsx
+++ b/src/components/LensCardPrice.tsx
@@ -32,7 +32,7 @@ export default function LensCardPrice({ lens }: { lens: Lens }) {
 
   return (
     <p className="flex items-baseline gap-1 text-sm">
-      <span className="font-semibold whitespace-nowrap tabular-nums text-zinc-700 dark:text-zinc-200">
+      <span data-redact-hook="price" className="font-semibold whitespace-nowrap tabular-nums text-zinc-700 dark:text-zinc-200">
         {t.rich("priceApprox", {
           price: priceDisplay,
           approx: (chunks) => (

--- a/src/components/PriceCell.tsx
+++ b/src/components/PriceCell.tsx
@@ -36,6 +36,7 @@ export function PriceCell({ lens, compact = false }: Props) {
   return (
     <div className="flex flex-col items-center gap-1 text-center">
       <span
+        data-redact-hook="price"
         className={cn(
           "font-semibold tabular-nums text-zinc-700 dark:text-zinc-200",
           compact ? "text-sm" : "text-base",

--- a/src/components/PriceSection.tsx
+++ b/src/components/PriceSection.tsx
@@ -39,7 +39,7 @@ export function PriceSection({ lens }: Props) {
   return (
     <div className="flex flex-col gap-1">
       {/* Row 1: Price + approx */}
-      <span className="text-xl font-semibold tabular-nums text-zinc-700 dark:text-zinc-200">
+      <span data-redact-hook="price" className="text-xl font-semibold tabular-nums text-zinc-700 dark:text-zinc-200">
         {t.rich("priceApprox", {
           price: priceDisplay,
           approx: (chunks) => (

--- a/src/components/TestHookPanel.tsx
+++ b/src/components/TestHookPanel.tsx
@@ -153,7 +153,7 @@ export default function TestHookPanel() {
             <code>?{REDACTION_QUERY_KEY}=</code> — clear all
           </p>
           <p>
-            <code>priceSource</code> = buy channels + price source · <code>posterQr</code> = poster QR
+            <code>price</code> = price figures · <code>priceSource</code> = buy channels + price source · <code>posterQr</code> = poster QR
           </p>
         </div>
       </div>

--- a/src/components/poster/SharePoster.tsx
+++ b/src/components/poster/SharePoster.tsx
@@ -648,7 +648,7 @@ export function SharePoster({ lenses, labels, custom, shareUrl, ref }: SharePost
               const sampledDisplay = formatSampledAt(sel.entry.sampledAt, labels.locale);
               return (
                 <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
-                  <span className={cn("font-semibold tabular-nums text-zinc-700 leading-none", statSize)}>
+                  <span data-redact-hook="price" className={cn("font-semibold tabular-nums text-zinc-700 leading-none", statSize)}>
                     {priceDisplay}
                   </span>
                   {/* Caption row 1: source */}

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -1,9 +1,13 @@
 // Demo-mode redaction. Used to blur sensitive surfaces (poster QR, price
-// source channel) while screen-recording, so platform moderators don't flag
-// the footage. To redact another surface, add a key here and mark the
-// element with `data-redact-hook="<key>"`.
+// figure, price source channel) while screen-recording, so platform moderators
+// don't flag the footage. To redact another surface, add a key here and mark
+// the element with `data-redact-hook="<key>"`.
+//
+// INTERNAL PARAM — keep the Atlens Obsidian doc "Internal params & cookies"
+// (Engineering/) in sync whenever a key, the query key, or the blur default
+// changes here.
 
-export const REDACTION_KEYS = ["posterQr", "priceSource"] as const;
+export const REDACTION_KEYS = ["posterQr", "price", "priceSource"] as const;
 
 export const REDACTION_QUERY_KEY = "redact";
 export const REDACTION_BLUR_QUERY_KEY = "redactBlur";

--- a/src/lib/testhook.ts
+++ b/src/lib/testhook.ts
@@ -2,6 +2,10 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 
 // -- Constants ----------------------------------------------------------------
 
+// INTERNAL PARAM — this query key and the option keys in
+// TESTHOOK_OPTION_DEFINITIONS below are internal/debug URL params. When adding,
+// renaming, or removing any, keep the Atlens Obsidian doc "Internal params &
+// cookies" (Engineering/) in sync.
 export const TESTHOOK_QUERY_KEYS = {
   testHook: "testhook",
 } as const;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,9 @@ import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 
+// INTERNAL PARAM — xg_internal is the internal-user gate cookie (set here after
+// passing Cloudflare Access on /admin). When changing how it is set/named, keep
+// the Atlens Obsidian doc "Internal params & cookies" (Engineering/) in sync.
 const INTERNAL_COOKIE = "xg_internal";
 const COUNTRY_COOKIE = "xg_country";
 const ONE_YEAR = 60 * 60 * 24 * 365;


### PR DESCRIPTION
## What

Follow-up to #361 (which shipped the `priceSource` check-price redaction + the test-panel reference).

### 1. New `price` redact target
Adds a third demo-redaction key, `price`, that blurs the **price figure itself** — distinct from `priceSource`, which only blurs the channel/source name. Marked on every price render site:
- `PriceSection` (detail), `PriceCell` (compare), `LensCardPrice` (card), `SharePoster` (poster).

Redaction is now **1 method (CSS blur) × 3 targets**: `price`, `priceSource`, `posterQr`. Each toggles independently via `?redact=`. The test-hook panel reference picks `price` up automatically from `REDACTION_KEYS`.

### 2. Anchor internal params to docs
Added `INTERNAL PARAM` comments at each internal/debug param source (`testhook.ts`, `redaction.ts`, `middleware.ts`) pointing at the Atlens "Internal params & cookies" doc, so the registry stays in sync when params are added. `grep "INTERNAL PARAM"` finds every source.

## Test plan
- `?redact=price` blurs price figures on detail / compare / card / poster, independently of `priceSource` and `posterQr`. Verified: detail price blurs while source stays sharp; 312 card prices blur on browse.
- `?testhook=1` (dev only) → panel reference lists `price`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)