### PR TITLE
refactor(dialog): replace DialogContent facade with compound parts

### DIFF
--- a/src/components/browse/LensSearchDialog.tsx
+++ b/src/components/browse/LensSearchDialog.tsx
@@ -23,7 +23,7 @@ import { useSearchTelemetry } from "@/components/browse/LensSearchDialog.telemet
 import {
   Dialog,
   DialogClose,
-  DialogContent,
+  DialogPopup,
   DialogDescription,
   DialogHeader,
   DialogTitle,
@@ -274,10 +274,9 @@ export default function LensSearchDialog({
             keyboard; for a search box we want the keyboard, so we hand it the input
             ref. Routing focus through the library's own open sequence (instead of a
             post-open setTimeout) makes it deterministic on the first open too. */}
-        <DialogContent
+        <DialogPopup
           initialFocus={inputRef}
           className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
-          showCloseButton={false}
         >
           <DialogHeader className="border-b border-zinc-100 pr-5 dark:border-zinc-800">
             <div className="flex items-center justify-between">
@@ -349,7 +348,7 @@ export default function LensSearchDialog({
               <div aria-hidden style={{ height: keyboardInset }} />
             )}
           </div>
-        </DialogContent>
+        </DialogPopup>
       </Dialog>
     </>
   );

--- a/src/components/browse/LensSearchDialog.tsx
+++ b/src/components/browse/LensSearchDialog.tsx
@@ -279,12 +279,12 @@ export default function LensSearchDialog({
           className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-zinc-200 bg-white shadow-2xl shadow-zinc-950/20 dark:border-zinc-800 dark:bg-zinc-950"
         >
           <DialogHeader className="border-b border-zinc-100 pr-5 dark:border-zinc-800">
-            <div className="flex items-center justify-between">
-              <div>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
                 <DialogTitle>{t("title")}</DialogTitle>
                 <DialogDescription className="sr-only">{t("description")}</DialogDescription>
               </div>
-              <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "hidden h-9 w-9 sm:inline-flex")}>
+              <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "hidden h-9 w-9 shrink-0 sm:inline-flex")}>
                 <X className="h-4 w-4" />
               </DialogClose>
             </div>

--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -196,22 +196,26 @@ export default function FeedbackDialog({
           stays put, instead of the cap clipping the footer off the bottom. No inner
           scroll region — the action row is always the bottom of the sheet. */}
       <DialogPopup className="max-w-md max-h-none">
-        <DialogHeader>
-          <DialogTitle>{t(titleKey)}</DialogTitle>
-          {status !== "success" && (
-            <p className="text-xs text-zinc-400 dark:text-zinc-500">
-              {t("emailLabel")}{" "}
-              <a
-                href="mailto:me@atlens.app"
-                className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              >
-                me@atlens.app
-              </a>
-            </p>
-          )}
+        <DialogHeader className="flex-row items-start justify-between gap-3 pr-5">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <DialogTitle>{t(titleKey)}</DialogTitle>
+            {status !== "success" && (
+              <p className="text-xs text-zinc-400 dark:text-zinc-500">
+                {t("emailLabel")}{" "}
+                <a
+                  href="mailto:me@atlens.app"
+                  className="underline underline-offset-2 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                >
+                  me@atlens.app
+                </a>
+              </p>
+            )}
+          </div>
           {/* Desktop-only corner close; the mobile drawer dismisses via swipe /
-              the footer Cancel, matching LensSearchDialog. */}
-          <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "absolute right-4 top-4 hidden h-9 w-9 sm:inline-flex")}>
+              the footer Cancel, matching LensSearchDialog. As a flex item (not
+              absolute) it occupies real space, so a long title wraps to its left
+              instead of running underneath it. */}
+          <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "hidden h-9 w-9 shrink-0 sm:inline-flex")}>
             <X className="h-4 w-4" />
           </DialogClose>
         </DialogHeader>

--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
+import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Iris from "@/components/iris/Iris";
 import type { IrisConfig } from "@/config/iris-config";
+import { ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS } from "@/config/ui-tokens";
 import {
   Dialog,
+  DialogClose,
   DialogPopup,
   DialogFooter,
   DialogHeader,
@@ -206,6 +209,11 @@ export default function FeedbackDialog({
               </a>
             </p>
           )}
+          {/* Desktop-only corner close; the mobile drawer dismisses via swipe /
+              the footer Cancel, matching LensSearchDialog. */}
+          <DialogClose className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "absolute right-4 top-4 hidden h-9 w-9 sm:inline-flex")}>
+            <X className="h-4 w-4" />
+          </DialogClose>
         </DialogHeader>
 
 

