### PR TITLE
ci(uptime): scoped failure alert via Bark

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -86,3 +86,24 @@ jobs:
                 labels: ["uptime-failure"],
               });
             }
+
+      # The GitHub issue above is a record, not an alert: a bot-created issue
+      # notifies nobody, and GitHub's built-in Actions email can't be scoped to
+      # one workflow (it would also fire on every routine CI failure). So this
+      # workflow pushes its OWN alert — fired only when an uptime check fails.
+      # Set the BARK_URL secret to your Bark base URL incl. device key
+      # (https://api.day.app/<key>); if unset, this step no-ops (issue still created).
+      - name: Push alert (Bark) on failure
+        if: failure()
+        env:
+          BARK_URL: ${{ secrets.BARK_URL }}
+        run: |
+          if [ -z "$BARK_URL" ]; then
+            echo "BARK_URL secret not set — skipping push (issue still created)."
+            exit 0
+          fi
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -fsS -X POST "${BARK_URL%/}" \
+            -H "Content-Type: application/json" \
+            -d "{\"title\":\"🚨 Atlens production check failed\",\"body\":\"Reachability or SSG-cache check went red. Tap to open the run.\",\"group\":\"atlens\",\"level\":\"timeSensitive\",\"url\":\"$run_url\"}" \
+            || echo "Bark push failed (issue still created)."


### PR DESCRIPTION
## Why
The uptime workflow (added in #401) opens a GitHub issue on failure, but that notified no one — a bot-created issue doesn't ping anyone. GitHub's built-in Actions email is the obvious fix, but it's **global**: it can't be scoped to one workflow, so enabling it would also email on every routine PR/CI failure (noise).

## What
To get an alert that fires **only** when an uptime check fails, the workflow pushes its own:
- On `failure()`, POST a Bark push (`BARK_URL` secret = `https://api.day.app/<device-key>`), `level: timeSensitive`, tappable to the run.
- No-ops if `BARK_URL` is unset, so the run never fails just because Bark isn't configured.
- The tracking issue stays as the persistent record; Bark is the actual alert.

## Setup (required for it to fire)
Add repo secret **`BARK_URL`** = `https://api.day.app/<your-device-key>` (Settings → Secrets and variables → Actions). Without it the step no-ops.

## Test plan
- [x] Bark endpoint verified by manual `curl` (push reaches device).
- [ ] After merge: `workflow_dispatch` against a branch with a deliberately broken canary to confirm the failure → Bark path end-to-end.

## Note
Leave GitHub's global "Actions failed-workflow email" OFF to avoid routine-CI noise; this scoped Bark step replaces it for uptime specifically.