### PR TITLE
refactor(collections): split predicates into collection-filters; tidy + harden slug integrity

### DIFF
--- a/src/lib/collection-filters.ts
+++ b/src/lib/collection-filters.ts
@@ -1,0 +1,218 @@
+import { isZoom } from "@/lib/lens/lens";
+import { pickNewEntry } from "@/lib/lens/pricing";
+import type { Lens } from "@/lib/types";
+
+// A collection membership predicate. Locale matters because some collections
+// (e.g. price bands) read region-specific pricing.
+export type LensFilter = (lens: Lens, locale: string) => boolean;
+
+function xMount(lens: Lens): boolean {
+  return lens.mount === "X";
+}
+
+function xPhoto(lens: Lens): boolean {
+  return xMount(lens) && !lens.isCine;
+}
+
+// Specialty optics deliver a non-standard projection (fisheye) or workflow
+// (macro, tilt/shift) and have their own dedicated collections. They are
+// excluded from general-purpose framing collections so a fisheye never
+// surfaces as an everyday "pancake" or a rectilinear wide-angle option.
+const SPECIAL_OPTICS = ["fisheye", "macro", "tilt", "shift"];
+function isSpecialOptic(lens: Lens): boolean {
+  return lens.opticalTraits?.some((t) => SPECIAL_OPTICS.includes(t)) ?? false;
+}
+
+function xPrime(focalMin: number, focalMax: number): LensFilter {
+  return (lens) =>
+    xPhoto(lens) &&
+    !isZoom(lens) &&
+    lens.focalLengthMin >= focalMin &&
+    lens.focalLengthMin <= focalMax;
+}
+
+function xBrand(brand: string): LensFilter {
+  return (lens) => xPhoto(lens) && lens.brand === brand;
+}
+
+// Chinese lens brands grouped under their own category. Extend this list as
+// more Chinese makers (AstrHori, …) get added to the dataset.
+const CHINESE_BRANDS = ["viltrox", "7artisans", "ttartisan", "brightinstar", "sgimage", "laowa", "meike", "sirui"];
+
+export const FILTERS = {
+  // --- Prime ---
+  "23mm": xPrime(22, 24),
+  "35mm": xPrime(33, 36),
+  "50mm": xPrime(48, 51),
+  "56mm": xPrime(55, 58),
+  "85mm": xPrime(83, 90),
+  "wide-angle-primes": (lens) =>
+    xPhoto(lens) && !isZoom(lens) && !isSpecialOptic(lens) && lens.focalLengthMin <= 18,
+
+  // --- Zoom ---
+  "wide-zoom": (lens) =>
+    xPhoto(lens) && isZoom(lens) && !isSpecialOptic(lens) && lens.focalLengthMin <= 12,
+
+  "standard-zoom": (lens) =>
+    xPhoto(lens) &&
+    isZoom(lens) &&
+    lens.focalLengthMin >= 13 &&
+    lens.focalLengthMin <= 20 &&
+    lens.focalLengthMax >= 40 &&
+    lens.focalLengthMax <= 60,
+
+  "travel-zoom": (lens) =>
+    xPhoto(lens) &&
+    isZoom(lens) &&
+    lens.focalLengthMin <= 20 &&
+    (lens.focalLengthMax / lens.focalLengthMin >= 4 || lens.focalLengthMax >= 120),
+
+  "tele-zoom": (lens) =>
+    xPhoto(lens) && isZoom(lens) && lens.focalLengthMin >= 50,
+
+  "super-tele": (lens) =>
+    xPhoto(lens) &&
+    (isZoom(lens) ? lens.focalLengthMax >= 300 : lens.focalLengthMin >= 200),
+
+  // --- Brand ---
+  fujifilm: (lens) => xPhoto(lens) && lens.brand === "fujifilm",
+  "7artisans": xBrand("7artisans"),
+  viltrox: (lens) => xPhoto(lens) && lens.brand === "viltrox" && lens.af === true,
+  ttartisan: xBrand("ttartisan"),
+  sigma: xBrand("sigma"),
+  brightinstar: xBrand("brightinstar"),
+  voigtlander: xBrand("voigtlander"),
+  laowa: xBrand("laowa"),
+  tamron: xBrand("tamron"),
+  sgimage: xBrand("sgimage"),
+
+  // --- Series ---
+  "fujifilm-xf": (lens) =>
+    xPhoto(lens) && lens.brand === "fujifilm" && lens.series === "XF",
+  "fujifilm-xc": (lens) =>
+    xPhoto(lens) && lens.brand === "fujifilm" && lens.series === "XC",
+  "sigma-contemporary": (lens) =>
+    xPhoto(lens) && lens.brand === "sigma" && lens.series === "Contemporary",
+  "viltrox-air": (lens) =>
+    xPhoto(lens) && lens.brand === "viltrox" && lens.series === "Air",
+  "viltrox-pro": (lens) =>
+    xPhoto(lens) && lens.brand === "viltrox" && lens.series === "Pro",
+  "voigtlander-nokton": (lens) =>
+    xPhoto(lens) && lens.brand === "voigtlander" && lens.series === "Nokton",
+
+  // --- Price ---
+  "under-200": (lens, locale) => {
+    if (locale === "zh") {
+      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
+      return xPhoto(lens) && p != null && p < 1000;
+    }
+    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
+    return xPhoto(lens) && p != null && p < 200;
+  },
+
+  "under-400": (lens, locale) => {
+    if (locale === "zh") {
+      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
+      return xPhoto(lens) && p != null && p < 2000;
+    }
+    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
+    return xPhoto(lens) && p != null && p < 400;
+  },
+
+  // --- Portability ---
+  "under-200g": (lens) => {
+    if (!xPhoto(lens)) {
+      return false;
+    }
+    const w = Array.isArray(lens.weightG) ? lens.weightG[1] : lens.weightG;
+    return w != null && w < 200;
+  },
+
+  "pancake": (lens) =>
+    xPhoto(lens) &&
+    !isZoom(lens) &&
+    !isSpecialOptic(lens) &&
+    lens.length?.mm != null &&
+    lens.length.mm <= 35,
+
+  // --- Aperture ---
+  "fast-aperture-primes": (lens) => {
+    if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
+      return false;
+    }
+    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
+    return ap <= 1.4;
+  },
+
+  "constant-aperture": (lens) =>
+    xPhoto(lens) &&
+    isZoom(lens) &&
+    lens.maxAperture != null &&
+    !Array.isArray(lens.maxAperture),
+
+  // --- Trait ---
+  "weather-sealed": (lens) =>
+    xPhoto(lens) && (lens.wr === true || lens.wr === "partial"),
+
+  "with-ois": (lens) => xPhoto(lens) && lens.ois === true,
+
+  // --- Dedicated ---
+  cine: (lens) => xMount(lens) && lens.isCine === true,
+
+  fisheye: (lens) =>
+    xPhoto(lens) && !!lens.opticalTraits?.includes("fisheye"),
+
+  "tilt-shift": (lens) =>
+    xPhoto(lens) &&
+    (!!lens.opticalTraits?.includes("tilt") || !!lens.opticalTraits?.includes("shift")),
+
+  macro: (lens) =>
+    xPhoto(lens) && !!lens.opticalTraits?.includes("macro"),
+
+  // --- Chinese brands ---
+  // A broad "all manual glass" bucket isn't a real shopping intent, so the
+  // manual side is split into sharp character/value collections instead.
+  // Specialty optics are excluded here — they live in the Dedicated section.
+  "chinese-af": (lens) =>
+    xPhoto(lens) &&
+    !isZoom(lens) &&
+    !isSpecialOptic(lens) &&
+    CHINESE_BRANDS.includes(lens.brand) &&
+    lens.af === true,
+  "chinese-mf-fast": (lens) => {
+    if (!xPhoto(lens) || isZoom(lens) || isSpecialOptic(lens) || lens.maxAperture == null) {
+      return false;
+    }
+    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
+    return CHINESE_BRANDS.includes(lens.brand) && lens.af === false && ap > 0.95 && ap <= 1.4;
+  },
+  "chinese-mf-budget": (lens, locale) => {
+    if (
+      !xPhoto(lens) ||
+      isZoom(lens) ||
+      isSpecialOptic(lens) ||
+      lens.af !== false ||
+      !CHINESE_BRANDS.includes(lens.brand)
+    ) {
+      return false;
+    }
+    if (locale === "zh") {
+      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
+      return p != null && p < 500;
+    }
+    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
+    return p != null && p < 100;
+  },
+  "chinese-mf-095": (lens) => {
+    if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
+      return false;
+    }
+    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
+    return CHINESE_BRANDS.includes(lens.brand) && ap <= 0.95;
+  },
+} satisfies Record<string, LensFilter>;
+
+// Valid collection slugs, derived from FILTERS so the slug set lives in exactly
+// one place. Anything in code that names a slug (the *_SLUGS lists in collections.ts) is
+// typed against this, so a typo becomes a compile error.
+export type CollectionSlug = keyof typeof FILTERS;

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,9 +1,6 @@
 import collectionsData from "@/data/collections.json";
