### PR TITLE
refactor(lens): extract buildSpecGroupLabels to dedupe label assembly

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -8,7 +8,7 @@ import { getLensUrl } from "@/lib/lens/lens";
 import { getLensesByMount } from "@/lib/lens/data";
 import { urlSegmentToMount, mountToUrlSegment } from "@/lib/mount";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens/image";
-import { buildSpecGroups, resolveSpecGroups } from "@/lib/lens/spec-groups";
+import { buildSpecGroups, buildSpecGroupLabels, resolveSpecGroups } from "@/lib/lens/spec-groups";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens/spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
 import LensDetailCompareToggle from "@/components/compare/LensDetailCompareToggle";
@@ -191,64 +191,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     canonicalUrl,
   });
 
-  const specGroups = buildSpecGroups({
-    groupOptics: t("groupOptics"),
-    groupFocus: t("groupFocus"),
-    groupStabilization: t("groupStabilization"),
-    groupPhysical: t("groupPhysical"),
-    groupFeatures: t("groupFeatures"),
-    groupRelease: t("groupRelease"),
-    focalLength: t("focalLength"),
-    focalLengthEquiv: t("focalLengthEquiv"),
-    maxAperture: t("maxAperture"),
-    minAperture: t("minAperture"),
-    maxTStop: t("maxTStop"),
-    minTStop: t("minTStop"),
-    angleOfView: t("angleOfView"),
-    angleOfViewEstNote: t("angleOfViewEstNote"),
-    apertureBladeCount: t("apertureBladeCount"),
-    lensConfiguration: t("lensConfiguration"),
-    af: t("af"),
-    focusMotor: t("focusMotor"),
-    internalFocusing: t("internalFocusing"),
-    minFocusDist: t("minFocusDist"),
-    maxMagnification: t("maxMagnification"),
-    ois: t("ois"),
-    weight: t("weight"),
-    dimensions: t("dimensions"),
-    filterSize: t("filterSize"),
-    lensMaterial: t("lensMaterial"),
-    wr: t("wr"),
-    apertureRing: t("apertureRing"),
-    powerZoom: t("powerZoom"),
-    internalZoom: t("internalZoom"),
-    releaseYear: t("releaseYear"),
-    releaseYearLabelNote: t("releaseYearLabelNote"),
-    accessories: t("accessories"),
-    yes: t("yes"),
-    no: t("no"),
-    partial: t("partial"),
-    retracted: t("lengthRetracted"),
-    wide: t("lengthWide"),
-    tele: t("lengthTele"),
-    lc: {
-      groups: t("lcGroups"),
-      elements: t("lcElements"),
-      aspherical: t("lcAspherical"),
-      ed: t("lcEd"),
-      superEd: t("lcSuperEd"),
-      sld: t("lcSld"),
-      fld: t("lcFld"),
-      highRefractive: t("lcHighRefractive"),
-      incl: t("lcIncl"),
-    },
-    motorClass: {
-      linear: t("motorLinear"),
-      stepping: t("motorStepping"),
-      dc: t("motorDc"),
-      other: t("motorOther"),
-    },
-  });
+  const specGroups = buildSpecGroups(buildSpecGroupLabels(t));
 
   // Per-view suppression: hide rows where this lens has no data.
   const valueCellLabels = {

--- a/src/components/compare/CompareTable.tsx
+++ b/src/components/compare/CompareTable.tsx
@@ -29,7 +29,7 @@ import { mountToUrlSegment } from "@/lib/mount";
 import { Link } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/browse/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens/image";
-import { buildSpecGroups, resolveSpecRow } from "@/lib/lens/spec-groups";
+import { buildSpecGroups, buildSpecGroupLabels, resolveSpecRow } from "@/lib/lens/spec-groups";
 import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens/spec-groups";
 import type { Lens } from "@/lib/types";
 import { PriceCell } from "@/components/price/PriceCell";
@@ -265,68 +265,7 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
     reorder(fromIndex, toIndex);
   }
 
