### PR TITLE
fix(routing): drop dynamicParams=false on [id]/[slug] — fixes total 404 on Cloudflare

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -48,11 +48,16 @@ export function generateStaticParams({ params }: { params: { locale: string; mou
   return getLensesByMount(resolvedMount, params.locale).map((lens) => ({ id: lens.id }));
 }
 
-// The lens catalog is a closed set, fully enumerated above. An id outside it can
-// only be a stale link or a probe, so serve a static 404 instead of spending an
-// on-demand render that would just fall through to notFound(). (The default,
-// dynamicParams: true, would render unknown ids at request time.)
-export const dynamicParams = false;
+// dynamicParams is left at its default (true) ON PURPOSE — do NOT set it to
+// false here. Every valid id is prerendered above, and an unknown id falls
+// through to notFound() below, so the user-visible behavior is identical either
+// way. But `dynamicParams = false` emits `fallback: false` for this route in the
+// prerender manifest, and our deploy target (Cloudflare Workers via OpenNext)
+// 404s EVERY request to such a route — even the prerendered ids whose HTML is
+// sitting in the cache. `next start` serves them fine, which is what makes the
+// regression invisible locally. Keeping the default makes the route `fallback:
+// null` (served from cache for known ids, on-demand → notFound() for unknown).
+// See PR #397, which set this to false and took the whole detail page down.
 
 export async function generateMetadata({
   params,

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -25,10 +25,14 @@ export function generateStaticParams() {
   return Object.keys(COLLECTIONS).map((slug) => ({ slug }));
 }
 
-// Collection slugs are a closed set (COLLECTIONS), so an unknown slug gets a
-// static 404 rather than an on-demand render that only falls through to
-// notFound(). Mirrors the [id] detail page.
-export const dynamicParams = false;
+// dynamicParams is left at its default (true) ON PURPOSE — do NOT set it to
+// false here. Every collection slug is prerendered above and an unknown slug
+// falls through to notFound() below, so behavior is identical either way. But
+// `dynamicParams = false` emits `fallback: false` for this route, and our deploy
+// target (Cloudflare Workers via OpenNext) 404s EVERY request to such a route —
+// including the prerendered slugs whose HTML is already cached. `next start`
+// hides this, which is why PR #397 (which set this to false) shipped a total
+// 404 of every collection detail page. See the matching note on the [id] page.
 
 function localized(field: { en: string; zh: string }, locale: string): string {
   return locale === "zh" ? field.zh : field.en;


### PR DESCRIPTION
## Problem

Every **lens detail** page (`/lenses/x/[id]`) and every **collection detail** page (`/lenses/x/collections/[slug]`) returns **404 in production**.

## Root cause

PR #397 added `export const dynamicParams = false` to both the `[id]` and `[slug]` pages. On our deploy target — **Cloudflare Workers via OpenNext** — that flag emits `fallback: false` for the route in `prerender-manifest.json`, and the Worker then **404s every request to such a route**, including the prerendered ids/slugs whose HTML is already sitting in the cache.

The prerendered content is fine; the Worker just never serves it.

### Why it slipped through

`next build` prerenders everything correctly, and `next start` serves all these routes with **200**. The regression only manifests on the actual Cloudflare Worker (`fallback: false` handling), so local/CI build checks couldn't catch it.

### Reproduction (local Worker via `wrangler dev` on the OpenNext bundle)

| Route | `dynamicParams` | Worker |
|---|---|---|
| `/en/lenses/x/browse` | default | 200 |
| `/en/lenses/x/collections` | default | 200 |
| `/en/lenses/x/collections/under-200g` | `false` (#397) | **404** |
| `/en/lenses/x/7artisans-4mm-f28-x` | `false` (#397) | **404** |

The only difference between the working and broken routes is `dynamicParams = false`.

## Fix

Remove `dynamicParams = false` from both pages, reverting that part of #397. The route goes back to `fallback: null`, which OpenNext serves correctly (same as the working `/browse` and `/collections` routes).

This is **behavior-neutral** vs. the intent of #397: both pages still enumerate their entire param set via `generateStaticParams` and still call `notFound()` for anything unknown. Known params are served statically from cache; unknown params render on demand and 404 via `notFound()`. The only thing lost is the static-404 micro-optimization for never-valid probe URLs — a worthwhile trade for not taking down every detail page.

The `generateStaticParams` refactor from #397 is kept as-is; it is correct and not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXAyQxqKewXPivVgTccBjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXAyQxqKewXPivVgTccBjN)_