### PR TITLE
refactor: idiomatic static params + lock [id]/[slug] to dynamicParams=false

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -3,7 +3,6 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Flag } from "lucide-react";
-import { routing } from "@/i18n/routing";
 import { getLensUrl } from "@/lib/lens/lens";
 import { getLensesByMount } from "@/lib/lens/data";
 import { urlSegmentToMount, mountToUrlSegment } from "@/lib/mount";
@@ -36,18 +35,17 @@ import { PriceSection } from "@/components/price/PriceSection";
 
 type Params = Promise<{ locale: string; mount: string; id: string }>;
 
-// Pre-render every (locale × mount × lens id) combination at build time so the
-// detail page is served as a static HTML asset with zero per-request CPU cost.
-// Lens IDs are language-agnostic — fetching the catalog in the default locale
-// to enumerate IDs is sufficient.
-export function generateStaticParams() {
-  const xLensIds = getLensesByMount("X", routing.defaultLocale).map((l) => l.id);
-  const gLensIds = getLensesByMount("G", routing.defaultLocale).map((l) => l.id);
+// Pre-render every lens id for the (locale × mount) combinations the parent
+// [locale] and [mount] segments supply, so each detail page is a static HTML
+// asset with zero per-request CPU. Lens IDs are language-agnostic, so the
+// catalog read here only enumerates ids — this page returns just { id }.
+export function generateStaticParams({ params }: { params: { locale: string; mount: string } }) {
+  const resolvedMount = urlSegmentToMount(params.mount);
+  if (!resolvedMount) {
+    return [];
+  }
 
-  return routing.locales.flatMap((locale) => [
-    ...xLensIds.map((id) => ({ locale, mount: "x", id })),
-    ...gLensIds.map((id) => ({ locale, mount: "gfx", id })),
-  ]);
+  return getLensesByMount(resolvedMount, params.locale).map((lens) => ({ id: lens.id }));
 }
 
 export async function generateMetadata({

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -48,6 +48,12 @@ export function generateStaticParams({ params }: { params: { locale: string; mou
   return getLensesByMount(resolvedMount, params.locale).map((lens) => ({ id: lens.id }));
 }
 
+// The lens catalog is a closed set, fully enumerated above. An id outside it can
+// only be a stale link or a probe, so serve a static 404 instead of spending an
+// on-demand render that would just fall through to notFound(). (The default,
+// dynamicParams: true, would render unknown ids at request time.)
+export const dynamicParams = false;
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -25,6 +25,11 @@ export function generateStaticParams() {
   return Object.keys(COLLECTIONS).map((slug) => ({ slug }));
 }
 
+// Collection slugs are a closed set (COLLECTIONS), so an unknown slug gets a
+// static 404 rather than an on-demand render that only falls through to
+// notFound(). Mirrors the [id] detail page.
+export const dynamicParams = false;
+
 function localized(field: { en: string; zh: string }, locale: string): string {
   return locale === "zh" ? field.zh : field.en;
 }


### PR DESCRIPTION
## 1. Idiomatic `generateStaticParams` for `[id]`

The lens detail page's `generateStaticParams` was the only one re-enumerating ancestor segments itself — it returned the full `{ locale, mount, id }` for every combination (and relied on Next.js deduping the redundant re-emission). Its sibling `collections/[slug]/page.tsx` already does the idiomatic thing: return only its own segment and let the parent layouts supply the rest.

This aligns `[id]` with that pattern:

```ts
export function generateStaticParams({ params }: { params: { locale: string; mount: string } }) {
  const resolvedMount = urlSegmentToMount(params.mount);
  if (!resolvedMount) return [];
  return getLensesByMount(resolvedMount, params.locale).map((lens) => ({ id: lens.id }));
}
```

- Reads `mount` / `locale` from the parent params instead of hardcoding `"x"`/`"gfx"` and flat-mapping over `routing.locales`.
- Returns only `{ id }` — the `[locale]` and `[mount]` layouts already generate those dimensions, so Next composes them.
- Same set of statically generated pages; no redundant full-set re-emission, no reliance on dedup.
- Drops the now-unused `routing` import.

## 2. Lock `[id]` / `[slug]` to a static 404

Both segments enumerate a **closed catalog** in `generateStaticParams` (lens ids, collection slugs), so a param outside that set can only be a stale link or a probe. Under the default `dynamicParams: true`, such a request is rendered on demand only to fall through to `notFound()` — a wasted server render. Setting `dynamicParams = false` returns a static 404 with zero per-request work.

```ts
export const dynamicParams = false;
```

- The in-page `notFound()` guards stay: they still narrow the `Lens | undefined` lookup (`Array.find` is always `| undefined`, and the routing-level guarantee is invisible to the type checker). Their runtime "404 the unknown id" role is now redundant; their type-narrowing role is not.
- Only the two leaf pages are locked. `[locale]` / `[mount]` are left on the default — adding `dynamicParams = false` cascades down the tree and **cannot be overridden back to `true` by a child** ([next.js#42940](https://github.com/vercel/next.js/issues/42940)), so per-leaf is the non-spooky choice.

**Verification** — `prerender-manifest.json` after build: both routes flip `fallback: null -> false` and move from `dynamicRoutes` into the fully-static `routes` set. `next build` passes (`447 routes prerendered, 2 intentionally dynamic`). eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)