-  const allGroups = useMemo(
-    () =>
-      buildSpecGroups({
-        groupOptics: td("groupOptics"),
-        groupFocus: td("groupFocus"),
-        groupStabilization: td("groupStabilization"),
-        groupPhysical: td("groupPhysical"),
-        groupFeatures: td("groupFeatures"),
-        groupRelease: td("groupRelease"),
-        focalLength: td("focalLength"),
-        focalLengthEquiv: td("focalLengthEquiv"),
-        maxAperture: td("maxAperture"),
-        minAperture: td("minAperture"),
-        maxTStop: td("maxTStop"),
-        minTStop: td("minTStop"),
-        angleOfView: td("angleOfView"),
-        angleOfViewEstNote: td("angleOfViewEstNote"),
-        apertureBladeCount: td("apertureBladeCount"),
-        lensConfiguration: td("lensConfiguration"),
-        af: td("af"),
-        focusMotor: td("focusMotor"),
-        internalFocusing: td("internalFocusing"),
-        minFocusDist: td("minFocusDist"),
-        maxMagnification: td("maxMagnification"),
-        ois: td("ois"),
-        weight: td("weight"),
-        dimensions: td("dimensions"),
-        filterSize: td("filterSize"),
-        lensMaterial: td("lensMaterial"),
-        wr: td("wr"),
-        apertureRing: td("apertureRing"),
-        powerZoom: td("powerZoom"),
-        internalZoom: td("internalZoom"),
-        releaseYear: td("releaseYear"),
-        releaseYearLabelNote: td("releaseYearLabelNote"),
-        accessories: td("accessories"),
-        yes: td("yes"),
-        no: td("no"),
-        partial: td("partial"),
-        retracted: td("lengthRetracted"),
-        wide: td("lengthWide"),
-        tele: td("lengthTele"),
-        lc: {
-          groups: td("lcGroups"),
-          elements: td("lcElements"),
-          aspherical: td("lcAspherical"),
-          ed: td("lcEd"),
-          superEd: td("lcSuperEd"),
-          sld: td("lcSld"),
-          fld: td("lcFld"),
-          highRefractive: td("lcHighRefractive"),
-          incl: td("lcIncl"),
-        },
-        motorClass: {
-          linear: td("motorLinear"),
-          stepping: td("motorStepping"),
-          dc: td("motorDc"),
-          other: td("motorOther"),
-        },
-      }),
-    [td]
-  );
+  const allGroups = useMemo(() => buildSpecGroups(buildSpecGroupLabels(td)), [td]);
 
   // Resolve all row values once per (lens, row) pair — single source of truth
   // for both the rendered cells and the Report Dialog's field list.

--- a/src/lib/lens/spec-groups.ts
+++ b/src/lib/lens/spec-groups.ts
@@ -214,6 +214,79 @@ export interface SpecGroupLabels {
   motorClass: Record<FocusMotorClass, string>;
 }
 
