### PR TITLE
refactor(lens): derive spec-row plainText on demand

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -8,7 +8,7 @@ import { getLensUrl } from "@/lib/lens/lens";
 import { getLensesByMount } from "@/lib/lens/data";
 import { urlSegmentToMount, mountToUrlSegment } from "@/lib/mount";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens/image";
-import { buildSpecGroups, buildSpecGroupLabels, resolveSpecGroups } from "@/lib/lens/spec-groups";
+import { buildSpecGroups, buildSpecGroupLabels, resolveSpecGroups, rowPlainText } from "@/lib/lens/spec-groups";
 import type { ResolvedSpecRow, StructuredLine } from "@/lib/lens/spec-groups";
 import { ExternalLink } from "@/components/ui/external-link";
 import LensDetailCompareToggle from "@/components/compare/LensDetailCompareToggle";
@@ -202,9 +202,9 @@ export default async function LensDetailPage({ params }: { params: Params }) {
     missing: t("missing"),
   };
 
-  // Resolve all row values once. This is the single source of truth for both
-  // the rendered spec table and the Report Dialog's field list.
-  const resolvedGroups = resolveSpecGroups(specGroups, lens, valueCellLabels);
+  // Resolve all row values once (raw data). Both the rendered spec table and
+  // the Report Dialog derive from these resolved rows + valueCellLabels.
+  const resolvedGroups = resolveSpecGroups(specGroups, lens);
 
   // Field options for the Report Dialog — taken directly from resolved values,
   // identical to what is rendered in the spec table below.
