### PR TITLE
feat: Recently Added page (lens-additions log) + footer rework

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 import { useTranslations } from "next-intl";
 import { buildAlternates } from "@/lib/seo";
-import { getLensesByMount, meta } from "@/lib/lens/data";
+import { getLensesByMount } from "@/lib/lens/data";
 import DataInfo from "@/components/DataFooter";
 import HomeCta from "@/components/HomeCta";
 import HeroBrand from "@/components/mount/MountTag";
@@ -53,7 +53,7 @@ function HomeContent({ mountStats }: { mountStats: { X: { lensCount: number; bra
           <div className="flex flex-wrap items-center justify-center gap-3">
             <HomeCta />
           </div>
-          <DataInfo mountStats={mountStats} meta={meta} />
+          <DataInfo mountStats={mountStats} />
         </div>
       </section>
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -32,11 +32,19 @@ export default async function HomePage({ params }: { params: Params }) {
     X: { lensCount: xLenses.length, brandCount: new Set(xLenses.map((l) => l.brand)).size },
     G: { lensCount: gLenses.length, brandCount: new Set(gLenses.map((l) => l.brand)).size },
   };
+  // Most recent date any lens entered the library, across both mounts — drives
+  // the "What's New" freshness hint in the footer.
+  const lastAddedAt =
+    [...xLenses, ...gLenses]
+      .map((l) => l.createdAt)
+      .filter((d): d is string => Boolean(d))
+      .sort()
+      .at(-1) ?? null;
 
-  return <HomeContent mountStats={mountStats} />;
+  return <HomeContent mountStats={mountStats} lastAddedAt={lastAddedAt} />;
 }
 
-function HomeContent({ mountStats }: { mountStats: { X: { lensCount: number; brandCount: number }; G: { lensCount: number; brandCount: number } } }) {
+function HomeContent({ mountStats, lastAddedAt }: { mountStats: { X: { lensCount: number; brandCount: number }; G: { lensCount: number; brandCount: number } }; lastAddedAt: string | null }) {
   const t = useTranslations("Common");
 
   return (
@@ -53,7 +61,7 @@ function HomeContent({ mountStats }: { mountStats: { X: { lensCount: number; bra
           <div className="flex flex-wrap items-center justify-center gap-3">
             <HomeCta />
           </div>
-          <DataInfo mountStats={mountStats} />
+          <DataInfo mountStats={mountStats} lastAddedAt={lastAddedAt} />
         </div>
       </section>
 

--- a/src/app/[locale]/recently-added/page.tsx
+++ b/src/app/[locale]/recently-added/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "WhatsNew" });
+  const t = await getTranslations({ locale, namespace: "RecentlyAdded" });
   const title = t("pageTitle");
   const description = t("metaDescription");
   return {
@@ -25,7 +25,7 @@ export async function generateMetadata({
       description,
       images: defaultOgImages(),
     },
-    alternates: buildAlternates(locale, "whats-new"),
+    alternates: buildAlternates(locale, "recently-added"),
   };
 }
 
@@ -43,11 +43,11 @@ function formatDay(dateStr: string, locale: string): string {
 const byBrandThenModel = (a: Lens, b: Lens) =>
   a.brand.localeCompare(b.brand) || a.model.localeCompare(b.model);
 
-export default async function WhatsNewPage({ params }: { params: Params }) {
+export default async function RecentlyAddedPage({ params }: { params: Params }) {
   const { locale } = await params;
   setRequestLocale(locale);
   const [t, tBrand] = await Promise.all([
-    getTranslations({ locale, namespace: "WhatsNew" }),
+    getTranslations({ locale, namespace: "RecentlyAdded" }),
     getTranslations({ locale, namespace: "Brands" }),
   ]);
 

--- a/src/app/[locale]/recently-added/page.tsx
+++ b/src/app/[locale]/recently-added/page.tsx
@@ -128,7 +128,7 @@ export default async function RecentlyAddedPage({ params }: { params: Params }) 
         {seedDate ? (
           <div className="flex items-baseline justify-between gap-3 border-t border-zinc-200 dark:border-zinc-800 pt-4 text-sm text-zinc-500 dark:text-zinc-500">
             <span>
-              {formatDay(seedDate, locale)} · {t("initialLibraryLabel")}
+              {formatDay(seedDate, locale)} · {t("initialBatchLabel")}
             </span>
             <span className="shrink-0 tabular-nums">
               {t("lensesCount", { count: byDate.get(seedDate)?.length ?? 0 })}

--- a/src/app/[locale]/whats-new/page.tsx
+++ b/src/app/[locale]/whats-new/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import { buildAlternates, defaultOgImages } from "@/lib/seo";
+import { getAllLenses } from "@/lib/lens/data";
+import { mountToUrlSegment } from "@/lib/mount";
+import type { Lens } from "@/lib/types";
+
+type Params = Promise<{ locale: string }>;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "WhatsNew" });
+  const title = t("pageTitle");
+  const description = t("metaDescription");
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${title} | Atlens`,
+      description,
+      images: defaultOgImages(),
+    },
+    alternates: buildAlternates(locale, "whats-new"),
+  };
+}
+
+// Date-only strings are formatted in UTC so the rendered day matches the stored
+// createdAt regardless of the server's timezone.
+function formatDay(dateStr: string, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${dateStr}T00:00:00Z`));
+}
+
+const byBrandThenModel = (a: Lens, b: Lens) =>
+  a.brand.localeCompare(b.brand) || a.model.localeCompare(b.model);
+
+export default async function WhatsNewPage({ params }: { params: Params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const [t, tBrand] = await Promise.all([
+    getTranslations({ locale, namespace: "WhatsNew" }),
+    getTranslations({ locale, namespace: "Brands" }),
+  ]);
+
+  // Group every lens by its createdAt day. The earliest day is the launch seed
+  // (the library's initial bulk import, backfilled from git history) — it is
+  // rendered as a single collapsed line rather than an enumerated batch, since
+  // it represents the starting catalog rather than a real daily addition.
+  const byDate = new Map<string, Lens[]>();
+  for (const lens of getAllLenses(locale)) {
+    if (!lens.createdAt) {
+      continue;
+    }
+    const group = byDate.get(lens.createdAt) ?? [];
+    group.push(lens);
+    byDate.set(lens.createdAt, group);
+  }
+
+  const sortedDates = [...byDate.keys()].sort();
+  const seedDate = sortedDates[0];
+  const entryDates = sortedDates.slice(1).reverse();
+
+  return (
+    <div className="w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4 sm:pt-12 pb-32 flex flex-col gap-6">
+      <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50 font-heading">
+        {t("pageTitle")}
+      </h1>
+      <p className="-mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+        {t("intro")}
+      </p>
+
+      <div className="flex flex-col gap-8">
+        {entryDates.map((date) => {
+          const lenses = byDate.get(date) ?? [];
+          const mountGroups = [
+            { key: "X", label: t("mountX"), lenses: lenses.filter((l) => l.mount === "X").sort(byBrandThenModel) },
+            { key: "G", label: t("mountG"), lenses: lenses.filter((l) => l.mount === "G").sort(byBrandThenModel) },
+          ].filter((g) => g.lenses.length > 0);
+
+          return (
+            <section key={date} className="flex flex-col gap-4">
+              <div className="flex items-baseline justify-between gap-3 border-b border-zinc-200 dark:border-zinc-800 pb-2">
+                <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                  {formatDay(date, locale)}
+                </h2>
+                <span className="shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 text-xs font-medium tabular-nums text-zinc-600 dark:text-zinc-300">
+                  {t("added", { count: lenses.length })}
+                </span>
+              </div>
+
+              {mountGroups.map((group) => (
+                <div key={group.key} className="flex flex-col gap-1.5">
+                  <p className="text-xs font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                    {group.label}
+                  </p>
+                  <ul className="flex flex-col gap-1">
+                    {group.lenses.map((lens) => (
+                      <li key={lens.id}>
+                        <Link
+                          href={`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`}
+                          className="group inline-flex items-baseline gap-1.5 text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+                        >
+                          <span className="text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-400 dark:group-hover:text-zinc-500">
+                            ·
+                          </span>
+                          <span>
+                            {tBrand(lens.brand as Parameters<typeof tBrand>[0])} {lens.model}
+                          </span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </section>
+          );
+        })}
+
+        {seedDate ? (
+          <div className="flex items-baseline justify-between gap-3 border-t border-zinc-200 dark:border-zinc-800 pt-4 text-sm text-zinc-500 dark:text-zinc-500">
+            <span>
+              {formatDay(seedDate, locale)} · {t("initialLibraryLabel")}
+            </span>
+            <span className="shrink-0 tabular-nums">
+              {t("lensesCount", { count: byDate.get(seedDate)?.length ?? 0 })}
+            </span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -31,7 +31,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }
     return paths;
   });
-  const staticPaths = [...mountPaths, "/about", "/whats-new", "/get"];
+  const staticPaths = [...mountPaths, "/about", "/recently-added", "/get"];
 
   const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) => [
     {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -31,7 +31,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }
     return paths;
   });
-  const staticPaths = [...mountPaths, "/about", "/get"];
+  const staticPaths = [...mountPaths, "/about", "/whats-new", "/get"];
 
   const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) => [
     {

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useLocale } from "next-intl";
+import { Sparkles, ArrowRight } from "lucide-react";
+import { Link } from "@/i18n/navigation";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 
-type ClickState = "date" | "version" | "easter";
+type ClickState = "count" | "easter";
 
 interface MountStats {
   lensCount: number;
@@ -14,50 +15,37 @@ interface MountStats {
 
 interface DataInfoProps {
   mountStats: { X: MountStats; G: MountStats };
-  meta: { lastUpdated: string; version: string; buildNumber: number };
 }
 
-export default function DataInfo({ mountStats, meta }: DataInfoProps) {
+export default function DataInfo({ mountStats }: DataInfoProps) {
   const h = useTranslations("Home");
   const t = useTranslations("Footer");
-  const locale = useLocale();
   const mount = useEffectiveMount();
   const { lensCount, brandCount } = mountStats[mount];
-  const [clickState, setClickState] = useState<ClickState>("date");
+  const [clickState, setClickState] = useState<ClickState>("count");
 
-  const cycle = () =>
-    setClickState((s) =>
-      s === "date" ? "version" : s === "version" ? "easter" : "date"
-    );
-
-  const formatDate = (dateStr: string) =>
-    new Intl.DateTimeFormat(locale, { year: "numeric", month: "long", day: "numeric" }).format(
-      new Date(dateStr)
-    );
-
-  const dateLabel = (() => {
-    if (clickState === "version")
-      {return `${meta.version} Build ${meta.buildNumber}`;}
-    if (clickState === "easter") {
-      return h("dataSnapshot");
-    }
-    return `${t("updatedPrefix")} ${formatDate(meta.lastUpdated)}`;
-  })();
+  const toggle = () =>
+    setClickState((s) => (s === "count" ? "easter" : "count"));
 
   return (
     <div className="flex flex-col items-center gap-0.5 mt-3">
       <p
-        className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono"
-        title={h("dataTooltip")}
-      >
-        {h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
-      </p>
-      <p
         className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono cursor-pointer hover:text-zinc-300 dark:hover:text-zinc-400 transition-colors"
-        onClick={cycle}
+        title={h("dataTooltip")}
+        onClick={toggle}
       >
-        {dateLabel}
+        {clickState === "easter"
+          ? h("dataSnapshot")
+          : h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
       </p>
+      <Link
+        href="/whats-new"
+        className="inline-flex items-center gap-1 text-[11px] tracking-wider font-mono text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+      >
+        <Sparkles className="size-3" />
+        {t("whatsNew")}
+        <ArrowRight className="size-3" />
+      </Link>
     </div>
   );
 }

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Sparkles, ArrowRight } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { useEffectiveMount } from "@/hooks/useMountParam";
-
-type ClickState = "count" | "easter";
 
 interface MountStats {
   lensCount: number;
@@ -15,35 +12,42 @@ interface MountStats {
 
 interface DataInfoProps {
   mountStats: { X: MountStats; G: MountStats };
+  lastAddedAt: string | null;
 }
 
-export default function DataInfo({ mountStats }: DataInfoProps) {
+export default function DataInfo({ mountStats, lastAddedAt }: DataInfoProps) {
   const h = useTranslations("Home");
   const t = useTranslations("Footer");
+  const locale = useLocale();
   const mount = useEffectiveMount();
   const { lensCount, brandCount } = mountStats[mount];
-  const [clickState, setClickState] = useState<ClickState>("count");
 
-  const toggle = () =>
-    setClickState((s) => (s === "count" ? "easter" : "count"));
+  const addedLabel = lastAddedAt
+    ? new Intl.DateTimeFormat(locale, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      }).format(new Date(`${lastAddedAt}T00:00:00Z`))
+    : null;
 
   return (
     <div className="flex flex-col items-center gap-0.5 mt-3">
       <p
-        className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono cursor-pointer hover:text-zinc-300 dark:hover:text-zinc-400 transition-colors"
+        className="text-[11px] tracking-wider text-zinc-400 dark:text-zinc-500 font-mono"
         title={h("dataTooltip")}
-        onClick={toggle}
       >
-        {clickState === "easter"
-          ? h("dataSnapshot")
-          : h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
+        {h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
       </p>
       <Link
         href="/whats-new"
         className="inline-flex items-center gap-1 text-[11px] tracking-wider font-mono text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
       >
         <Sparkles className="size-3" />
-        {t("whatsNew")}
+        <span>{t("whatsNew")}</span>
+        {addedLabel ? (
+          <span className="text-zinc-400 dark:text-zinc-500">· {addedLabel}</span>
+        ) : null}
         <ArrowRight className="size-3" />
       </Link>
     </div>

--- a/src/components/DataFooter.tsx
+++ b/src/components/DataFooter.tsx
@@ -40,14 +40,12 @@ export default function DataInfo({ mountStats, lastAddedAt }: DataInfoProps) {
         {h("dataSnapshotCount", { count: lensCount, brands: brandCount })}
       </p>
       <Link
-        href="/whats-new"
-        className="inline-flex items-center gap-1 text-[11px] tracking-wider font-mono text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+        href="/recently-added"
+        className="inline-flex items-center gap-1 text-[11px] tracking-wider font-mono text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
       >
         <Sparkles className="size-3" />
-        <span>{t("whatsNew")}</span>
-        {addedLabel ? (
-          <span className="text-zinc-400 dark:text-zinc-500">· {addedLabel}</span>
-        ) : null}
+        <span>{t("recentlyAdded")}</span>
+        {addedLabel ? <span>· {addedLabel}</span> : null}
         <ArrowRight className="size-3" />
       </Link>
     </div>

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -269,10 +269,10 @@ export default async function AboutContent() {
           })}
         </p>
         <Link
-          href="/whats-new"
+          href="/recently-added"
           className="inline-flex items-center gap-0.5 self-start text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
         >
-          {t("whatsNewLink")}
+          {t("recentlyAddedLink")}
           <ArrowRight className="size-3" />
         </Link>
       </Section>

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -1,5 +1,6 @@
 import { getTranslations, getLocale } from "next-intl/server";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, ArrowRight } from "lucide-react";
+import { Link } from "@/i18n/navigation";
 import Image from "next/image";
 import FeedbackTrigger from "@/components/feedback/FeedbackTrigger";
 import AnthropicLogo from "@/components/logos/AnthropicLogo";
@@ -332,7 +333,14 @@ export default async function AboutContent() {
 
         {/* Update cadence */}
         <p className="text-xs text-zinc-500 dark:text-zinc-500">
-          {t("dataUpdateNote")}{"  "}{t("dataVersionNote")}
+          {t("dataUpdateNote")}{"  "}
+          <Link
+            href="/whats-new"
+            className="inline-flex items-center gap-0.5 font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+          >
+            {t("whatsNewLink")}
+            <ArrowRight className="size-3" />
+          </Link>
         </p>
 
         {/* ── Price Data subsection ── */}

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -268,6 +268,13 @@ export default async function AboutContent() {
             ),
           })}
         </p>
+        <Link
+          href="/whats-new"
+          className="inline-flex items-center gap-0.5 self-start text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+        >
+          {t("whatsNewLink")}
+          <ArrowRight className="size-3" />
+        </Link>
       </Section>
 
       {/* Data & Accuracy */}
@@ -333,14 +340,7 @@ export default async function AboutContent() {
 
         {/* Update cadence */}
         <p className="text-xs text-zinc-500 dark:text-zinc-500">
-          {t("dataUpdateNote")}{"  "}
-          <Link
-            href="/whats-new"
-            className="inline-flex items-center gap-0.5 font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
-          >
-            {t("whatsNewLink")}
-            <ArrowRight className="size-3" />
-          </Link>
+          {t("dataUpdateNote")}
         </p>
 
         {/* ── Price Data subsection ── */}

--- a/src/config/static-routes.ts
+++ b/src/config/static-routes.ts
@@ -23,7 +23,7 @@ import gLensesData from "../data/lenses-gfx.json" with { type: "json" };
 export const STATIC_LOCALIZED_SUBPATHS = [
   "",
   "about",
-  "whats-new",
+  "recently-added",
   "get",
   "lenses/x/browse",
   "lenses/gfx/browse",

--- a/src/config/static-routes.ts
+++ b/src/config/static-routes.ts
@@ -23,6 +23,7 @@ import gLensesData from "../data/lenses-gfx.json" with { type: "json" };
 export const STATIC_LOCALIZED_SUBPATHS = [
   "",
   "about",
+  "whats-new",
   "get",
   "lenses/x/browse",
   "lenses/gfx/browse",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -443,13 +443,13 @@
   },
   "RecentlyAdded": {
     "pageTitle": "Recently Added",
-    "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and G-mount (Medium Format) coverage.",
+    "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and GFX-mount (Medium Format) coverage.",
     "intro": "Lenses added to the Atlens database over time.",
     "added": "+{count}",
     "lensesCount": "{count} lenses",
     "initialBatchLabel": "First cataloged",
-    "mountX": "Fujifilm X",
-    "mountG": "Fujifilm GFX"
+    "mountX": "X Mount",
+    "mountG": "G Mount"
   },
   "Feedback": {
     "titleDataIssue": "Report an issue",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -391,7 +391,7 @@
     "pipelinePLabel": "Publish Gate",
     "pipelinePDesc": "Schema validation, normalization, independent cross-check, and final merge",
     "dataUpdateNote": "The database is updated when new lenses launch or when existing data needs correction.",
-    "dataVersionNote": "The version number and last-updated timestamp in the footer reflect the latest published data release.",
+    "whatsNewLink": "See recently added lenses",
     "dataPricingTitle": "Price data",
     "dataPricingPoint1Title": "Produced independently from spec data",
     "dataPricingPoint1Body": "Pricing has its own sampling sources and collection process, kept separate from the spec pipeline. It is meant to give rough purchase context, not a live quote.",
@@ -435,11 +435,21 @@
     "ackClosing": "My deepest gratitude to the AI collaborators whose contributions were decisive in making this project a reality — Claude Code, Google Gemini, and Claude Design."
   },
   "Footer": {
-    "updatedPrefix": "Updated",
+    "whatsNew": "What's New",
     "tagline1": "Data over opinions",
     "tagline2": "Glass matters",
     "tagline3": "aperture ring > mode dial",
     "tagline4": "f/2 feels right"
+  },
+  "WhatsNew": {
+    "pageTitle": "What's New",
+    "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and GFX-mount coverage.",
+    "intro": "Lenses added to the Atlens library over time, newest first.",
+    "added": "+{count}",
+    "lensesCount": "{count} lenses",
+    "initialLibraryLabel": "Initial library",
+    "mountX": "Fujifilm X",
+    "mountG": "Fujifilm GFX"
   },
   "Feedback": {
     "titleDataIssue": "Report an issue",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -444,7 +444,7 @@
   "RecentlyAdded": {
     "pageTitle": "Recently Added",
     "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and GFX-mount (Medium Format) coverage.",
-    "intro": "Lenses added to the Atlens database over time.",
+    "intro": "Tracking the expanding scope of the database.",
     "added": "+{count}",
     "lensesCount": "{count} lenses",
     "initialBatchLabel": "First cataloged",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -391,7 +391,7 @@
     "pipelinePLabel": "Publish Gate",
     "pipelinePDesc": "Schema validation, normalization, independent cross-check, and final merge",
     "dataUpdateNote": "The database is updated when new lenses launch or when existing data needs correction.",
-    "whatsNewLink": "See recently added lenses",
+    "recentlyAddedLink": "See recently added lenses",
     "dataPricingTitle": "Price data",
     "dataPricingPoint1Title": "Produced independently from spec data",
     "dataPricingPoint1Body": "Pricing has its own sampling sources and collection process, kept separate from the spec pipeline. It is meant to give rough purchase context, not a live quote.",
@@ -435,14 +435,14 @@
     "ackClosing": "My deepest gratitude to the AI collaborators whose contributions were decisive in making this project a reality — Claude Code, Google Gemini, and Claude Design."
   },
   "Footer": {
-    "whatsNew": "What's New",
+    "recentlyAdded": "Recently Added",
     "tagline1": "Data over opinions",
     "tagline2": "Glass matters",
     "tagline3": "aperture ring > mode dial",
     "tagline4": "f/2 feels right"
   },
-  "WhatsNew": {
-    "pageTitle": "What's New",
+  "RecentlyAdded": {
+    "pageTitle": "Recently Added",
     "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and GFX-mount coverage.",
     "intro": "Lenses added to the Atlens library over time, newest first.",
     "added": "+{count}",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -443,11 +443,11 @@
   },
   "RecentlyAdded": {
     "pageTitle": "Recently Added",
-    "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and GFX-mount coverage.",
-    "intro": "Lenses added to the Atlens library over time, newest first.",
+    "metaDescription": "Recently added lenses in the Atlens database, by date — new additions across Fujifilm X-mount and G-mount (Medium Format) coverage.",
+    "intro": "Lenses added to the Atlens database over time.",
     "added": "+{count}",
     "lensesCount": "{count} lenses",
-    "initialLibraryLabel": "Initial library",
+    "initialBatchLabel": "First cataloged",
     "mountX": "Fujifilm X",
     "mountG": "Fujifilm GFX"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -444,7 +444,7 @@
   "RecentlyAdded": {
     "pageTitle": "新增镜头",
     "metaDescription": "Atlens 数据库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口（中画幅）新收录镜头一览。",
-    "intro": "Atlens 数据库的增补记录。按日期排列，展示最近新增的镜头。",
+    "intro": "记录数据库收录范围的持续扩展。",
     "added": "+{count}",
     "lensesCount": "{count} 支镜头",
     "initialBatchLabel": "首批收录",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -391,7 +391,7 @@
     "pipelinePLabel": "发布门控",
     "pipelinePDesc": "数据合法性校验、归一化、独立交叉核查、合并写入",
     "dataUpdateNote": "新镜头上市或已有数据需要修正时，数据库将随之更新。",
-    "whatsNewLink": "查看最近新增的镜头",
+    "recentlyAddedLink": "查看最近新增的镜头",
     "dataPricingTitle": "价格数据",
     "dataPricingPoint1Title": "独立于参数数据生产",
     "dataPricingPoint1Body": "价格有独立的采样源和采集流程，与参数数据互不影响。这里给的是大致的购买参考，不是实时价格。",
@@ -435,13 +435,13 @@
     "ackClosing": "向在这个项目开发过程中给予了决定性帮助的 AI 协作者——Claude Code、Google Gemini 与 Claude Design，致以最诚挚的感激。"
   },
   "Footer": {
-    "whatsNew": "新增镜头",
+    "recentlyAdded": "新增镜头",
     "tagline1": "Data over opinions",
     "tagline2": "Glass matters",
     "tagline3": "aperture ring > mode dial",
     "tagline4": "f/2 feels right"
   },
-  "WhatsNew": {
+  "RecentlyAdded": {
     "pageTitle": "新增镜头",
     "metaDescription": "Atlens 镜头库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口新收录镜头一览。",
     "intro": "Atlens 镜头库的增补记录，新的在前。",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -391,7 +391,7 @@
     "pipelinePLabel": "发布门控",
     "pipelinePDesc": "数据合法性校验、归一化、独立交叉核查、合并写入",
     "dataUpdateNote": "新镜头上市或已有数据需要修正时，数据库将随之更新。",
-    "dataVersionNote": "页面底部显示的版本号和更新时间，对应的是最近一次正式发布的数据版本。",
+    "whatsNewLink": "查看最近新增的镜头",
     "dataPricingTitle": "价格数据",
     "dataPricingPoint1Title": "独立于参数数据生产",
     "dataPricingPoint1Body": "价格有独立的采样源和采集流程，与参数数据互不影响。这里给的是大致的购买参考，不是实时价格。",
@@ -435,11 +435,21 @@
     "ackClosing": "向在这个项目开发过程中给予了决定性帮助的 AI 协作者——Claude Code、Google Gemini 与 Claude Design，致以最诚挚的感激。"
   },
   "Footer": {
-    "updatedPrefix": "更新于",
+    "whatsNew": "新增镜头",
     "tagline1": "Data over opinions",
     "tagline2": "Glass matters",
     "tagline3": "aperture ring > mode dial",
     "tagline4": "f/2 feels right"
+  },
+  "WhatsNew": {
+    "pageTitle": "新增镜头",
+    "metaDescription": "Atlens 镜头库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口新收录镜头一览。",
+    "intro": "Atlens 镜头库的增补记录，新的在前。",
+    "added": "+{count}",
+    "lensesCount": "{count} 支镜头",
+    "initialLibraryLabel": "初始上线",
+    "mountX": "富士 X",
+    "mountG": "富士 GFX"
   },
   "Feedback": {
     "titleDataIssue": "反馈问题",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -443,11 +443,11 @@
   },
   "RecentlyAdded": {
     "pageTitle": "新增镜头",
-    "metaDescription": "Atlens 镜头库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口新收录镜头一览。",
-    "intro": "Atlens 镜头库的增补记录，新的在前。",
+    "metaDescription": "Atlens 数据库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口新收录镜头一览。",
+    "intro": "Atlens 数据库的增补记录。",
     "added": "+{count}",
     "lensesCount": "{count} 支镜头",
-    "initialLibraryLabel": "初始上线",
+    "initialBatchLabel": "首批收录",
     "mountX": "富士 X",
     "mountG": "富士 GFX"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -443,13 +443,13 @@
   },
   "RecentlyAdded": {
     "pageTitle": "新增镜头",
-    "metaDescription": "Atlens 数据库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口新收录镜头一览。",
-    "intro": "Atlens 数据库的增补记录。",
+    "metaDescription": "Atlens 数据库的增补记录，按日期排列——富士 X 卡口与 GFX 卡口（中画幅）新收录镜头一览。",
+    "intro": "Atlens 数据库的增补记录。按日期排列，展示最近新增的镜头。",
     "added": "+{count}",
     "lensesCount": "{count} 支镜头",
     "initialBatchLabel": "首批收录",
-    "mountX": "富士 X",
-    "mountG": "富士 GFX"
+    "mountX": "X 卡口",
+    "mountG": "G 卡口"
   },
   "Feedback": {
     "titleDataIssue": "反馈问题",


### PR DESCRIPTION
## What

Add a **Recently Added** page (`/[locale]/recently-added`) listing lenses by the date they entered the catalog, newest first, split per mount. Each lens links to its detail page. The earliest date is the launch seed (initial bulk import backfilled from git history) and is collapsed to a single "Initial library" line rather than enumerated.

Rework the home footer: drop the data-file publish date/version display and surface a "Recently Added · {date}" link instead.

Entry points: home footer + an About → Coverage & Roadmap link.

## Non-obvious notes (traps)

- **The route slug `/recently-added` was chosen deliberately before the page is indexed.** Renaming it later costs a 301 + ranking churn, so treat the slug as stable. The user-facing label is "Recently Added" (EN) / "新增镜头" (ZH) — "added", not "released": the list is catalog additions, which may or may not be new releases.
- **The footer no longer shows the data-file publish timestamp.** That value (`meta.lastUpdated`) bumps on *every* pipeline rebuild (price refresh, spec fix…), not only on new lenses — a weak, misleading freshness signal. It is replaced by the most-recent lens-`createdAt` date, which is what "Recently Added" actually tracks. The two are different concepts; don't conflate them again.
- The seed date is detected as `min(createdAt)`, not hardcoded — future pipeline additions need no code change.

## Test plan

- `npm run build` passes (447 routes prerendered, static-route check green; `/recently-added` is SSG for both locales).
- Verified zh/en × mobile/desktop: page layout, footer link, About entry — no wrap/overflow.
- Footer link color now matches the lens-count line and label+date darken together on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)