### PR TITLE
chore(testhook): drop collection routes from the hidden-routes panel

### DIFF
--- a/src/components/TestHookPanel.tsx
+++ b/src/components/TestHookPanel.tsx
@@ -18,17 +18,8 @@ import {
   REDACTION_BLUR_QUERY_KEY,
   DEFAULT_REDACTION_BLUR_PX,
 } from "@/lib/redaction";
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const collectionsData = require("@/data/collections.json") as {
-  collections: { slug: string; title: { en: string } }[];
-};
 
 const HIDDEN_ROUTES: { label: string; href: string }[] = [
-  { label: "All Collections", href: "/lenses/x/collections" },
-  ...collectionsData.collections.map((c) => ({
-    label: c.title.en,
-    href: `/lenses/x/collections/${c.slug}`,
-  })),
   { label: "Design Lab — Iris", href: "/design-lab/iris" },
   { label: "Design Lab — Iris Pheno", href: "/design-lab/iris-pheno" },
   { label: "Design Lab — Outro (end card)", href: "/design-lab/outro" },


### PR DESCRIPTION
## What
Trim the `TestHookPanel` hidden-routes list to the genuinely-hidden Design Lab routes; drop the "All Collections" + per-collection entries. Those were the only consumer of the `collections.json` `require`, so the now-dead import (and its `eslint-disable`) go too.

## Scope
TestHookPanel only — a dev/QA panel rendered solely under test-hook mode. No production-facing surface changes.

## Test plan
- [x] `eslint` clean (no unused `collectionsData`).
- [ ] CI green.