### PR TITLE
chore(scripts): validate the GFX catalog too, not just X-mount

### DIFF
--- a/scripts/validate-lenses.mts
+++ b/scripts/validate-lenses.mts
@@ -3,18 +3,29 @@ import { resolve } from "node:path";
 
 import { formatZodIssues, lensCatalogSchema } from "../src/lib/lens-schema.ts";
 
-const lensesPath = resolve(process.cwd(), "src/data/lenses.json");
-const raw = readFileSync(lensesPath, "utf8");
-const parsed = JSON.parse(raw) as unknown;
+// X-mount and GFX are stored as separate catalogs and consumed separately, so
+// validate each on its own (duplicate detection is meant to run per-catalog).
+const catalogPaths = ["src/data/lenses.json", "src/data/lenses-gfx.json"];
 
-const result = lensCatalogSchema.safeParse(parsed);
+let failed = false;
 
-if (!result.success) {
-  console.error(`Lens catalog validation failed for ${lensesPath}`);
-  for (const issue of formatZodIssues(result.error)) {
-    console.error(`- ${issue}`);
+for (const relPath of catalogPaths) {
+  const path = resolve(process.cwd(), relPath);
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  const result = lensCatalogSchema.safeParse(parsed);
+
+  if (!result.success) {
+    console.error(`Lens catalog validation failed for ${path}`);
+    for (const issue of formatZodIssues(result.error)) {
+      console.error(`- ${issue}`);
+    }
+    failed = true;
+    continue;
   }
-  process.exit(1);
+
+  console.log(`Lens catalog validation passed for ${path}`);
 }
 
-console.log(`Lens catalog validation passed for ${lensesPath}`);
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
## What

`scripts/validate-lenses.mts` only validated `src/data/lenses.json`, so `lenses-gfx.json` (27 GFX lenses) was never schema-checked at build time. The script now loops over both catalogs and exits non-zero if either fails.

Each catalog is validated **separately** (not concatenated), because they're consumed as independent catalogs and the schema's duplicate detection is meant to run per-catalog.

## Notes

Independent of #370 (the optional→required narrowing) — this only touches the validator. The two compose: once #370 lands, this script will enforce the tightened schema on the GFX catalog too.

## Test plan

- `node scripts/validate-lenses.mts` → both `lenses.json` (169) and `lenses-gfx.json` (27) report pass; exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)