--- a/src/components/feedback/FeedbackDialog.tsx
+++ b/src/components/feedback/FeedbackDialog.tsx
@@ -7,7 +7,7 @@ import Iris from "@/components/iris/Iris";
 import type { IrisConfig } from "@/config/iris-config";
 import {
   Dialog,
-  DialogContent,
+  DialogPopup,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -192,10 +192,7 @@ export default function FeedbackDialog({
           the drawer grows upward from its pinned bottom edge so the Cancel/Submit row
           stays put, instead of the cap clipping the footer off the bottom. No inner
           scroll region — the action row is always the bottom of the sheet. */}
-      <DialogContent
-        layerRef={dialogLayerRef}
-        className="max-w-md max-h-none"
-      >
+      <DialogPopup className="max-w-md max-h-none">
         <DialogHeader>
           <DialogTitle>{t(titleKey)}</DialogTitle>
           {status !== "success" && (
@@ -400,7 +397,11 @@ export default function FeedbackDialog({
             </>
           )}
         </DialogFooter>
-      </DialogContent>
+        {/* Portal anchor for the nested field-picker Select: rendering its popup
+            inside the dialog (not document.body) keeps clicks within the dialog's
+            dismiss scope, so picking a field doesn't close the dialog. */}
+        <div ref={dialogLayerRef} />
+      </DialogPopup>
     </Dialog>
   );
 }

--- a/src/components/share/LightboxDialog.tsx
+++ b/src/components/share/LightboxDialog.tsx
@@ -2,7 +2,8 @@
 
 import { ChevronDown, Loader2, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogPortal, DialogBackdrop, DialogRawPopup } from "@/components/ui/dialog";
+import { Z } from "@/config/ui";
 import type { LightboxState } from "@/hooks/useLightbox";
 
 type LightboxDialogProps = Omit<LightboxState, "handleOpen" | "scrollRef"> & {
@@ -32,55 +33,55 @@ export function LightboxDialog({
       }}
       responsive={false}
     >
-      <DialogContent
-        noDefaultPositioning
-        className="fixed inset-0 flex items-center justify-center border-0 bg-transparent p-0 shadow-none duration-100"
-        backdropClassName="bg-zinc-950/75 transition-[background-color] duration-150"
-        showCloseButton={false}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) {
-            handleClose();
-          }
-        }}
-      >
-        <div className="relative w-[calc(100vw-44px)] max-w-[750px]">
-          <button
-            onClick={handleClose}
-            className="absolute right-0 top-0 z-10 flex h-8 w-8 -translate-y-1/2 translate-x-1/2 cursor-pointer items-center justify-center rounded-full bg-white text-zinc-500 shadow-md transition-colors hover:text-zinc-900 sm:hidden"
-            aria-label={t("close")}
-          >
-            <X className="size-3.5" />
-          </button>
-
-          <div className="relative w-full overflow-hidden rounded-2xl bg-white shadow-[0_8px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(0,0,0,0.06)] animate-in fade-in-0 zoom-in-95 duration-150 ease-out">
-            <div
-              ref={scrollRef}
-              className="max-h-[calc(100svh-3rem-10px)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100svh-3rem)]"
-              onScroll={() => {
-                if (!hasScrolled) {
-                  handleScroll();
-                }
-              }}
+      <DialogPortal>
+        <DialogBackdrop className="bg-zinc-950/75 transition-[background-color] duration-150" />
+        <DialogRawPopup
+          className={`fixed inset-0 ${Z.dialog} flex items-center justify-center border-0 bg-transparent p-0 shadow-none duration-100`}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              handleClose();
+            }
+          }}
+        >
+          <div className="relative w-[calc(100vw-44px)] max-w-[750px]">
+            <button
+              onClick={handleClose}
+              className="absolute right-0 top-0 z-10 flex h-8 w-8 -translate-y-1/2 translate-x-1/2 cursor-pointer items-center justify-center rounded-full bg-white text-zinc-500 shadow-md transition-colors hover:text-zinc-900 sm:hidden"
+              aria-label={t("close")}
             >
