### PR TITLE
fix(image): align next/image priority usage with Next 16 semantics

### DIFF
--- a/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
+++ b/src/app/[locale]/lenses/[mount]/(browse)/[id]/page.tsx
@@ -270,7 +270,10 @@ export default async function LensDetailPage({ params }: { params: Params }) {
                 sizes="256px"
                 style={lensImageStyle}
                 className="object-contain"
-                priority
+                // LCP hero: preload (early discovery) + high fetch priority.
+                // `priority` is deprecated in Next 16.
+                preload
+                fetchPriority="high"
               />
             </div>
           </div>

--- a/src/components/compare/CompareTable.tsx
+++ b/src/components/compare/CompareTable.tsx
@@ -65,7 +65,8 @@ function LensHeaderContent({
             sizes="(min-width: 640px) 160px, 80px"
             style={lensImageStyle}
             className="object-contain"
-            priority
+            // Above-fold compare thumbnail: eager, not preloaded (small, not LCP).
+            loading="eager"
           />
         </div>
       </div>

--- a/src/components/lens/LensCard.tsx
+++ b/src/components/lens/LensCard.tsx
@@ -102,8 +102,9 @@ export default memo(function LensCard({
                 sizes="(max-width: 499px) 112px, (max-width: 640px) 50vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
                 style={lensImageStyle}
                 className="object-contain"
-                priority={priority}
-                loading={priority ? undefined : "lazy"}
+                // Next 16: `priority` only adds a head preload link; drive loading
+                // directly so above-fold cards are eager (no preload spam), rest lazy.
+                loading={priority ? "eager" : "lazy"}
               />
             </div>
           </div>


### PR DESCRIPTION
## Why

Next 16 deprecated the `priority` prop on `next/image`. It now only injects a `<link rel="preload">` in the head and **no longer sets `loading` / `fetchpriority` on the `<img>`** (that combined behavior was Next <=15). The type defs confirm it — `priority` is marked `@deprecated Use 'preload' instead`.

So the existing `priority` usages silently lost the `fetchpriority="high"` img hint, and using `priority` across grid cards emits one preload link per card — the "dont use preload" case the Next 16 docs call out (many images that could each be the LCP depending on viewport).

## What

Split the intent explicitly per call site:

| Site | Before | After |
| --- | --- | --- |
| Detail hero (single LCP) | `priority` | `preload` + `fetchPriority="high"` |
| Browse / collection grids | `priority={i<8}` + explicit `loading` | `loading={priority ? "eager" : "lazy"}` (eager above the fold, no per-card preload) |
| Compare thumbnails | `priority` | `loading="eager"` (small, not the LCP) |

Below-the-fold lazy loading is unchanged. `tsc --noEmit` passes.

Ref: https://nextjs.org/docs/app/api-reference/components/image

🤖 Generated with [Claude Code](https://claude.com/claude-code)