@@ -214,7 +214,7 @@ export default async function LensDetailPage({ params }: { params: Params }) {
   const priceSelection = pickPriceEntry(lens.pricing, locale);
   const reportableFields = [
     ...resolvedGroups.flatMap((group) =>
-      group.rows.map((row) => ({ label: row.label, currentValue: row.plainText, group: group.label }))
+      group.rows.map((row) => ({ label: row.label, currentValue: rowPlainText(row, valueCellLabels), group: group.label }))
     ),
     ...(priceSelection
       ? [{ label: tPricing("fieldLabel"), currentValue: formatPriceForReport(priceSelection, locale, tPricing), group: tPricing("groupLabel") }]

--- a/src/components/compare/CompareTable.tsx
+++ b/src/components/compare/CompareTable.tsx
@@ -29,7 +29,7 @@ import { mountToUrlSegment } from "@/lib/mount";
 import { Link } from "@/i18n/navigation";
 import LensSearchDialog from "@/components/browse/LensSearchDialog";
 import { lensImageStyle, getLensImageUrl } from "@/lib/lens/image";
-import { buildSpecGroups, buildSpecGroupLabels, resolveSpecRow } from "@/lib/lens/spec-groups";
+import { buildSpecGroups, buildSpecGroupLabels, resolveSpecRow, rowPlainText } from "@/lib/lens/spec-groups";
 import type { StructuredLine, ResolvedSpecRow } from "@/lib/lens/spec-groups";
 import type { Lens } from "@/lib/types";
 import { PriceCell } from "@/components/price/PriceCell";
@@ -275,7 +275,7 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
       const rowMap = new Map<string, ResolvedSpecRow>();
       for (const group of allGroups) {
         for (const row of group.rows) {
-          const resolved = resolveSpecRow(row, lens, valueCellLabels);
+          const resolved = resolveSpecRow(row, lens);
           if (resolved) {
             rowMap.set(row.label, resolved);
           }
@@ -284,7 +284,7 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
       map.set(lens.id, rowMap);
     }
     return map;
-  }, [allGroups, orderedLenses, valueCellLabels]);
+  }, [allGroups, orderedLenses]);
 
   // Per-view suppression: hide rows where no compared lens has data.
   const visibleGroups = useMemo(
@@ -832,7 +832,7 @@ export default function CompareTable({ lenses: initialLenses, allLenses, minColu
                     .map((row) => {
                       const resolved = resolvedPerLens.get(lens.id)?.get(row.label);
                       return resolved
-                        ? { label: row.label, currentValue: resolved.plainText, group: group.label }
+                        ? { label: row.label, currentValue: rowPlainText(resolved, valueCellLabels), group: group.label }
                         : null;
                     })
                     .filter((f): f is NonNullable<typeof f> => f !== null)

--- a/src/lib/__tests__/lens-spec-groups.test.ts
+++ b/src/lib/__tests__/lens-spec-groups.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSpecGroups, resolveSpecRow } from "@/lib/lens/spec-groups";
+import { buildSpecGroups, resolveSpecRow, rowPlainText } from "@/lib/lens/spec-groups";
 import type { Lens } from "@/lib/types";
 
 const labels = {
@@ -114,12 +114,12 @@ function getRow(label: string) {
   return row!;
 }
 
-describe("resolveSpecRow — plainText", () => {
+describe("rowPlainText", () => {
   it("includes secondary text for bool rows", () => {
     const lens = makeLens({ ois: true, oisStops: 5 });
     const row = getRow("OIS");
 
-    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe("Yes\n5 stops");
+    expect(rowPlainText(resolveSpecRow(row, lens)!, valueLabels)).toBe("Yes\n5 stops");
   });
 
   it("serializes MFD with macro-first logic", () => {
@@ -131,7 +131,7 @@ describe("resolveSpecRow — plainText", () => {
     });
     const row = getRow("Min Focus Distance");
 
-    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe("12cm");
+    expect(rowPlainText(resolveSpecRow(row, lens)!, valueLabels)).toBe("12cm");
   });
 
   it("preserves primary and secondary text rows", () => {
@@ -141,7 +141,7 @@ describe("resolveSpecRow — plainText", () => {
     });
     const row = getRow("Dimensions");
 
-    expect(resolveSpecRow(row, lens, valueLabels)?.plainText).toBe(
+    expect(rowPlainText(resolveSpecRow(row, lens)!, valueLabels)).toBe(
       "⌀65 × 71mm\nRetracted 60mm\nTele 89mm"
     );
   });

--- a/src/lib/lens/spec-groups.ts
+++ b/src/lib/lens/spec-groups.ts
@@ -120,8 +120,6 @@ export interface ResolvedTextRow {
   note?: string;
   displayValue?: string;
   subValue?: string;
-  /** Plain-text representation of the visible cell — single source of truth for the Report Dialog. */
-  plainText: string;
 }
 
 export interface ResolvedNumericRow {
@@ -136,7 +134,6 @@ export interface ResolvedNumericRow {
   comparable?: number;
   bestDir?: "min" | "max";
   highlightFragment?: string;
-  plainText: string;
 }
 
 export interface ResolvedBoolRow {
@@ -147,7 +144,6 @@ export interface ResolvedBoolRow {
   note?: string;
   boolValue: boolean | "partial" | undefined;
   subValue?: string;
-  plainText: string;
 }
 
 export type ResolvedSpecRow = ResolvedTextRow | ResolvedNumericRow | ResolvedBoolRow;
@@ -292,18 +288,16 @@ function joinParts(...parts: (string | undefined)[]): string {
 }
 
 /**
- * Resolves a single spec row for a specific lens, calling all formatter functions
- * exactly once. Returns null when this lens has no data for the row (caller should
- * omit the row from the visible set for this lens).
+ * Resolves a single spec row for a specific lens, calling all formatter
+ * functions exactly once. Returns null when this lens has no data for the row
+ * (caller omits the row from the visible set for this lens).
  *
- * The returned `plainText` field is the single source of truth for the Report
- * Dialog's "current value" — identical to what is rendered in the spec table.
+ * Pure extraction — the resolved row carries only the raw values (boolValue,
+ * displayValue, structuredLines, …). The flat text for the Report Dialog is
+ * derived on demand via `rowPlainText`, so this stays free of display labels
+ * and each surface can map raw values to text its own way.
  */
-export function resolveSpecRow(
-  row: SpecRow,
-  lens: Lens,
-  labels: SpecValueTextLabels
-): ResolvedSpecRow | null {
+export function resolveSpecRow(row: SpecRow, lens: Lens): ResolvedSpecRow | null {
   if (!row.hasData(lens)) {
     return null;
   }
@@ -316,66 +310,42 @@ export function resolveSpecRow(
   const labelNoteVariant = row.labelNoteVariant;
 
   if (row.kind === "bool") {
-    const boolValue = row.getValue(lens);
-    const subValue = row.getSubValue?.(lens);
-    const primaryText =
-      boolValue === true
-        ? labels.yes
-        : boolValue === "partial"
-          ? labels.partial
-          : boolValue === false
-            ? labels.no
-            : labels.unknown;
     return {
       kind: "bool",
       label: row.label,
       labelNote,
       labelNoteVariant,
       note,
-      boolValue,
-      subValue,
-      plainText: joinParts(primaryText, subValue, note && `(${note})`),
+      boolValue: row.getValue(lens),
+      subValue: row.getSubValue?.(lens),
     };
   }
 
   if (row.kind === "numeric") {
-    const structuredLines = row.getStructuredLines?.(lens);
-    const displayValue = row.getDisplayValue(lens);
-    const subValue = row.getSubValue?.(lens);
-    const primary =
-      structuredLines && structuredLines.length > 0
-        ? structuredLines
-            .map((l) => (l.label ? `${l.value} (${l.label})` : l.value))
-            .join("\n")
-        : (displayValue ?? labels.missing);
     return {
       kind: "numeric",
       label: row.label,
       labelNote,
       labelNoteVariant,
       note,
-      displayValue,
-      subValue,
-      structuredLines,
+      displayValue: row.getDisplayValue(lens),
+      subValue: row.getSubValue?.(lens),
+      structuredLines: row.getStructuredLines?.(lens),
       comparable: row.toComparable(lens),
       bestDir: row.bestDir,
       highlightFragment: row.getHighlightFragment?.(lens),
-      plainText: joinParts(primary, subValue, note && `(${note})`),
     };
   }
 
   // text
-  const displayValue = row.getDisplayValue(lens);
-  const subValue = row.getSubValue?.(lens);
   return {
     kind: "text",
     label: row.label,
     labelNote,
     labelNoteVariant,
     note,
-    displayValue,
-    subValue,
-    plainText: joinParts(displayValue ?? labels.missing, subValue, note && `(${note})`),
+    displayValue: row.getDisplayValue(lens),
+    subValue: row.getSubValue?.(lens),
   };
 }
 
@@ -383,19 +353,49 @@ export function resolveSpecRow(
  * Resolves all spec groups for a single lens, filtering out rows and groups
  * where the lens has no data. Use on the detail page or any single-lens view.
  */
-export function resolveSpecGroups(
-  groups: SpecGroup[],
-  lens: Lens,
-  labels: SpecValueTextLabels
-): ResolvedSpecGroup[] {
+export function resolveSpecGroups(groups: SpecGroup[], lens: Lens): ResolvedSpecGroup[] {
   return groups
     .map((group) => ({
       label: group.label,
       rows: group.rows
-        .map((row) => resolveSpecRow(row, lens, labels))
+        .map((row) => resolveSpecRow(row, lens))
         .filter((r): r is ResolvedSpecRow => r !== null),
     }))
     .filter((group) => group.rows.length > 0);
+}
+
+/**
+ * Flat-text representation of a resolved row — the single source of truth for
+ * the Report Dialog's "current value". Derived from the already-resolved row
+ * plus the display labels, so it stays in step with the spec table (which
+ * renders the same resolved values). Kept out of `resolveSpecRow` so resolution
+ * is pure data and labels live only at the presentation boundary.
+ */
+export function rowPlainText(row: ResolvedSpecRow, labels: SpecValueTextLabels): string {
+  if (row.kind === "bool") {
+    const primaryText =
+      row.boolValue === true
+        ? labels.yes
+        : row.boolValue === "partial"
+          ? labels.partial
+          : row.boolValue === false
+            ? labels.no
+            : labels.unknown;
+    return joinParts(primaryText, row.subValue, row.note && `(${row.note})`);
+  }
+
+  if (row.kind === "numeric") {
+    const primary =
+      row.structuredLines && row.structuredLines.length > 0
+        ? row.structuredLines
+            .map((l) => (l.label ? `${l.value} (${l.label})` : l.value))
+            .join("\n")
+        : (row.displayValue ?? labels.missing);
+    return joinParts(primary, row.subValue, row.note && `(${row.note})`);
+  }
+
+  // text
+  return joinParts(row.displayValue ?? labels.missing, row.subValue, row.note && `(${row.note})`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`resolveSpecRow` previously took the display labels and **baked a `plainText` string into every resolved row** (the Report Dialog's "current value"). That made resolution do double duty — data extraction **and** display-string building — and created a parallel derivation: `plainText` (built at resolve) and the visible cell (built at render) had to stay in sync by convention.

Now:
- `resolveSpecRow(row, lens)` / `resolveSpecGroups(groups, lens)` are **pure data extraction** — no labels, no `plainText` on the resolved row.
- A new `rowPlainText(row, labels)` derives the flat report text from an already-resolved row, called only by the two Report Dialog field builders (detail page, compare table).

Why correct: the visible cells already map raw values → labels **per surface** at render time (e.g. `boolValue === undefined` shows "unknown" on detail but "—" on compare), so labels belong at the presentation boundary, not in the shared resolve.

## Verification
- `lens-spec-groups.test.ts` updated to assert via `rowPlainText` — 3/3 pass.
- eslint clean (also tightened the `resolvedPerLens` useMemo deps, which no longer depend on the labels); tsc: no errors in changed files.

(Collections refactors that were originally bundled here are now in #395.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)