### PR TITLE
fix(compare): dedupe compare_add telemetry — move effect from hook to Provider

### DIFF
--- a/src/context/CompareProvider.tsx
+++ b/src/context/CompareProvider.tsx
@@ -26,6 +26,19 @@ const CompareContext = createContext<CompareContextValue | null>(null);
 export function CompareProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState(initialCompareState);
   const value = useMemo(() => ({ state, setState }), [state]);
+  const mount = useEffectiveMount();
+  const compareIds = state[mount];
+  const prevIdsRef = useRef(compareIds);
+
+  useEffect(() => {
+    const prev = prevIdsRef.current;
+    prevIdsRef.current = compareIds;
+    const added = compareIds.filter((id) => !prev.includes(id));
+    if (added.length === 1) {
+      track("compare_add", { lens_slug: added[0] });
+    }
+  }, [compareIds]);
+
   return (
     <CompareContext value={value}>
       {children}
@@ -41,16 +54,6 @@ export function useCompare() {
   const mount = useEffectiveMount();
   const { state, setState } = ctx;
   const compareIds = state[mount];
-
-  const prevIdsRef = useRef(compareIds);
-  useEffect(() => {
-    const prev = prevIdsRef.current;
-    prevIdsRef.current = compareIds;
-    const added = compareIds.filter((id) => !prev.includes(id));
-    if (added.length === 1) {
-      track("compare_add", { lens_slug: added[0] });
-    }
-  }, [compareIds]);
 
   const add = useCallback(
     (id: string) => {


### PR DESCRIPTION
## Problem
`compare_add` was over-reported: every "add to compare" action fired the event multiple times.

## Root cause
The telemetry `useEffect` (diff `compareIds` → `track("compare_add")`) lived in the **`useCompare()` hook**. That hook is consumed by ~a dozen components (`Nav`, `CompareBar`, `CompareTable`, `LensListClient`, …). A custom hook is inlined into each caller, so the effect was instantiated once per mounted consumer — and since it watches the **shared** `compareIds` from context, a single add woke every instance's effect, each with its own `prevIdsRef`, each firing once.

## Fix
Move the effect into **`CompareProvider`**, which is mounted exactly once (root `[locale]/layout`). The event now fires a single time per add. Consumers no longer carry their own `prevIdsRef`/effect.

## Notes
- `CompareProvider` now calls `useEffectiveMount()` (→ `useMountPreference()`), so it must stay nested inside `MountPreferenceProvider` — it already is in the layout.
- Pre-existing, not changed here: the `compare_add` heuristic infers an "add" from a state diff (`added.length === 1`), so URL-seed restore (`seed()`) and mount switches can still single-fire a stray event. Out of scope for this dedupe; can be a follow-up if we want action-explicit instrumentation.

## Test plan
- `vitest run CompareProvider.test.tsx useCompareLensSearch.test.tsx` → 25/25 pass
- `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)