### PR TITLE
refactor(types): make 5 fully-covered specs required

### DIFF
--- a/src/lib/__tests__/lens-spec-groups.test.ts
+++ b/src/lib/__tests__/lens-spec-groups.test.ts
@@ -93,6 +93,11 @@ function makeLens(overrides: Partial<Lens> = {}): Lens {
     ois: false,
     wr: false,
     apertureRing: false,
+    powerZoom: false,
+    weightG: 187,
+    diameterMm: 65,
+    length: { mm: 70 },
+    angleOfViewCalc: 30,
     searchAliases: { en: "Test Lens" },
     ...overrides,
   };

--- a/src/lib/__tests__/lenses.test.ts
+++ b/src/lib/__tests__/lenses.test.ts
@@ -39,6 +39,8 @@ function makeLens(
     weightG: 187,
     diameterMm: 65,
     length: { mm: 45 },
+    angleOfViewCalc: 44.2,
+    powerZoom: false,
     filterMm: 52,
     minFocusDistance: { normal: { cm: 28 } },
     releaseYear: 2012,

--- a/src/lib/lens-schema.ts
+++ b/src/lib/lens-schema.ts
@@ -75,7 +75,7 @@ const lensBaseShape = {
   oisStops: positiveNumberSchema.optional(),
   wr: z.union([z.boolean(), z.literal("partial")]),
   apertureRing: z.boolean(),
-  powerZoom: z.boolean().optional(),
+  powerZoom: z.boolean(),
   focusMotor: optionalNonEmptyStringSchema,
   internalFocusing: z.boolean().optional(),
   weightG: z.union([
@@ -84,8 +84,8 @@ const lensBaseShape = {
       (arr) => arr[0] < arr[1],
       { message: "weightG range: first value (min) must be less than second (max)" }
     ),
-  ]).optional(),
-  diameterMm: positiveNumberSchema.optional(),
+  ]),
+  diameterMm: positiveNumberSchema,
   length: z.strictObject({
     mm: positiveNumberSchema,
     variants: z.strictObject({
@@ -93,7 +93,7 @@ const lensBaseShape = {
       wide: positiveNumberSchema.optional(),
       tele: positiveNumberSchema.optional(),
     }).optional(),
-  }).optional(),
+  }),
   minFocusDistance: z.strictObject({
     normal: focusDistanceModeSchema,
     macro: focusDistanceModeSchema.optional(),
@@ -115,7 +115,7 @@ const lensBaseShape = {
       (arr) => arr[0] > arr[1],
       { message: "angleOfViewCalc tuple must be [wideEnd, teleEnd] with wide > tele" }
     ),
-  ]).optional(),
+  ]),
   apertureBladeCount: z.union([z.number().int().positive(), specNaSchema]).optional(),
   releaseYear: z.number().int().min(1900).max(2100).optional(),
   searchAliases: z.strictObject({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -484,10 +484,9 @@ export interface Lens {
 
   /**
    * Whether the lens uses a power zoom (motorized zoom) mechanism.
-   * Optional until pipeline backfills this field for all lenses.
    * @example true
    */
-  powerZoom?: boolean;
+  powerZoom: boolean;
 
   /**
    * Brand's verbatim AF motor or actuator label, copied from the source
@@ -559,13 +558,13 @@ export interface Lens {
    * @example 187
    * @example [340, 395]
    */
-  weightG?: number | [number, number];
+  weightG: number | [number, number];
 
   /**
    * Maximum outer diameter in millimeters.
    * @example 65
    */
-  diameterMm?: number;
+  diameterMm: number;
 
   /**
    * Physical length of the lens body, measured from the mount flange to the
@@ -575,7 +574,7 @@ export interface Lens {
    * @example { mm: 50.4 }
    * @example { mm: 57.2, variants: { retracted: 37.5, wide: 55.6, tele: 57.2 } }
    */
-  length?: LensLength;
+  length: LensLength;
 
   /**
    * Filter thread diameter in millimeters.
@@ -642,7 +641,7 @@ export interface Lens {
    * @example 44.2
    * @example [86.9, 35.0]
    */
-  angleOfViewCalc?: number | [number, number];
+  angleOfViewCalc: number | [number, number];
 
   /**
    * Structured optical construction data parsed from the source spec.


### PR DESCRIPTION
## What

Narrows five lens spec fields from optional to **required**, in both the hand-written `Lens` interface (`types.ts`) and the Zod schema (`lens-schema.ts`):

`length` · `weightG` · `diameterMm` · `angleOfViewCalc` · `powerZoom`

All five are at **100% data coverage** (196/196 across X-mount + GFX). Keeping them `?` only enabled silent `?? fallback` reads; requiring them makes a future lens that's missing one **fail validation loudly at build time** — the intended "missing data = bug" behaviour.

## Why these five (and not `filterMm`)

`filterMm` is also 100% covered today but is **deliberately left optional**: its schema reserves `undefined` for "filter size not published", which is distinct from the `"N/A"` sentinel ("lens has no front thread"). Requiring it would collapse a meaningful, designed state.

`fieldNotes` was excluded too — it's present on every lens but ~75% are empty `{}`, i.e. not real coverage.

## Notes

- The bidirectional compile-time assertion in `lens-schema.ts` (`_LensSchemaCheck`) enforces that `types.ts` and the Zod-inferred type stay in sync — so this PR had to tighten **both** sides; tightening only one would fail typecheck.
- **Pipeline follow-up (separate private repo):** the data generator should also guarantee these five fields, so a future pipeline run can't surprise-fail the web build. This PR enforces the contract on the web side; the producer side should match.
- Test factories in `lenses.test.ts` and `lens-spec-groups.test.ts` updated to supply the newly-required fields.

## Test plan

- `npm run typecheck` — clean (incl. the sync assertion).
- `node scripts/validate-lenses.mts` + manual `lensCatalogSchema` parse — both `lenses.json` (169) and `lenses-gfx.json` (27) pass.
- `npm test` — 366 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)