### PR TITLE
refactor(search/dialog): lift navigation, flatten renders, drop dead dialog API

### DIFF
--- a/src/components/browse/LensListClient.tsx
+++ b/src/components/browse/LensListClient.tsx
@@ -71,7 +71,7 @@ export default function LensListClient({ lenses }: LensListClientProps) {
     filters.features.length > 0,
   ].filter(Boolean).length;
 
-  function onSelectLens(lens: Lens) {
+  function handleSelectLens(lens: Lens) {
     router.push(`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`);
   }
 
@@ -145,7 +145,7 @@ export default function LensListClient({ lenses }: LensListClientProps) {
             searchSlot={
               <LensSearchDialog
                 lenses={lenses}
-                onSelectLens={onSelectLens}
+                onSelectLens={handleSelectLens}
                 triggerVariant="button"
                 triggerLabel={tSearch("browseTrigger")}
                 triggerClassName="sm:h-10"

--- a/src/components/browse/LensListClient.tsx
+++ b/src/components/browse/LensListClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useEffect, useRef, useLayoutEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 import {
   filterLenses,
@@ -26,6 +26,7 @@ import LensUsageSwitch from "@/components/browse/LensUsageSwitch";
 import LensSortControl from "@/components/browse/LensSortControl";
 import LensSearchDialog from "@/components/browse/LensSearchDialog";
 import FeedbackTrigger from "@/components/feedback/FeedbackTrigger";
+import { mountToUrlSegment } from "@/lib/mount";
 
 interface LensListClientProps {
   lenses: Lens[];
@@ -35,6 +36,7 @@ export default function LensListClient({ lenses }: LensListClientProps) {
   const t = useTranslations("LensList");
   const tSearch = useTranslations("Search");
   const hookAttr = useUiHookAttr();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams));
   const { compareIds, toggle } = useCompare();
@@ -68,6 +70,10 @@ export default function LensListClient({ lenses }: LensListClientProps) {
     filters.focalCategories.length > 0,
     filters.features.length > 0,
   ].filter(Boolean).length;
+
+  function onSelectLens(lens: Lens) {
+    router.push(`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`);
+  }
 
   function clearAllFilters() {
     // Reset clears refinements but preserves the photo/cine view mode — usage
@@ -139,6 +145,7 @@ export default function LensListClient({ lenses }: LensListClientProps) {
             searchSlot={
               <LensSearchDialog
                 lenses={lenses}
+                onSelectLens={onSelectLens}
                 triggerVariant="button"
                 triggerLabel={tSearch("browseTrigger")}
                 triggerClassName="sm:h-10"

--- a/src/components/browse/LensSearchDialog.tsx
+++ b/src/components/browse/LensSearchDialog.tsx
@@ -98,7 +98,9 @@ export default function LensSearchDialog({
       : [],
     [searchIndex, deferredQuery],
   );
-  const isSearching = false;
+
+  const hasInput = query.trim().length > 0;
+  const hasResults = results.length > 0;
 
   useSearchTelemetry({ query: deferredQuery, resultsCount: results.length, isOpen: open });
 
@@ -137,46 +139,44 @@ export default function LensSearchDialog({
   }
 
   function renderResults() {
-    if (query.trim().length === 0) {
+    if (!hasInput) {
       return null;
     }
-
-    if (isSearching && results.length === 0) {
-      return (
-        <div className="flex items-center justify-center py-16">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-700 dark:border-t-zinc-400" />
-        </div>
-      );
+    if (!hasResults) {
+      return renderNoMatches();
     }
+    return renderMatchList();
+  }
 
-    if (results.length === 0) {
-      return (
-        <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
-          <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
-            {t("noResults")}
-          </p>
-          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-            {t("noResultsHint")}
-          </p>
-          <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
-            {t("suggestLens")}{" "}
-            <FeedbackTrigger
-              type="general"
-              context={{ searchQuery: deferredQuery.trim() }}
-            >
-              {t("suggestLensLink")}
-            </FeedbackTrigger>
-          </p>
-          <Link
-            href="/about#coverage"
-            className="mt-2 inline-block text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+  function renderNoMatches() {
+    return (
+      <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
+        <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
+          {t("noResults")}
+        </p>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+          {t("noResultsHint")}
+        </p>
+        <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
+          {t("suggestLens")}{" "}
+          <FeedbackTrigger
+            type="general"
+            context={{ searchQuery: deferredQuery.trim() }}
           >
-            {t("coverageLink")}
-          </Link>
-        </div>
-      );
-    }
+            {t("suggestLensLink")}
+          </FeedbackTrigger>
+        </p>
+        <Link
+          href="/about#coverage"
+          className="mt-2 inline-block text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+        >
+          {t("coverageLink")}
+        </Link>
+      </div>
+    );
+  }
 
+  function renderMatchList() {
     return (
       <div
         id={resultsId}

--- a/src/components/browse/LensSearchDialog.tsx
+++ b/src/components/browse/LensSearchDialog.tsx
@@ -2,6 +2,7 @@
 
 import {
   type KeyboardEvent,
+  useCallback,
   useDeferredValue,
   useEffect,
   useId,
@@ -12,8 +13,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useRouter, Link } from "@/i18n/navigation";
-import { mountToUrlSegment } from "@/lib/mount";
+import { Link } from "@/i18n/navigation";
 import { useKeyboardInset } from "@/hooks/useViewport";
 import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens/search";
 import type { Lens } from "@/lib/types";
@@ -38,7 +38,7 @@ interface LensSearchResultState {
 
 interface LensSearchDialogProps {
   lenses: Lens[];
-  onSelectLens?: (lens: Lens) => void;
+  onSelectLens: (lens: Lens) => void;
   getResultState?: (lens: Lens) => LensSearchResultState | undefined;
   triggerClassName?: string;
   triggerLabel?: string;
@@ -58,7 +58,6 @@ export default function LensSearchDialog({
 }: LensSearchDialogProps) {
   const t = useTranslations("Search");
   const tBrand = useTranslations("Brands");
-  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
@@ -103,18 +102,13 @@ export default function LensSearchDialog({
 
   useSearchTelemetry({ query: deferredQuery, resultsCount: results.length, isOpen: open });
 
-  function handleSelect(lens: Lens) {
-    setOpen(false);
-
-    if (onSelectLens) {
-
+  const handleSelect = useCallback(
+    (lens: Lens) => {
+      setOpen(false);
       onSelectLens(lens);
-      return;
-
-    }
-
-    router.push(`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`);
-  }
+    },
+    [onSelectLens]
+  );
 
   function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === "ArrowDown") {
@@ -136,11 +130,9 @@ export default function LensSearchDialog({
     }
 
     if (event.key === "Enter" && results[activeIndex]) {
-
       event.preventDefault();
       handleSelect(results[activeIndex]);
       return;
-
     }
   }
 

--- a/src/components/browse/LensSearchDialog.tsx
+++ b/src/components/browse/LensSearchDialog.tsx
@@ -136,6 +136,105 @@ export default function LensSearchDialog({
     }
   }
 
+  function renderResults() {
+    if (query.trim().length === 0) {
+      return null;
+    }
+
+    if (isSearching && results.length === 0) {
+      return (
+        <div className="flex items-center justify-center py-16">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-700 dark:border-t-zinc-400" />
+        </div>
+      );
+    }
+
+    if (results.length === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
+          <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
+            {t("noResults")}
+          </p>
+          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            {t("noResultsHint")}
+          </p>
+          <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
+            {t("suggestLens")}{" "}
+            <FeedbackTrigger
+              type="general"
+              context={{ searchQuery: deferredQuery.trim() }}
+            >
+              {t("suggestLensLink")}
+            </FeedbackTrigger>
+          </p>
+          <Link
+            href="/about#coverage"
+            className="mt-2 inline-block text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+          >
+            {t("coverageLink")}
+          </Link>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        id={resultsId}
+        role="listbox"
+        aria-label={t("results")}
+        className="space-y-2"
+      >
+        {results.map((lens, index) => {
+          const isActive = index === activeIndex;
+          const resultState = getResultState?.(lens);
+          const actionLabel = resultState?.actionLabel ?? t("view");
+          const isDisabled = resultState?.disabled ?? false;
+
+          return (
+            <button
+              key={lens.id}
+              type="button"
+              role="option"
+              aria-selected={isActive}
+              disabled={isDisabled}
+              onMouseEnter={() => setActiveIndex(index)}
+              onClick={() => handleSelect(lens)}
+              className={cn(
+                "flex w-full items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition-colors",
+                isDisabled
+                  ? "cursor-not-allowed border-transparent bg-zinc-50/80 opacity-60 dark:bg-zinc-900/60"
+                  : isActive
+                    ? "border-zinc-200 bg-zinc-50/80 dark:border-zinc-700 dark:bg-zinc-800/50"
+                    : "border-transparent bg-white hover:bg-zinc-50 dark:bg-zinc-950 dark:hover:bg-zinc-900"
+              )}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-xs uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+                  {lensSubtitleLine(tBrand(lens.brand), lens.series)}
+                </p>
+                <p className="mt-0.5 truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                  {lens.model}
+                </p>
+              </div>
+              <span className="shrink-0 text-xs font-medium text-zinc-400 dark:text-zinc-500">
+                {actionLabel}
+              </span>
+            </button>
+          );
+        })}
+        <p className="pt-1 text-center text-xs text-zinc-400 dark:text-zinc-500">
+          {t("suggestLensResults")}{" "}
+          <FeedbackTrigger
+            type="general"
+            context={{ searchQuery: deferredQuery.trim() }}
+          >
+            {t("suggestLensLink")}
+          </FeedbackTrigger>
+        </p>
+      </div>
+    );
+  }
+
   return (
     <>
       <button
@@ -242,90 +341,7 @@ export default function LensSearchDialog({
             style={{ scrollPaddingBottom: keyboardInset || undefined }}
             className="h-[300px] overflow-y-auto px-3 py-3 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-200 dark:[&::-webkit-scrollbar-thumb]:bg-zinc-700"
           >
-            {query.trim().length === 0 ? null : isSearching && results.length === 0 ? (
-              <div className="flex items-center justify-center py-16">
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-700 dark:border-t-zinc-400" />
-              </div>
-            ) : results.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-zinc-200 px-5 py-10 text-center dark:border-zinc-800">
-                <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
-                  {t("noResults")}
-                </p>
-                <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-                  {t("noResultsHint")}
-                </p>
-                <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
-                  {t("suggestLens")}{" "}
-                  <FeedbackTrigger
-                    type="general"
-                    context={{ searchQuery: deferredQuery.trim() }}
-                  >
-                    {t("suggestLensLink")}
-                  </FeedbackTrigger>
-                </p>
-                <Link
-                  href="/about#coverage"
-                  className="mt-2 inline-block text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                >
-                  {t("coverageLink")}
-                </Link>
-              </div>
-            ) : (
-              <div
-                id={resultsId}
-                role="listbox"
-                aria-label={t("results")}
-                className="space-y-2"
-              >
-                {results.map((lens, index) => {
-                  const isActive = index === activeIndex;
-                  const resultState = getResultState?.(lens);
-                  const actionLabel = resultState?.actionLabel ?? t("view");
-                  const isDisabled = resultState?.disabled ?? false;
-
-                  return (
-                    <button
-                      key={lens.id}
-                      type="button"
-                      role="option"
-                      aria-selected={isActive}
-                      disabled={isDisabled}
-                      onMouseEnter={() => setActiveIndex(index)}
-                      onClick={() => handleSelect(lens)}
-                      className={cn(
-                        "flex w-full items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition-colors",
-                        isDisabled
-                          ? "cursor-not-allowed border-transparent bg-zinc-50/80 opacity-60 dark:bg-zinc-900/60"
-                          : isActive
-                            ? "border-zinc-200 bg-zinc-50/80 dark:border-zinc-700 dark:bg-zinc-800/50"
-                            : "border-transparent bg-white hover:bg-zinc-50 dark:bg-zinc-950 dark:hover:bg-zinc-900"
-                      )}
-                    >
-                      <div className="min-w-0">
-                        <p className="truncate text-xs uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
-                          {lensSubtitleLine(tBrand(lens.brand), lens.series)}
-                        </p>
-                        <p className="mt-0.5 truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                          {lens.model}
-                        </p>
-                      </div>
-                      <span className="shrink-0 text-xs font-medium text-zinc-400 dark:text-zinc-500">
-                        {actionLabel}
-                      </span>
-                    </button>
-                  );
-                })}
-                <p className="pt-1 text-center text-xs text-zinc-400 dark:text-zinc-500">
-                  {t("suggestLensResults")}{" "}
-                  <FeedbackTrigger
-                    type="general"
-                    context={{ searchQuery: deferredQuery.trim() }}
-                  >
-                    {t("suggestLensLink")}
-                  </FeedbackTrigger>
-                </p>
-              </div>
-            )}
+            {renderResults()}
             {/* Spacer that reserves the keyboard's height inside the scroll area so the
                 last result can be scrolled clear of the on-screen keyboard. Collapses to
                 0 when the keyboard is down. */}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,19 +44,6 @@ function Dialog({
   );
 }
 
-function DialogTrigger({
-  className,
-  ...props
-}: DialogPrimitive.Trigger.Props) {
-  return (
-    <DialogPrimitive.Trigger
-      data-slot="dialog-trigger"
-      className={className}
-      {...props}
-    />
-  );
-}
-
 function DialogPortal({
   children,
   ...props
@@ -87,33 +74,25 @@ function DialogBackdrop({ className }: { className?: string }) {
   );
 }
 
-const DialogContent = React.forwardRef<
-  HTMLDivElement,
-  DialogPrimitive.Popup.Props & {
-    backdropClassName?: string;
-    layerRef?: React.Ref<HTMLDivElement>;
-    showCloseButton?: boolean;
-    /** Renders the close button outside the popup at the card's top-right corner (-right-4 -top-4).
-     *  Requires the popup to NOT have overflow-hidden (move it to inner content instead). */
-    showOverlayCloseButton?: boolean;
-    /** Omits the default centered positioning (left-1/2 top-1/2 max-w-2xl -translate-*) so the
-     *  caller can supply custom fixed inset classes without Tailwind class conflicts. */
-    noDefaultPositioning?: boolean;
-  }
->(function DialogContent(
-  {
-    className,
-    backdropClassName,
-    children,
-    layerRef,
-    showCloseButton = true,
-    showOverlayCloseButton = false,
-    noDefaultPositioning = false,
-    render: _render, // eslint-disable-line @typescript-eslint/no-unused-vars -- strip before DOM spread
-    ...props
-  },
-  ref
-) {
+type DialogContentProps = DialogPrimitive.Popup.Props & {
+  backdropClassName?: string;
+  layerRef?: React.Ref<HTMLDivElement>;
+  showCloseButton?: boolean;
+  /** Omits the default centered positioning (left-1/2 top-1/2 max-w-2xl -translate-*) so the
+   *  caller can supply custom fixed inset classes without Tailwind class conflicts. */
+  noDefaultPositioning?: boolean;
+};
+
+function DialogContent({
+  className,
+  backdropClassName,
+  children,
+  layerRef,
+  showCloseButton = true,
+  noDefaultPositioning = false,
+  render: _render, // eslint-disable-line @typescript-eslint/no-unused-vars -- strip before DOM spread
+  ...props
+}: DialogContentProps) {
   const mode = useDialogMode();
 
   return mode === "drawer" ? (
@@ -127,7 +106,6 @@ const DialogContent = React.forwardRef<
       />
       <DrawerPrimitive.Viewport>
         <DrawerPrimitive.Popup
-          ref={ref}
           data-slot="dialog-content"
           className={cn(
             `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
@@ -150,7 +128,6 @@ const DialogContent = React.forwardRef<
       <div ref={layerRef} className={cn("fixed inset-0", Z.dialog)}>
         <DialogBackdrop className={backdropClassName} />
         <DialogPrimitive.Popup
-          ref={ref}
           data-slot="dialog-content"
           className={cn(
             `fixed ${Z.local} rounded-2xl border border-zinc-200 bg-white p-0 shadow-2xl dark:border-zinc-800 dark:bg-zinc-950`,
@@ -166,16 +143,11 @@ const DialogContent = React.forwardRef<
               <X className="h-4 w-4" />
             </DialogPrimitive.Close>
           )}
-          {showOverlayCloseButton && (
-            <DialogPrimitive.Close className="absolute -right-4 -top-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white backdrop-blur-md transition-colors hover:bg-black/70">
-              <X className="h-4 w-4" />
-            </DialogPrimitive.Close>
-          )}
         </DialogPrimitive.Popup>
       </div>
     </DialogPortal>
   );
-});
+}
 
 function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
@@ -238,9 +210,6 @@ function DialogClose({ className, ...props }: Omit<DialogPrimitive.Close.Props, 
 
 export {
   Dialog,
-  DialogTrigger,
-  DialogPortal,
-  DialogBackdrop,
   DialogContent,
   DialogClose,
   DialogHeader,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -116,40 +116,36 @@ const DialogContent = React.forwardRef<
 ) {
   const mode = useDialogMode();
 
-  if (mode === "drawer") {
-    return (
-      <DrawerPrimitive.Portal>
-        <DrawerPrimitive.Backdrop
-          data-slot="dialog-backdrop"
+  return mode === "drawer" ? (
+    <DrawerPrimitive.Portal>
+      <DrawerPrimitive.Backdrop
+        data-slot="dialog-backdrop"
+        className={cn(
+          `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+          backdropClassName
+        )}
+      />
+      <DrawerPrimitive.Viewport>
+        <DrawerPrimitive.Popup
+          ref={ref}
+          data-slot="dialog-content"
           className={cn(
-            `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
-            backdropClassName
+            `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
+            "transition-[transform,opacity] data-[swipe-dismiss]:!transition-none data-[nested-drawer-open]:scale-[0.94] data-[nested-drawer-open]:opacity-40",
+            className,
+            "rounded-t-2xl rounded-b-none"
           )}
-        />
-        <DrawerPrimitive.Viewport>
-          <DrawerPrimitive.Popup
-            ref={ref}
-            data-slot="dialog-content"
-            className={cn(
-              `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
-              "transition-[transform,opacity] data-[swipe-dismiss]:!transition-none data-[nested-drawer-open]:scale-[0.94] data-[nested-drawer-open]:opacity-40",
-              className,
-              "rounded-t-2xl rounded-b-none"
-            )}
-            {...(props as Omit<typeof props, "style">)}
-          >
-            <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
-              <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
-            </div>
-            {children}
-            {layerRef && <div ref={layerRef} />}
-          </DrawerPrimitive.Popup>
-        </DrawerPrimitive.Viewport>
-      </DrawerPrimitive.Portal>
-    );
-  }
-
-  return (
+          {...(props as Omit<typeof props, "style">)}
+        >
+          <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
+            <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
+          </div>
+          {children}
+          {layerRef && <div ref={layerRef} />}
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
+    </DrawerPrimitive.Portal>
+  ) : (
     <DialogPortal>
       <div ref={layerRef} className={cn("fixed inset-0", Z.dialog)}>
         <DialogBackdrop className={backdropClassName} />


### PR DESCRIPTION
## What

A few related refactors around `LensSearchDialog` and the shared `Dialog` primitives. No behavior change.

**1. Lift navigation out of `LensSearchDialog`**
- `onSelectLens` is now a **required** prop; dropped the dialog's internal `router.push` fallback so each call site owns navigation.
- `LensListClient` provides its own `handleSelectLens` (the only caller that relied on the fallback). The other three (`CompareTable`, `CompareBar`, `ComparePageHeader`) already passed it.
- Plain handler, not `useCallback` (dialog isn't memoized — matches `useCompareLensSearch`). Removed now-unused `useRouter` / `mountToUrlSegment` imports from the dialog.

**2. Flatten branchy renders**
- `LensSearchDialog`: extracted the 4-state result body into `renderResults()` with guard clauses, replacing a 3-level nested ternary in JSX.
- `DialogContent`: dropped the early `return` for drawer mode; both modes now render as parallel branches of one ternary return.

**3. Drop dead preventive API from `ui/dialog.tsx`**
Audited every caller of `ui/dialog` across `src` and removed what nothing uses:
- `forwardRef` ref channel — no call site ever passed `ref` to `DialogContent`. Converted to a plain function (React 19 needs no `forwardRef`).
- `showOverlayCloseButton` prop + its render branch — zero references.
- `DialogTrigger` — exported but unused internally and externally.
- `DialogPortal` / `DialogBackdrop` exports — used only inside the file; dropped from the public export list (components stay).

Kept `showCloseButton` / `noDefaultPositioning` / `backdropClassName` / `layerRef` / `responsive` — each has a real caller.

## Test plan

- [x] `tsc --noEmit` clean (whole project)
- [x] `eslint` clean on all touched files
- [ ] CI build (local Turbopack build hits an unrelated worktree workspace-root issue — node_modules incomplete in this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)