### PR TITLE
fix(worktree): detect incomplete node_modules in setup guard

### DIFF
--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -18,7 +18,13 @@ cd "$WORKTREE_ROOT"
 mkdir -p .claude
 
 # ── npm install (skip if node_modules is up to date) ─────────────────────────
-if [ ! -d "node_modules" ] || [ "package.json" -nt "node_modules" ]; then
+# Guard on npm's install marker (node_modules/.package-lock.json), not on the
+# directory itself: tools like vitest and turbopack drop caches under
+# node_modules/ (e.g. .vite, .cache), so a bare `-d node_modules` check sees the
+# directory exist and wrongly assumes deps are installed — leaving an empty
+# node_modules that breaks `next dev` (Turbopack can't resolve `next`).
+INSTALL_MARKER="node_modules/.package-lock.json"
+if [ ! -e "$INSTALL_MARKER" ] || [ "package.json" -nt "$INSTALL_MARKER" ]; then
   echo "Running npm install…"
   npm install
 fi


### PR DESCRIPTION
## Problem

`scripts/worktree-setup.sh` (SessionStart hook) skipped `npm install` whenever a `node_modules` **directory** existed:

```bash
if [ ! -d "node_modules" ] || [ "package.json" -nt "node_modules" ]; then
```

But vitest/turbopack write caches under `node_modules/` (`.vite`, `.cache`). On a worktree whose deps were never installed, the first `vitest` run materialized an otherwise-empty `node_modules/` — after which the `-d` check saw the directory and permanently skipped the install. Tooling that resolves up the tree (tsc/eslint/vitest via the parent repo's `node_modules`) kept working, hiding the gap until `next dev`: Turbopack is pinned to the worktree via `turbopack.root`, so it can't resolve `next` from a parent and fails.

## Fix

Guard on npm's install marker `node_modules/.package-lock.json` (written only by a completed install) instead of the directory. An empty or stale `node_modules` now self-heals on the next session.

## Test plan
- `bash -n scripts/worktree-setup.sh` passes.
- Manually: an empty `node_modules/` (only `.vite`) → guard now triggers `npm install`; a fully installed one → still skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)