-import { isZoom } from "@/lib/lens/lens";
-import { pickNewEntry } from "@/lib/lens/pricing";
+import { FILTERS, type LensFilter, type CollectionSlug } from "@/lib/collection-filters";
 import type { Lens } from "@/lib/types";
-
-type LensFilter = (lens: Lens, locale: string) => boolean;
 
 export interface LensCollection {
   slug: string;
@@ -13,234 +10,40 @@ export interface LensCollection {
   filter: LensFilter;
 }
 
-function xMount(lens: Lens): boolean {
-  return lens.mount === "X";
-}
-
-function xPhoto(lens: Lens): boolean {
-  return xMount(lens) && !lens.isCine;
-}
-
-// Specialty optics deliver a non-standard projection (fisheye) or workflow
-// (macro, tilt/shift) and have their own dedicated collections. They are
-// excluded from general-purpose framing collections so a fisheye never
-// surfaces as an everyday "pancake" or a rectilinear wide-angle option.
-const SPECIAL_OPTICS = ["fisheye", "macro", "tilt", "shift"];
-function isSpecialOptic(lens: Lens): boolean {
-  return lens.opticalTraits?.some((t) => SPECIAL_OPTICS.includes(t)) ?? false;
-}
-
-function xPrime(focalMin: number, focalMax: number): LensFilter {
-  return (lens) =>
-    xPhoto(lens) &&
-    !isZoom(lens) &&
-    lens.focalLengthMin >= focalMin &&
-    lens.focalLengthMin <= focalMax;
-}
-
-function xBrand(brand: string): LensFilter {
-  return (lens) => xPhoto(lens) && lens.brand === brand;
-}
-
-// Chinese lens brands grouped under their own category. Extend this list as
-// more Chinese makers (AstrHori, …) get added to the dataset.
-const CHINESE_BRANDS = ["viltrox", "7artisans", "ttartisan", "brightinstar", "sgimage", "laowa", "meike", "sirui"];
-
-const FILTERS: Record<string, LensFilter> = {
-  // --- Prime ---
-  "23mm": xPrime(22, 24),
-  "35mm": xPrime(33, 36),
-  "50mm": xPrime(48, 51),
-  "56mm": xPrime(55, 58),
-  "85mm": xPrime(83, 90),
-  "wide-angle-primes": (lens) =>
-    xPhoto(lens) && !isZoom(lens) && !isSpecialOptic(lens) && lens.focalLengthMin <= 18,
-
-  // --- Zoom ---
-  "wide-zoom": (lens) =>
-    xPhoto(lens) && isZoom(lens) && !isSpecialOptic(lens) && lens.focalLengthMin <= 12,
-
-  "standard-zoom": (lens) =>
-    xPhoto(lens) &&
-    isZoom(lens) &&
-    lens.focalLengthMin >= 13 &&
-    lens.focalLengthMin <= 20 &&
-    lens.focalLengthMax >= 40 &&
-    lens.focalLengthMax <= 60,
-
-  "travel-zoom": (lens) =>
-    xPhoto(lens) &&
-    isZoom(lens) &&
-    lens.focalLengthMin <= 20 &&
-    (lens.focalLengthMax / lens.focalLengthMin >= 4 || lens.focalLengthMax >= 120),
-
-  "tele-zoom": (lens) =>
-    xPhoto(lens) && isZoom(lens) && lens.focalLengthMin >= 50,
-
-  "super-tele": (lens) =>
-    xPhoto(lens) &&
-    (isZoom(lens) ? lens.focalLengthMax >= 300 : lens.focalLengthMin >= 200),
-
-  // --- Brand ---
-  fujifilm: (lens) => xPhoto(lens) && lens.brand === "fujifilm",
-  "7artisans": xBrand("7artisans"),
-  viltrox: (lens) => xPhoto(lens) && lens.brand === "viltrox" && lens.af === true,
-  ttartisan: xBrand("ttartisan"),
-  sigma: xBrand("sigma"),
-  brightinstar: xBrand("brightinstar"),
-  voigtlander: xBrand("voigtlander"),
-  laowa: xBrand("laowa"),
-  tamron: xBrand("tamron"),
-  sgimage: xBrand("sgimage"),
-
-  // --- Series ---
-  "fujifilm-xf": (lens) =>
-    xPhoto(lens) && lens.brand === "fujifilm" && lens.series === "XF",
-  "fujifilm-xc": (lens) =>
-    xPhoto(lens) && lens.brand === "fujifilm" && lens.series === "XC",
-  "sigma-contemporary": (lens) =>
-    xPhoto(lens) && lens.brand === "sigma" && lens.series === "Contemporary",
-  "viltrox-air": (lens) =>
-    xPhoto(lens) && lens.brand === "viltrox" && lens.series === "Air",
-  "viltrox-pro": (lens) =>
-    xPhoto(lens) && lens.brand === "viltrox" && lens.series === "Pro",
-  "voigtlander-nokton": (lens) =>
-    xPhoto(lens) && lens.brand === "voigtlander" && lens.series === "Nokton",
-
-  // --- Price ---
-  "under-200": (lens, locale) => {
-    if (locale === "zh") {
-      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
-      return xPhoto(lens) && p != null && p < 1000;
-    }
-    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
-    return xPhoto(lens) && p != null && p < 200;
-  },
-
-  "under-400": (lens, locale) => {
-    if (locale === "zh") {
-      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
-      return xPhoto(lens) && p != null && p < 2000;
-    }
-    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
-    return xPhoto(lens) && p != null && p < 400;
-  },
-
-  // --- Portability ---
-  "under-200g": (lens) => {
-    if (!xPhoto(lens)) {
-      return false;
-    }
-    const w = Array.isArray(lens.weightG) ? lens.weightG[1] : lens.weightG;
-    return w != null && w < 200;
-  },
-
-  "pancake": (lens) =>
-    xPhoto(lens) &&
-    !isZoom(lens) &&
-    !isSpecialOptic(lens) &&
-    lens.length?.mm != null &&
-    lens.length.mm <= 35,
-
-  // --- Aperture ---
-  "fast-aperture-primes": (lens) => {
-    if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
-      return false;
-    }
-    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
-    return ap <= 1.4;
-  },
-
-  "constant-aperture": (lens) =>
-    xPhoto(lens) &&
-    isZoom(lens) &&
-    lens.maxAperture != null &&
-    !Array.isArray(lens.maxAperture),
-
-  // --- Trait ---
-  "weather-sealed": (lens) =>
-    xPhoto(lens) && (lens.wr === true || lens.wr === "partial"),
-
-  "with-ois": (lens) => xPhoto(lens) && lens.ois === true,
-
-  // --- Dedicated ---
-  cine: (lens) => xMount(lens) && lens.isCine === true,
-
-  fisheye: (lens) =>
-    xPhoto(lens) && !!lens.opticalTraits?.includes("fisheye"),
-
-  "tilt-shift": (lens) =>
-    xPhoto(lens) &&
-    (!!lens.opticalTraits?.includes("tilt") || !!lens.opticalTraits?.includes("shift")),
-
-  macro: (lens) =>
-    xPhoto(lens) && !!lens.opticalTraits?.includes("macro"),
-
-  // --- Chinese brands ---
-  // A broad "all manual glass" bucket isn't a real shopping intent, so the
-  // manual side is split into sharp character/value collections instead.
-  // Specialty optics are excluded here — they live in the Dedicated section.
-  "chinese-af": (lens) =>
-    xPhoto(lens) &&
-    !isZoom(lens) &&
-    !isSpecialOptic(lens) &&
-    CHINESE_BRANDS.includes(lens.brand) &&
-    lens.af === true,
-  "chinese-mf-fast": (lens) => {
-    if (!xPhoto(lens) || isZoom(lens) || isSpecialOptic(lens) || lens.maxAperture == null) {
-      return false;
-    }
-    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
-    return CHINESE_BRANDS.includes(lens.brand) && lens.af === false && ap > 0.95 && ap <= 1.4;
-  },
-  "chinese-mf-budget": (lens, locale) => {
-    if (
-      !xPhoto(lens) ||
-      isZoom(lens) ||
-      isSpecialOptic(lens) ||
-      lens.af !== false ||
-      !CHINESE_BRANDS.includes(lens.brand)
-    ) {
-      return false;
-    }
-    if (locale === "zh") {
-      const p = pickNewEntry(lens.pricing?.cn?.new)?.price;
-      return p != null && p < 500;
-    }
-    const p = pickNewEntry(lens.pricing?.global?.new)?.price;
-    return p != null && p < 100;
-  },
-  "chinese-mf-095": (lens) => {
-    if (!xPhoto(lens) || isZoom(lens) || lens.maxAperture == null) {
-      return false;
-    }
-    const ap = Array.isArray(lens.maxAperture) ? lens.maxAperture[0] : lens.maxAperture;
-    return CHINESE_BRANDS.includes(lens.brand) && ap <= 0.95;
-  },
-};
-
+// Join JSON metadata with the code-side predicates by slug, validated BOTH ways
+// at module load so the two files can never silently drift.
 const parsed: LensCollection[] = collectionsData.collections.map((entry) => {
-  const filter = FILTERS[entry.slug];
+  // Forward: a collections.json entry must have a predicate.
+  const filter = (FILTERS as Record<string, LensFilter | undefined>)[entry.slug];
   if (!filter) {
-    throw new Error(`No filter defined for collection "${entry.slug}"`);
+    throw new Error(`collections.json: "${entry.slug}" has no predicate in FILTERS`);
   }
   return { slug: entry.slug, title: entry.title, description: entry.description, shortDescription: entry.shortDescription, filter };
 });
