### PR TITLE
perf(cache): serve SSG pages from prerender via static-assets incremental cache

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,3 +1,14 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import staticAssetsIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache";
 
-export default defineCloudflareConfig();
+// Serve prerendered (SSG) pages from the build output instead of re-rendering
+// them in the Worker on every request. Without an incrementalCache override the
+// default is the no-op "dummy" cache, which always misses — so every SSG page
+// silently degrades to an on-demand (edge-SSR) render. The static-assets cache
+// is read-only and ships the prerendered HTML/RSC as Worker assets under
+// `cdn-cgi/_next_cache`, which is exactly what a no-revalidation, pure-SSG site
+// wants. (ISR/on-demand revalidation would instead require the writable R2
+// cache + a queue; this site has no ISR routes, so static-assets is the fit.)
+export default defineCloudflareConfig({
+  incrementalCache: staticAssetsIncrementalCache,
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "npm run lint && npm run typecheck",
     "prebuild": "wrangler types --env-interface CloudflareEnv && node --experimental-strip-types scripts/build-lens-image-manifest.mts",
     "build": "tsx scripts/gen-icons.tsx && tsx scripts/verify-icons.ts && node --experimental-strip-types scripts/validate-lenses.mts && next build && node --experimental-strip-types scripts/check-static-routes.mts",
-    "build:cf": "wrangler types --env-interface CloudflareEnv && npx opennextjs-cloudflare build",
+    "build:cf": "wrangler types --env-interface CloudflareEnv && npx opennextjs-cloudflare build && npx opennextjs-cloudflare populateCache remote",
     "start": "next start",
     "nuke": "pkill -f 'next dev' 2>/dev/null; pkill -f 'next-server' 2>/dev/null; rm -rf .next; echo 'Cache cleared. Run npm run dev to restart.'",
     "lint": "eslint",

--- a/src/app/[locale]/lenses/[mount]/compare/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/compare/page.tsx
@@ -15,13 +15,12 @@ import { mountToUrlSegment } from "@/lib/mount";
 import { lensDisplayName } from "@/lib/lens/format";
 import { notFound } from "next/navigation";
 
-// Compare page depends on ?ids=A,B,C searchParams for server-rendered metadata
-// (title and OG tag include the lens names), so it cannot be fully SSG. The
-// trade-off: keep it as SSR but mark it cacheable with a long s-maxage so the
-// edge CDN (Vercel Edge Cache / Cloudflare) caches each unique URL after first
-// render. Result: per-URL CPU cost happens once per (ids, preset) combination,
-// then subsequent visitors hit cache.
-export const revalidate = 31536000; // 1 year
+// The compare page reads ?ids=A,B,C from searchParams to build server-rendered
+// metadata (title/OG carry the lens names). Reading searchParams forces dynamic
+// rendering, so this route is served per request (Cache-Control: no-store), not
+// prerendered. It is intentionally uncached: the route cache keys on pathname,
+// not the query string, so caching per ?ids= combination would require moving
+// the ids into the path segment.
 
 type Params = Promise<{ locale: string; mount: string }>;
 type SearchParams = Promise<{ ids?: string }>;

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -81,6 +81,12 @@ export function GET(req: Request) {
     },
     {
       headers: {
+        // `no-store` because nothing on the site calls this at runtime (the UI
+        // filters client-side over props), so caching buys nothing today. The
+        // payload is derived entirely from build-static data (lenses.json) and
+        // only changes on redeploy — so if this becomes a public/hot endpoint,
+        // revisit: it is safe to cache aggressively (e.g. a long `s-maxage`
+        // keyed on the query params) instead of `no-store`.
         "Cache-Control": "private, no-store",
       },
     },

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -80,6 +80,12 @@ export function GET(req: Request) {
     { results, query: query.trim() },
     {
       headers: {
+        // `no-store` because the UI searches client-side and nothing calls this
+        // at runtime, so caching buys nothing today. Results come from a
+        // build-static search index that only changes on redeploy — so if this
+        // becomes a public/hot endpoint, revisit: it is safe to cache (e.g. a
+        // long `s-maxage` keyed on `q`/`mount`/`locale`/`limit`) instead of
+        // `no-store`.
         "Cache-Control": "private, no-store",
       },
     },

--- a/src/config/static-routes.ts
+++ b/src/config/static-routes.ts
@@ -43,9 +43,8 @@ export const INTENTIONALLY_DYNAMIC_ROUTE_PATTERNS = [
   {
     pattern: "/[locale]/lenses/[mount]/compare",
     reason:
-      "Needs server-rendered metadata derived from ?ids=A,B,C searchParams. " +
-      "Marked with `export const revalidate = 31536000` so each unique URL " +
-      "is cached at the edge after first render.",
+      "Reads ?ids=A,B,C from searchParams to build server-rendered metadata, " +
+      "which forces dynamic rendering. Served per request (no-store), not cached.",
   },
   {
     pattern: "/api/feedback",


### PR DESCRIPTION
## Problem

`open-next.config.ts` was a bare `defineCloudflareConfig()`, leaving `incrementalCache` at the no-op **"dummy"** default (no R2/KV binding either). The dummy cache always misses, so on Cloudflare **every prerendered (SSG) page silently degraded to an on-demand edge-SSR render on every request** — the build-time prerendered HTML was never served at runtime.

It "worked" because our pages are cheap (bundled `lenses.json`, no DB), but it's wasted Worker CPU on every hit and contradicts the whole point of SSG.

## Fix (two parts — both required)

**1. `open-next.config.ts` — select the static-assets incremental cache.**
The read-only **`static-assets`** backend is the one OpenNext intends for *"applications that do NOT want revalidation and ONLY want to serve prerendered data"* — exactly this site. The prerendered HTML/RSC is served directly, no re-render. (We have **no ISR routes** — the only `revalidate` is on `/compare`, which is dynamic via `searchParams` so it's inert — so a read-only cache is sufficient; on-demand revalidation would instead need the writable R2 cache + a queue.)

**2. `build:cf` — actually populate the cache into the deployed assets.**
`opennextjs-cloudflare build` does **not** populate; `populate` is a separate step that copies the prerendered entries into `.open-next/assets/cdn-cgi` (which then ship via the `[assets]` binding). Without it `cdn-cgi` stays empty in the deploy and every page still misses — i.e. part 1 alone is a **no-op in production**. So `build:cf` now ends with `opennextjs-cloudflare populateCache remote`. For the static-assets backend this is a local file copy (no R2/KV, no auth); verified `npm run build:cf` ends with 635 files under `assets/cdn-cgi`.

> ⚠️ Reviewer note: if the CF deploy pipeline uses a custom deploy command (e.g. `opennextjs-cloudflare deploy`, which populates internally) rather than `build:cf` + `wrangler deploy`, part 2 is redundant-but-harmless. The decisive check is the runtime header below.

## Verification (local `opennextjs-cloudflare preview`)

Signal = the **`x-nextjs-cache`** response header on a page (`HIT` = served from prerender, `MISS` = re-rendered).

| | before (dummy) | after (this PR) |
|---|---|---|
| `cdn-cgi/_next_cache` | empty | 635 files |
| `/lenses/x/collections/[slug]` | `x-nextjs-cache: MISS` | **`HIT`** |
| `/lenses/x/[id]` | MISS | **HIT** |
| `/browse`, `/` | MISS | **HIT** |
| `/compare?ids=…` (dynamic) | 200 | 200 (unchanged) |
| unknown id (soft 404) | 200 | 200 (unchanged) |

On the deployed preview, confirm via DevTools → Network → document request → Response Headers → `x-nextjs-cache: HIT`. The CF build log should also show `Populating Workers static assets... Successfully populated static assets cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)