### PR TITLE
style(nav): drop brand hover fade, make GitHub icon dark by default

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -130,7 +130,7 @@ export default function Nav() {
         <div className="flex items-center gap-1 sm:gap-2 shrink-0">
           <Link
             href="/"
-            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-base sm:text-lg tracking-tight hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors whitespace-nowrap"
+            className="flex items-center gap-1.5 font-bold font-heading text-zinc-900 dark:text-zinc-50 text-base sm:text-lg tracking-tight whitespace-nowrap"
             aria-label="Home"
           >
             <Iris config={IRIS_NAV} uid="nav" size={16} />
@@ -173,7 +173,7 @@ export default function Nav() {
             href="https://github.com/sentacraft/atlens"
             target="_blank"
             rel="noopener noreferrer"
-            className="hidden sm:inline text-zinc-400 dark:text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors px-1"
+            className="hidden sm:inline text-zinc-900 dark:text-zinc-50 px-1"
             aria-label="GitHub"
           >
             <GitHubMark />


### PR DESCRIPTION
## What

Two desktop navbar hover/color tweaks:

1. **Brand name (Atlens)** — removed the hover that dimmed it from `zinc-900` to `zinc-600`. A dark-default label fading *lighter* on hover read as backwards.
2. **GitHub icon** — it's an external link with no route state, so the inactive-link "light default → darken on hover" two-tone carried no meaning and left it fainter than the real nav links. Now dark by default for prominence, with the hover shift dropped.

## Notes

CSS-only (Tailwind class) changes in `src/components/Nav.tsx`; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)