+
+// Reverse: every predicate must have JSON metadata (catches a dead FILTERS entry
+// that would otherwise go unnoticed).
+const metaSlugs = new Set(collectionsData.collections.map((c) => c.slug));
+for (const slug of Object.keys(FILTERS)) {
+  if (!metaSlugs.has(slug)) {
+    throw new Error(`FILTERS: "${slug}" has no entry in collections.json`);
+  }
+}
 
 export const COLLECTIONS: Record<string, LensCollection> = Object.fromEntries(
   parsed.map((c) => [c.slug, c]),
 );
 
-export const PRIME_SLUGS = ["23mm", "35mm", "50mm", "56mm", "85mm", "wide-angle-primes"];
-export const ZOOM_SLUGS = ["wide-zoom", "standard-zoom", "travel-zoom", "tele-zoom"];
-export const BRAND_SLUGS = ["fujifilm", "7artisans", "viltrox", "ttartisan", "sigma", "brightinstar", "voigtlander", "laowa", "tamron", "sgimage"];
-export const SERIES_SLUGS = ["fujifilm-xf", "fujifilm-xc", "sigma-contemporary", "viltrox-air", "viltrox-pro", "voigtlander-nokton"];
-export const PRICE_SLUGS = ["under-200", "under-400"];
-export const PORTABILITY_SLUGS = ["under-200g", "pancake"];
-export const APERTURE_SLUGS = ["fast-aperture-primes", "constant-aperture"];
-export const TRAIT_SLUGS = ["weather-sealed", "with-ois", "super-tele"];
-export const DEDICATED_SLUGS = ["cine", "fisheye", "tilt-shift", "macro"];
-export const CHINESE_SLUGS = ["chinese-af", "chinese-mf-fast", "chinese-mf-095", "chinese-mf-budget"];
+export const PRIME_SLUGS: CollectionSlug[] = ["23mm", "35mm", "50mm", "56mm", "85mm", "wide-angle-primes"];
+export const ZOOM_SLUGS: CollectionSlug[] = ["wide-zoom", "standard-zoom", "travel-zoom", "tele-zoom"];
+export const BRAND_SLUGS: CollectionSlug[] = ["fujifilm", "7artisans", "viltrox", "ttartisan", "sigma", "brightinstar", "voigtlander", "laowa", "tamron", "sgimage"];
+export const SERIES_SLUGS: CollectionSlug[] = ["fujifilm-xf", "fujifilm-xc", "sigma-contemporary", "viltrox-air", "viltrox-pro", "voigtlander-nokton"];
+export const PRICE_SLUGS: CollectionSlug[] = ["under-200", "under-400"];
+export const PORTABILITY_SLUGS: CollectionSlug[] = ["under-200g", "pancake"];
+export const APERTURE_SLUGS: CollectionSlug[] = ["fast-aperture-primes", "constant-aperture"];
+export const TRAIT_SLUGS: CollectionSlug[] = ["weather-sealed", "with-ois", "super-tele"];
+export const DEDICATED_SLUGS: CollectionSlug[] = ["cine", "fisheye", "tilt-shift", "macro"];
+export const CHINESE_SLUGS: CollectionSlug[] = ["chinese-af", "chinese-mf-fast", "chinese-mf-095", "chinese-mf-budget"];
 
 export function getRelatedCollections(
   slug: string,

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -338,19 +338,38 @@ export interface MemberCollectionInfo {
   lensCount: number;
 }
 
+// Attaches `lensCount` (how many lenses in the whole catalog match this
+// collection) to a collection, producing the shape the UI lists need.
+function withLensCount(
+  collection: LensCollection,
+  allLenses: Lens[],
+  locale: string,
+): MemberCollectionInfo {
+  return {
+    ...collection,
+    lensCount: allLenses.filter((lens) => collection.filter(lens, locale)).length,
+  };
+}
+
+/**
+ * Collections a single lens belongs to — i.e. whose predicate matches the lens.
+ * Used on the lens detail page ("this lens appears in …").
+ */
 export function getMemberCollections(
   lens: Lens,
   allLenses: Lens[],
   locale: string,
 ): MemberCollectionInfo[] {
   return Object.values(COLLECTIONS)
-    .filter((c) => c.filter(lens, locale))
-    .map((c) => ({
-      ...c,
-      lensCount: allLenses.filter((l) => c.filter(l, locale)).length,
-    }));
+    .filter((collection) => collection.filter(lens, locale))
+    .map((collection) => withLensCount(collection, allLenses, locale));
 }
 
+/**
+ * Collections shared by ALL of the given lenses — i.e. whose predicate matches
+ * every lens. Used on the compare page. Degenerate cases: zero lenses → none;
+ * one lens → just that lens's member collections.
+ */
 export function getSharedCollections(
   lenses: Lens[],
   allLenses: Lens[],
@@ -363,9 +382,6 @@ export function getSharedCollections(
     return getMemberCollections(lenses[0], allLenses, locale);
   }
   return Object.values(COLLECTIONS)
-    .filter((c) => lenses.every((lens) => c.filter(lens, locale)))
-    .map((c) => ({
-      ...c,
-      lensCount: allLenses.filter((l) => c.filter(l, locale)).length,
-    }));
+    .filter((collection) => lenses.every((lens) => collection.filter(lens, locale)))
+    .map((collection) => withLensCount(collection, allLenses, locale));
 }


### PR DESCRIPTION
Collections-only refactors (was bundled in #394, split out per review hygiene).

## Changes

- **`withLensCount` helper** + doc comments clarifying **member** (one lens's collections — detail page) vs **shared** (collections all lenses share — compare page).
- **Predicate registry moved to a new `collection-filters.ts`**, leaving `collections.ts` as the join + validation + query API (≈400 → ≈190 lines).
- **`CollectionSlug` union** derived from `FILTERS` (`keyof typeof`, via `satisfies`); the `*_SLUGS` grouping lists are typed against it → a slug typo in code is now a compile error.
- **Bidirectional json↔predicate validation** at module load: a json entry with no predicate, or a predicate with no json entry, throws — so the two files can never silently drift.

Why collections keep a code predicate (not a static id list like `curated-presets.json`): membership is **dynamic** — any matching lens, including future ones, auto-joins. The predicate is the leverage.

## Verification

- `collections.test.ts` unchanged and green — **41/41 pass**.
- eslint clean; tsc: no errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)