+// Translator compatible with next-intl's getTranslations (server) and
+// useTranslations (client) return types — both are called as t(key). A minimal
+// structural type (not next-intl's) keeps buildSpecGroups consuming plain
+// strings: the schema below never touches a translation key directly.
+type Translator = (key: string, values?: Record<string, string | number>) => string;
+
+/**
+ * Assembles the pre-translated SpecGroupLabels from a `LensDetail`-namespace
+ * translator. Single home for the label assembly shared by the detail page and
+ * the compare table — the one place that maps translation keys to label fields,
+ * so each call site no longer repeats the ~40-line object.
+ */
+export function buildSpecGroupLabels(t: Translator): SpecGroupLabels {
+  return {
+    groupOptics: t("groupOptics"),
+    groupFocus: t("groupFocus"),
+    groupStabilization: t("groupStabilization"),
+    groupPhysical: t("groupPhysical"),
+    groupFeatures: t("groupFeatures"),
+    groupRelease: t("groupRelease"),
+    focalLength: t("focalLength"),
+    focalLengthEquiv: t("focalLengthEquiv"),
+    maxAperture: t("maxAperture"),
+    minAperture: t("minAperture"),
+    maxTStop: t("maxTStop"),
+    minTStop: t("minTStop"),
+    angleOfView: t("angleOfView"),
+    angleOfViewEstNote: t("angleOfViewEstNote"),
+    apertureBladeCount: t("apertureBladeCount"),
+    lensConfiguration: t("lensConfiguration"),
+    af: t("af"),
+    focusMotor: t("focusMotor"),
+    internalFocusing: t("internalFocusing"),
+    minFocusDist: t("minFocusDist"),
+    maxMagnification: t("maxMagnification"),
+    ois: t("ois"),
+    weight: t("weight"),
+    dimensions: t("dimensions"),
+    filterSize: t("filterSize"),
+    lensMaterial: t("lensMaterial"),
+    wr: t("wr"),
+    apertureRing: t("apertureRing"),
+    powerZoom: t("powerZoom"),
+    internalZoom: t("internalZoom"),
+    releaseYear: t("releaseYear"),
+    releaseYearLabelNote: t("releaseYearLabelNote"),
+    accessories: t("accessories"),
+    yes: t("yes"),
+    no: t("no"),
+    partial: t("partial"),
+    retracted: t("lengthRetracted"),
+    wide: t("lengthWide"),
+    tele: t("lengthTele"),
+    lc: {
+      groups: t("lcGroups"),
+      elements: t("lcElements"),
+      aspherical: t("lcAspherical"),
+      ed: t("lcEd"),
+      superEd: t("lcSuperEd"),
+      sld: t("lcSld"),
+      fld: t("lcFld"),
+      highRefractive: t("lcHighRefractive"),
+      incl: t("lcIncl"),
+    },
+    motorClass: {
+      linear: t("motorLinear"),
+      stepping: t("motorStepping"),
+      dc: t("motorDc"),
+      other: t("motorOther"),
+    },
+  };
+}
+
 function joinParts(...parts: (string | undefined)[]): string {
   return parts.filter(Boolean).join("\n");
 }


### PR DESCRIPTION
## What

The lens **detail page** and the **compare table** each assembled an identical ~40-line `SpecGroupLabels` object inline before calling `buildSpecGroups`. This PR extracts that assembly into a `buildSpecGroupLabels(t)` helper and has both call sites use it.

- `spec-groups.ts` — adds `buildSpecGroupLabels(t)` next to the `SpecGroupLabels` interface (the one place that maps translation keys → label fields).
- `[id]/page.tsx`, `CompareTable.tsx` — inline blocks replaced with `buildSpecGroups(buildSpecGroupLabels(t))`.

Net: **−122 / +77**; the two call sites each shed ~60 duplicated lines.

## Why

`buildSpecGroups` deliberately takes **pre-translated strings** (`SpecGroupLabels`), not a translator, so the schema stays unit-testable with plain strings and never hardcodes a translation key. That boundary is good and unchanged — `buildSpecGroupLabels` is the single bridge between the translator and that boundary.

The real smell was that the **assembly** of those strings was duplicated at both call sites. This keeps the decoupling while removing the duplication.

## Notes

- Behavior-preserving: the assembled object is character-identical to both previous inline versions (only `t` vs `td`, both `LensDetail` translators).
- The helper's translator type is a minimal structural `(key) => string`, accepting both `getTranslations` (server, detail) and `useTranslations` (client, compare) — mirroring the existing pattern in `lib/lens/seo.ts`.
- Follow-up (separate PR, out of scope): that minimal translator type is hand-rolled in ~4 places (`seo.ts`, `pricing.ts`, `ShareButton.tsx`, here) — could be DRY'd into one shared `Translator` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)