### PR TITLE
feat(analytics): add per-dimension filter usage card

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "wrangler types --env-interface CloudflareEnv",
     "predev": "node --experimental-strip-types scripts/build-lens-image-manifest.mts",
     "dev": "next dev",
-    "prebuild": "node --experimental-strip-types scripts/build-lens-image-manifest.mts",
+    "prebuild": "wrangler types --env-interface CloudflareEnv && node --experimental-strip-types scripts/build-lens-image-manifest.mts",
     "build": "tsx scripts/gen-icons.tsx && tsx scripts/verify-icons.ts && node --experimental-strip-types scripts/validate-lenses.mts && next build && node --experimental-strip-types scripts/check-static-routes.mts",
     "build:cf": "wrangler types --env-interface CloudflareEnv && npx opennextjs-cloudflare build",
     "start": "next start",

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -7,6 +7,7 @@
 
 import { queryAE } from "@/lib/analytics-query";
 import {
+  aggregateFilterDimensions,
   formatFilterSnapshot,
   formatHref,
   formatLensSlug,
@@ -91,6 +92,20 @@ const Q_FILTER_USAGE = `
   GROUP BY filters
   ORDER BY n DESC
   LIMIT 10
+`;
+
+// Same source as Q_FILTER_USAGE but pulls a deep slice of distinct combos so
+// the server can decompose them into per-dimension counts (see
+// aggregateFilterDimensions). The limit is a safety cap; real distinct-combo
+// cardinality is far below it.
+const Q_FILTER_DIMENSIONS = `
+  SELECT blob4 AS filters, SUM(_sample_interval) AS n
+  FROM xglass_events
+  WHERE index1 = 'filter_apply'
+    AND ${DASHBOARD_FILTER}
+  GROUP BY filters
+  ORDER BY n DESC
+  LIMIT 1000
 `;
 
 // Same constraint as the overview uniques: instead of conditional
@@ -357,6 +372,7 @@ export default async function AnalyticsDashboardPage() {
     searchZero,
     searchAll,
     filterUsage,
+    filterDimensions,
     compareFunnel,
     compareCombos,
     lensViews,
@@ -378,6 +394,7 @@ export default async function AnalyticsDashboardPage() {
     queryAE(Q_SEARCH_ZERO),
     queryAE(Q_SEARCH_ALL),
     queryAE(Q_FILTER_USAGE),
+    queryAE(Q_FILTER_DIMENSIONS),
     queryAE(Q_COMPARE_FUNNEL),
     queryAE(Q_COMPARE_COMBOS),
     queryAE(Q_LENS_VIEW_TOP),
@@ -447,6 +464,7 @@ export default async function AnalyticsDashboardPage() {
       ["searchZero", searchZero],
       ["searchAll", searchAll],
       ["filterUsage", filterUsage],
+      ["filterDimensions", filterDimensions],
       ["compareFunnel", compareFunnel],
       ["compareCombos", compareCombos],
       ["lensViews", lensViews],
@@ -479,6 +497,7 @@ export default async function AnalyticsDashboardPage() {
     ...r,
     display: formatFilterSnapshot(String(r.filters ?? "")),
   }));
+  const filterDimensionRows = aggregateFilterDimensions(filterDimensions.data);
   const shareRows = share.data.map((r) => ({
     ...r,
     display: formatShareMethod(String(r.method ?? "")),
@@ -628,6 +647,16 @@ export default async function AnalyticsDashboardPage() {
             rows={filterUsageRows}
             columns={[
               { key: "display", label: "Filters", titleKey: "filters" },
+              { key: "n", label: "Applies", align: "right", widthClass: COUNT_WIDTH },
+            ]}
+          />
+        </Card>
+
+        <Card title="Filters · per-dimension usage">
+          <Table
+            rows={filterDimensionRows}
+            columns={[
+              { key: "dimension", label: "Filter" },
               { key: "n", label: "Applies", align: "right", widthClass: COUNT_WIDTH },
             ]}
           />

--- a/src/lib/__tests__/analytics-format.test.ts
+++ b/src/lib/__tests__/analytics-format.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  aggregateFilterDimensions,
+  formatFilterSnapshot,
+} from "../analytics-format";
+
+describe("formatFilterSnapshot", () => {
+  it("renders optical trait (previously dropped from the label)", () => {
+    const snap = JSON.stringify({ typeFilter: "prime", opticalTrait: "macro" });
+    expect(formatFilterSnapshot(snap)).toBe("Prime · Trait: macro");
+  });
+
+  it("summarises a multi-dimension snapshot", () => {
+    const snap = JSON.stringify({
+      brands: ["sigma"],
+      typeFilter: "zoom",
+      focusFilter: "auto",
+      usage: "photo",
+      focusMotorClass: null,
+      features: [],
+      focalCategories: ["standard"],
+    });
+    expect(formatFilterSnapshot(snap)).toBe(
+      "Brand: sigma · Zoom · AF · Focal: standard",
+    );
+  });
+
+  it("returns (no filters) for an all-default snapshot", () => {
+    const snap = JSON.stringify({ usage: "photo", brands: [], features: [] });
+    expect(formatFilterSnapshot(snap)).toBe("(no filters)");
+  });
+
+  it("falls back to the raw text on invalid JSON", () => {
+    expect(formatFilterSnapshot("not json")).toBe("not json");
+  });
+});
+
+describe("aggregateFilterDimensions", () => {
+  it("tallies each active dimension weighted by n, sorted descending", () => {
+    const rows = [
+      { filters: JSON.stringify({ typeFilter: "prime", focalCategories: ["standard"] }), n: 5 },
+      { filters: JSON.stringify({ typeFilter: "zoom", focalCategories: ["wide"] }), n: 3 },
+      { filters: JSON.stringify({ opticalTrait: "macro" }), n: 2 },
+    ];
+    const result = aggregateFilterDimensions(rows);
+    const get = (d: string) => result.find((r) => r.dimension === d)?.n;
+
+    expect(get("Lens type (prime/zoom)")).toBe(8);
+    expect(get("Focal range")).toBe(8);
+    expect(get("Optical trait")).toBe(2);
+    expect(get("Brand")).toBe(0);
+    // descending by count
+    expect(result[0].n).toBeGreaterThanOrEqual(result[result.length - 1].n);
+  });
+
+  it("counts non-default usage as active but default usage as inactive", () => {
+    const rows = [
+      { filters: JSON.stringify({ usage: "photo" }), n: 4 },
+      { filters: JSON.stringify({ usage: "cine" }), n: 6 },
+    ];
+    const usage = aggregateFilterDimensions(rows).find(
+      (r) => r.dimension === "Usage (photo/cine)",
+    );
+    expect(usage?.n).toBe(6);
+  });
+
+  it("skips malformed rows without throwing", () => {
+    const rows = [
+      { filters: "broken{", n: 9 },
+      { filters: JSON.stringify({ brands: ["fujifilm"] }), n: 2 },
+    ];
+    const brand = aggregateFilterDimensions(rows).find(
+      (r) => r.dimension === "Brand",
+    );
+    expect(brand?.n).toBe(2);
+  });
+
+  it("coerces numeric-string n weights (AE can return them as strings)", () => {
+    const rows = [{ filters: JSON.stringify({ typeFilter: "prime" }), n: "7" }];
+    const type = aggregateFilterDimensions(rows).find(
+      (r) => r.dimension === "Lens type (prime/zoom)",
+    );
+    expect(type?.n).toBe(7);
+  });
+});

--- a/src/lib/analytics-format.ts
+++ b/src/lib/analytics-format.ts
@@ -92,8 +92,68 @@ export function formatFilterSnapshot(json: string): string {
   if (Array.isArray(focal) && focal.length > 0) {
     parts.push(`Focal: ${focal.join(",")}`);
   }
+  if (typeof f.opticalTrait === "string" && f.opticalTrait) {
+    parts.push(`Trait: ${f.opticalTrait}`);
+  }
 
   return parts.length > 0 ? parts.join(" · ") : "(no filters)";
+}
+
+// One filter dimension and the predicate that decides whether a snapshot has
+// it active (non-default). Order here is the display fallback when counts tie.
+const FILTER_DIMENSIONS: {
+  label: string;
+  isActive: (f: Record<string, unknown>) => boolean;
+}[] = [
+  { label: "Lens type (prime/zoom)", isActive: (f) => typeof f.typeFilter === "string" && !!f.typeFilter },
+  { label: "Focus (AF/MF)", isActive: (f) => typeof f.focusFilter === "string" && !!f.focusFilter },
+  { label: "Brand", isActive: (f) => Array.isArray(f.brands) && f.brands.length > 0 },
+  { label: "Usage (photo/cine)", isActive: (f) => typeof f.usage === "string" && f.usage !== defaultFilters.usage },
+  { label: "Focal range", isActive: (f) => Array.isArray(f.focalCategories) && f.focalCategories.length > 0 },
+  { label: "Focus motor", isActive: (f) => typeof f.focusMotorClass === "string" && !!f.focusMotorClass },
+  { label: "Features", isActive: (f) => Array.isArray(f.features) && f.features.length > 0 },
+  { label: "Optical trait", isActive: (f) => typeof f.opticalTrait === "string" && !!f.opticalTrait },
+];
+
+// A `type` (not `interface`) so the row is assignable to the dashboard
+// Table's `Record<string, unknown>[]` prop — interfaces are treated as
+// open/augmentable and lack the implicit index signature.
+export type FilterDimensionUsage = {
+  dimension: string;
+  n: number;
+};
+
+// The "most-used snapshots" card groups by the whole filter combo, so a
+// filter used across many different combos never accumulates into a visible
+// row. This decomposes each snapshot and tallies how often every individual
+// filter dimension was active — answering "how many applies touched filter X"
+// rather than "what's the most common full combo". `n` is the per-combo
+// apply weight (SUM(_sample_interval)) that the caller already aggregated.
+export function aggregateFilterDimensions(
+  rows: Array<{ filters?: unknown; n?: unknown }>,
+): FilterDimensionUsage[] {
+  const totals = new Map<string, number>(FILTER_DIMENSIONS.map((d) => [d.label, 0]));
+  for (const row of rows) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(String(row.filters ?? ""));
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      continue;
+    }
+    const f = parsed as Record<string, unknown>;
+    const weight = typeof row.n === "number" ? row.n : Number(row.n) || 0;
+    for (const dim of FILTER_DIMENSIONS) {
+      if (dim.isActive(f)) {
+        totals.set(dim.label, (totals.get(dim.label) ?? 0) + weight);
+      }
+    }
+  }
+  return FILTER_DIMENSIONS
+    .map((d) => ({ dimension: d.label, n: totals.get(d.label) ?? 0 }))
+    .sort((a, b) => b.n - a.n);
 }
 
 // Strip protocol + trailing slash from a URL for compact display.


### PR DESCRIPTION
## Why

The **Filters · most-used snapshots** card groups by the *entire* filter combo (`blob4` = full `filters_json`) and shows the top 10. A "more filters" dimension (focal range, focus motor, features, optical trait) is both used less often **and** scattered across many distinct combos, so no combo containing it ever cracks the top 10 — the persistent Prime/Zoom/Brand/AF combos fill every slot. The data is captured fine; the card just can't answer "how many applies used filter X".

## What

- **New card "Filters · per-dimension usage"** — decomposes every `filter_apply` snapshot and tallies how often each individual filter dimension was active (weighted by `_sample_interval`). Directly answers per-filter popularity.
- **Bug fix:** `formatFilterSnapshot` silently dropped `opticalTrait` from the snapshot label — trait-filtered combos now render `Trait: macro` instead of omitting it.
- **Build chore (2nd commit):** run `wrangler types` in `postinstall` + `prebuild`. `worker-configuration.d.ts` (the `CloudflareEnv` interface, incl. the `ANALYTICS` binding this dashboard reads) is gitignored and generated by `wrangler types`; plain `next build`/bare `tsc` never regenerated it, so a fresh checkout failed typechecking with "Property 'ANALYTICS' does not exist on type 'CloudflareEnv'". Surfaced while working on this dashboard, so folded in here.

## Approach note

Aggregation runs in JS server-side over the existing `GROUP BY blob4` result (a new query with a generous `LIMIT 1000`), **not** via Analytics Engine JSON SQL. This reuses a query pattern already proven in this file rather than depending on AE's uncertain JSON-extraction support. The `LIMIT` is a safety cap; real distinct-combo cardinality is far below it.

## Test plan

- `npm test` — 374 pass, incl. new `aggregateFilterDimensions` tests (weighting, default-vs-active usage, malformed-row skip, string-`n` coercion) and the `opticalTrait` snapshot fix.
- `npm run typecheck` — clean.
- `wrangler types` runs cleanly from the new hooks (reads `wrangler.toml`, no network/auth).
- Dashboard logic only; with no AE credentials every card (incl. the new one) renders gracefully empty, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)