-              {imageLoading ? (
-                <div className="flex h-48 items-center justify-center">
-                  <Loader2 className="size-6 animate-spin text-zinc-400" />
-                </div>
-              ) : imageUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element -- blob URL, not optimizable
-                <img src={imageUrl} alt="" className="w-full" onLoad={handleImageLoad} />
-              ) : null}
-            </div>
+              <X className="size-3.5" />
+            </button>
 
-            {isScrollable && !hasScrolled && (
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-28 flex-col items-center justify-end bg-[linear-gradient(to_top,white_30%,rgba(255,255,255,0.85)_60%,transparent)] pb-4">
-                <ChevronDown className="size-6 -mb-2 text-zinc-600" />
-                <ChevronDown className="size-6 text-zinc-600" />
+            <div className="relative w-full overflow-hidden rounded-2xl bg-white shadow-[0_8px_40px_rgba(0,0,0,0.22),0_0_0_1px_rgba(0,0,0,0.06)] animate-in fade-in-0 zoom-in-95 duration-150 ease-out">
+              <div
+                ref={scrollRef}
+                className="max-h-[calc(100svh-3rem-10px)] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:max-h-[calc(100svh-3rem)]"
+                onScroll={() => {
+                  if (!hasScrolled) {
+                    handleScroll();
+                  }
+                }}
+              >
+                {imageLoading ? (
+                  <div className="flex h-48 items-center justify-center">
+                    <Loader2 className="size-6 animate-spin text-zinc-400" />
+                  </div>
+                ) : imageUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element -- blob URL, not optimizable
+                  <img src={imageUrl} alt="" className="w-full" onLoad={handleImageLoad} />
+                ) : null}
               </div>
-            )}
+
+              {isScrollable && !hasScrolled && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-28 flex-col items-center justify-end bg-[linear-gradient(to_top,white_30%,rgba(255,255,255,0.85)_60%,transparent)] pb-4">
+                  <ChevronDown className="size-6 -mb-2 text-zinc-600" />
+                  <ChevronDown className="size-6 text-zinc-600" />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      </DialogContent>
+        </DialogRawPopup>
+      </DialogPortal>
     </Dialog>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,10 +3,8 @@
 import * as React from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
-import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { FROSTED_OVERLAY_CHROME_CLS, ICON_CLOSE_BTN_CLS } from "@/config/ui-tokens";
 import { Z } from "@/config/ui";
 import { useBreakpoint } from "@/hooks/useViewport";
 
@@ -44,28 +42,34 @@ function Dialog({
   );
 }
 
-function DialogPortal({
-  children,
-  ...props
-}: DialogPrimitive.Portal.Props) {
-  return (
-    <DialogPrimitive.Portal {...props}>
-      {children}
-    </DialogPrimitive.Portal>
-  );
+function DialogPortal({ children }: { children: React.ReactNode }) {
+  const mode = useDialogMode();
+  const Primitive = mode === "drawer" ? DrawerPrimitive.Portal : DialogPrimitive.Portal;
+  return <Primitive>{children}</Primitive>;
 }
 
-// Clicking the backdrop dismisses the dialog. We render it as a
-// DialogPrimitive.Close so the close flows through Base UI's internal
-// onOpenChange — no need to thread the callback through props.
 function DialogBackdrop({ className }: { className?: string }) {
-  return (
+  const mode = useDialogMode();
+
+  return mode === "drawer" ? (
+    <DrawerPrimitive.Backdrop
+      data-slot="dialog-backdrop"
+      className={cn(
+        `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
+        className
+      )}
+    />
+  ) : (
+    // Dialog mode has no native click-to-dismiss backdrop, so we render the
+    // backdrop AS a Close trigger: clicking it routes through Base UI's internal
+    // onOpenChange, no callback threading. (DialogPrimitive.Backdrop is purely
+    // presentational — role="presentation", no press handler.)
     <DialogPrimitive.Close
       render={<div />}
       nativeButton={false}
       data-slot="dialog-backdrop"
       className={cn(
-        "absolute inset-0 bg-zinc-950/55 backdrop-blur-sm cursor-default outline-none",
+        `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm cursor-default outline-none`,
         className
       )}
       aria-label="Close"
@@ -74,77 +78,74 @@ function DialogBackdrop({ className }: { className?: string }) {
   );
 }
 
-type DialogContentProps = DialogPrimitive.Popup.Props & {
-  backdropClassName?: string;
-  layerRef?: React.Ref<HTMLDivElement>;
-  showCloseButton?: boolean;
-  /** Omits the default centered positioning (left-1/2 top-1/2 max-w-2xl -translate-*) so the
-   *  caller can supply custom fixed inset classes without Tailwind class conflicts. */
-  noDefaultPositioning?: boolean;
+// Bare popup element with no positioning or box chrome — the escape hatch for
+// callers (e.g. the fullscreen lightbox) that paint their own surface. Drawer
+// mode wraps it in the swipe Viewport. `render` is omitted from the prop type so
+// callers cannot replace the element and corrupt the fixed portal structure.
+// Narrow className/style to their plain forms: Base UI's Dialog and Drawer popups
+// each accept a state-callback variant keyed to their own (incompatible) popup
+// state, so the union forms can't be forwarded to both. Every caller passes plain
+// values anyway. `render` is omitted so callers can't swap the element and corrupt
+// the fixed portal structure.
+type DialogRawPopupProps = Omit<DialogPrimitive.Popup.Props, "render" | "className" | "style"> & {
+  className?: string;
+  style?: React.CSSProperties;
 };
 
-function DialogContent({
-  className,
-  backdropClassName,
-  children,
-  layerRef,
-  showCloseButton = true,
-  noDefaultPositioning = false,
-  render: _render, // eslint-disable-line @typescript-eslint/no-unused-vars -- strip before DOM spread
-  ...props
-}: DialogContentProps) {
+function DialogRawPopup({ className, children, ...props }: DialogRawPopupProps) {
   const mode = useDialogMode();
 
   return mode === "drawer" ? (
-    <DrawerPrimitive.Portal>
-      <DrawerPrimitive.Backdrop
-        data-slot="dialog-backdrop"
-        className={cn(
-          `fixed inset-0 ${Z.dialog} bg-zinc-950/55 backdrop-blur-sm transition-colors duration-200 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
-          backdropClassName
-        )}
-      />
-      <DrawerPrimitive.Viewport>
-        <DrawerPrimitive.Popup
-          data-slot="dialog-content"
+    <DrawerPrimitive.Viewport>
+      <DrawerPrimitive.Popup data-slot="dialog-content" className={className} {...props}>
+        {children}
+      </DrawerPrimitive.Popup>
+    </DrawerPrimitive.Viewport>
+  ) : (
+    <DialogPrimitive.Popup data-slot="dialog-content" className={className} {...props}>
+      {children}
+    </DialogPrimitive.Popup>
+  );
+}
+
+// Opinionated surface: Portal + Backdrop + a positioned box (centered card on
+// desktop, bottom sheet on mobile). Callers compose their own header/body/footer
+// and place a <DialogClose> wherever they want one.
+function DialogPopup({ className, children, ...props }: DialogRawPopupProps) {
+  const mode = useDialogMode();
+
+  return (
+    <DialogPortal>
+      <DialogBackdrop />
+      {mode === "drawer" ? (
+        <DialogRawPopup
           className={cn(
-            `fixed inset-x-0 bottom-0 ${Z.dialog} flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
+            `flex max-h-[85svh] flex-col border border-b-0 border-zinc-200 bg-white p-0 pb-[var(--safe-inset-bottom)] shadow-2xl duration-200 data-open:animate-in data-open:slide-in-from-bottom data-closed:animate-out data-closed:slide-out-to-bottom dark:border-zinc-800 dark:bg-zinc-950`,
+            `fixed inset-x-0 bottom-0 ${Z.dialog}`,
             "transition-[transform,opacity] data-[swipe-dismiss]:!transition-none data-[nested-drawer-open]:scale-[0.94] data-[nested-drawer-open]:opacity-40",
             className,
             "rounded-t-2xl rounded-b-none"
           )}
-          {...(props as Omit<typeof props, "style">)}
+          {...props}
         >
           <div className="flex shrink-0 touch-none justify-center pb-1 pt-3">
             <div className="h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600" />
           </div>
           {children}
-          {layerRef && <div ref={layerRef} />}
-        </DrawerPrimitive.Popup>
-      </DrawerPrimitive.Viewport>
-    </DrawerPrimitive.Portal>
-  ) : (
-    <DialogPortal>
-      <div ref={layerRef} className={cn("fixed inset-0", Z.dialog)}>
-        <DialogBackdrop className={backdropClassName} />
-        <DialogPrimitive.Popup
-          data-slot="dialog-content"
+        </DialogRawPopup>
+      ) : (
+        <DialogRawPopup
           className={cn(
-            `fixed ${Z.local} rounded-2xl border border-zinc-200 bg-white p-0 shadow-2xl dark:border-zinc-800 dark:bg-zinc-950`,
-            !noDefaultPositioning && "left-1/2 top-1/2 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2",
+            `fixed ${Z.dialog} rounded-2xl border border-zinc-200 bg-white p-0 shadow-2xl dark:border-zinc-800 dark:bg-zinc-950`,
+            "left-1/2 top-1/2 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2",
             "origin-[var(--transform-origin)] duration-200 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-90 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-90",
             className
           )}
           {...props}
         >
           {children}
-          {showCloseButton && (
-            <DialogPrimitive.Close className={cn(ICON_CLOSE_BTN_CLS, FROSTED_OVERLAY_CHROME_CLS, "absolute right-4 top-4 z-10 h-9 w-9")}>
-              <X className="h-4 w-4" />
-            </DialogPrimitive.Close>
-          )}
-        </DialogPrimitive.Popup>
-      </div>
+        </DialogRawPopup>
+      )}
     </DialogPortal>
   );
 }
@@ -210,7 +211,10 @@ function DialogClose({ className, ...props }: Omit<DialogPrimitive.Close.Props, 
 
 export {
   Dialog,
-  DialogContent,
+  DialogPortal,
+  DialogBackdrop,
+  DialogRawPopup,
+  DialogPopup,
   DialogClose,
   DialogHeader,
   DialogFooter,


### PR DESCRIPTION
## What

The single `DialogContent` had accumulated flags to serve three divergent surfaces (search, feedback, lightbox): `showCloseButton`, `layerRef`, `noDefaultPositioning`, `backdropClassName`, plus a runtime `render` strip. This replaces it with composable parts that each fork the drawer/dialog mode internally.

**New API (`ui/dialog.tsx`):**
- `DialogPopup` — opinionated centered-card (desktop) / bottom-sheet (mobile) surface. Used by `LensSearchDialog` and `FeedbackDialog`. Callers compose their own `DialogClose`.
- `DialogPortal` / `DialogBackdrop` / `DialogRawPopup` — raw escape hatch for the fullscreen lightbox, which paints its own surface.

**Flags eliminated:**
| Flag | Replacement |
|------|-------------|
| `showCloseButton` | callers place `<DialogClose>` where they want it |
| `layerRef` | caller owns the nested-portal anchor div (Feedback) |
| `noDefaultPositioning` / `backdropClassName` | lightbox composes raw parts |
| `render` strip | omitted from the prop type instead |

Dialog mode also drops the wrapper layer `div`; the backdrop is now a self-positioned `fixed` Close trigger and the popup sits at `z-dialog`, matching the drawer mode's stacking approach.

## Why

Each flag existed for exactly one caller — almost all of them for the lightbox, which barely uses the dialog chrome. Pushing the outlier onto raw primitives lets the common surface (`DialogPopup`) stay flag-free.

## Notes / traps
- The dialog-mode backdrop stays a `DialogPrimitive.Close render={<div/>}` (not `DialogPrimitive.Backdrop`, which is `role="presentation"` with no press handler) so a backdrop click still dismisses through Base UI's internal `onOpenChange`.
- `DialogRawPopup` narrows `className`/`style` to their plain forms: Base UI's Dialog and Drawer popups each accept a state-callback variant keyed to their own incompatible popup state, so the union forms can't be forwarded to both.

## Test plan
Verified on a local dev server (snapshot + bounding-box / computed-style assertions; screenshots time out in the sandbox):
- **Search, desktop (1440):** centered card (`max-w-2xl`, centered), backdrop `fixed inset-0 z-[60]` Close trigger, popup `z-[60]`, corner close button, Escape dismisses, results render.
- **Search, mobile (390):** bottom sheet `fixed` flush to bottom, full-width, grab handle centered, rounded-top/square-bottom, wrapped in the swipe Viewport.
- **Feedback, desktop:** the nested field-picker `Select` dropdown renders **inside** the dialog (into the caller-owned trailing anchor div), and picking a field does not dismiss the dialog.
- **Lightbox, desktop:** fullscreen transparent `flex` center via raw `DialogRawPopup`, custom backdrop `bg-zinc-950/75`, image + close button present.

Drawer/dialog split threshold (`useBreakpoint("sm")`) is unchanged, so behavior matches pre-refactor across both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)