### PR TITLE
test(DO NOT MERGE): probe dynamicParams=false on OpenNext 1.19.11 (preview only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "atlens",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/source-serif-4": "^5.2.9",
@@ -28,7 +29,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@opennextjs/cloudflare": "^1.19.8",
+        "@opennextjs/cloudflare": "^1.19.11",
         "@playwright/test": "^1.59.1",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/postcss": "^4",
@@ -4348,9 +4349,9 @@
       }
     },
     "node_modules/@opennextjs/cloudflare": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@opennextjs/cloudflare/-/cloudflare-1.19.9.tgz",
-      "integrity": "sha512-GUs+X25VFUqulzA0fALvUABWZ08zR1cpAPpREcNxhzVdhERe2OU3NslU25GsecV+0askV/w/NmE9PgpzENaAIg==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@opennextjs/cloudflare/-/cloudflare-1.19.11.tgz",
+      "integrity": "sha512-spZ7YsZZW9q/OJStaZlJhuklYKei5e2tNQ7PMi3DDSJ7x7167m7EYYHQZfVN5gwJBDkMR2jUDW88oHjnGz4YYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "^1.19.8",
+    "@opennextjs/cloudflare": "^1.19.11",
     "@playwright/test": "^1.59.1",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/postcss": "^4",

--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -48,16 +48,11 @@ export function generateStaticParams({ params }: { params: { locale: string; mou
   return getLensesByMount(resolvedMount, params.locale).map((lens) => ({ id: lens.id }));
 }
 
-// dynamicParams is left at its default (true) ON PURPOSE — do NOT set it to
-// false here. Every valid id is prerendered above, and an unknown id falls
-// through to notFound() below, so the user-visible behavior is identical either
-// way. But `dynamicParams = false` emits `fallback: false` for this route in the
-// prerender manifest, and our deploy target (Cloudflare Workers via OpenNext)
-// 404s EVERY request to such a route — even the prerendered ids whose HTML is
-// sitting in the cache. `next start` serves them fine, which is what makes the
-// regression invisible locally. Keeping the default makes the route `fallback:
-// null` (served from cache for known ids, on-demand → notFound() for unknown).
-// See PR #397, which set this to false and took the whole detail page down.
+// The lens catalog is a closed set, fully enumerated above. An id outside it can
+// only be a stale link or a probe, so serve a static 404 instead of spending an
+// on-demand render that would just fall through to notFound(). (The default,
+// dynamicParams: true, would render unknown ids at request time.)
+export const dynamicParams = false;
 
 export async function generateMetadata({
   params,

--- a/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/collections/[slug]/page.tsx
@@ -25,14 +25,10 @@ export function generateStaticParams() {
   return Object.keys(COLLECTIONS).map((slug) => ({ slug }));
 }
 
-// dynamicParams is left at its default (true) ON PURPOSE — do NOT set it to
-// false here. Every collection slug is prerendered above and an unknown slug
-// falls through to notFound() below, so behavior is identical either way. But
-// `dynamicParams = false` emits `fallback: false` for this route, and our deploy
-// target (Cloudflare Workers via OpenNext) 404s EVERY request to such a route —
-// including the prerendered slugs whose HTML is already cached. `next start`
-// hides this, which is why PR #397 (which set this to false) shipped a total
-// 404 of every collection detail page. See the matching note on the [id] page.
+// Collection slugs are a closed set (COLLECTIONS), so an unknown slug gets a
+// static 404 rather than an on-demand render that only falls through to
+// notFound(). Mirrors the [id] detail page.
+export const dynamicParams = false;
 
 function localized(field: { en: string; zh: string }, locale: string): string {
   return locale === "zh" ? field.zh : field.en;


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — preview probe only

This branch exists **only** to get a real Cloudflare **preview** deployment to test against. Merging it would re-introduce the production outage that PR #398 just fixed (every lens-detail `[id]` and collection-detail `[slug]` page returns 404).

## What this tests

PR #398 reverted `dynamicParams=false` because it 404s every detail/collection page on Cloudflare/OpenNext (OpenNext issue #611). A comment on #611 (2025-10-14) claims it "should now work". This PR puts it back **plus** bumps `@opennextjs/cloudflare` 1.19.9 → **1.19.11** so we can verify on a real preview deploy.

## Local finding (to be confirmed on the preview)

On `wrangler dev` with 1.19.11:
- ❌ `/en/lenses/x/7artisans-4mm-f28-x` (valid id) → **404**
- ❌ `/en/lenses/x/collections/under-200g` (valid slug) → **404**
- ✅ `/robots.txt`, `/sitemap.xml`, `/en/lenses/x/browse`, `/collections` → 200

So 1.19.11 fixed the *unrelated-route* collateral damage (#611's headline), but the route's **own** valid prerendered params still 404. This preview is to confirm that against real production infra.

## How to test the preview

Once Cloudflare posts the preview URL on this PR, open in a browser:
- A real lens detail page, e.g. `/en/lenses/x/7artisans-4mm-f28-x` → expect **404** if still broken, **200** if fixed
- A collection detail page, e.g. `/en/lenses/x/collections/under-200g`

If both 200 → #611 is genuinely fixed and we can re-enable `dynamicParams=false` (closed set + hard 404). If 404 → keep the #398 revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)