### PR TITLE
feat(copilot): experimental AI lens copilot — Sprint 0 (DeepSeek streaming scaffold)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ yarn-error.log*
 .env*
 !.env.example
 
+# wrangler local secrets (DEEPSEEK_API_KEY etc. for `npm run preview`)
+.dev.vars
+
 # vercel
 .vercel
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,6 @@ yarn-error.log*
 .env*
 !.env.example
 
-# wrangler local secrets (DEEPSEEK_API_KEY etc. for `npm run preview`)
-.dev.vars
-
 # vercel
 .vercel
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Cloudflare Workers / OpenNext build artifacts:
     ".open-next/**",
+    // Wrangler local state (bundled worker written by `npm run preview`):
+    ".wrangler/**",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,13 @@
     "": {
       "name": "atlens",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@ai-sdk/deepseek": "^3.0.2",
+        "@ai-sdk/react": "^4.0.9",
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/source-serif-4": "^5.2.9",
+        "ai": "^7.0.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "geist": "^1.7.0",
@@ -54,6 +58,106 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/deepseek": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-3.0.2.tgz",
+      "integrity": "sha512-0IIbl1xRRX+lI9BXpFF6e8yi7egGXMwXROuawivG/vimcBULtuFHUYlfHHTq0MzSPiG6GbCQ9C5XTFa/SA3iQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.6.tgz",
+      "integrity": "sha512-8GjssUxXeTd8tst2fYXNOFbtNNZFv3sG7aq7wKnQYrU2eB3JFR7np6o4F3Snp/fy/rJZSeH28LvjSWq5wkdL8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.4.tgz",
+      "integrity": "sha512-o5edIxgQrssKl/DABaXOzTUG/DUOyn25ilnnczQeLpnlSEUNXqYc3TSOZ7u6aBB+vkersQ7MXkfNMzqulR6CKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.1.tgz",
+      "integrity": "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.2.tgz",
+      "integrity": "sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.1",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.9.tgz",
+      "integrity": "sha512-KJ/b9OOHgWHIwugupb+ARBlfh1dqBJhO1hEPzLmlp5R0yD9kARSO0JZxS7a9MFoFML/DytHbcFUUbIuUMAvmsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.4",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "ai": "7.0.8",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -6106,7 +6210,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -7499,6 +7602,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -7585,6 +7697,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7654,6 +7772,23 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.8.tgz",
+      "integrity": "sha512-vTEKl6fDBZ2IxBXTRaZOajf9W2Ev57Ju8iKtUvqlmDk8Z9BrEP4c22SWJsg1RcWHSFmJMSBa/s5dlUBHUq3YwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.6",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -8936,7 +9071,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11924,6 +12058,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -15312,6 +15452,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15387,6 +15540,18 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@ai-sdk/deepseek": "^3.0.2",
+    "@ai-sdk/react": "^4.0.9",
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/source-serif-4": "^5.2.9",
+    "ai": "^7.0.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",

--- a/src/app/[locale]/copilot/page.tsx
+++ b/src/app/[locale]/copilot/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { setRequestLocale } from "next-intl/server";
+import CopilotChat from "@/components/copilot/CopilotChat";
+
+type Params = Promise<{ locale: string }>;
+
+// Experimental Copilot surface: reachable only by direct URL (no nav entry) and
+// kept out of search indexes until it ships for real.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default async function CopilotPage({ params }: { params: Params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return <CopilotChat />;
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,3 @@
-import { deepseek } from "@ai-sdk/deepseek";
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -6,6 +5,7 @@ import {
   toUIMessageStream,
   type UIMessage,
 } from "ai";
+import { copilotModel, copilotProviderOptions } from "@/lib/ai/model";
 
 // First AI streaming endpoint in the app, backing the experimental Copilot
 // surface (src/app/[locale]/copilot). Deliberately minimal — a bare,
@@ -22,7 +22,8 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: deepseek("deepseek-chat"),
+    model: copilotModel,
+    providerOptions: copilotProviderOptions,
     messages: await convertToModelMessages(messages),
   });
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,38 @@
+import { deepseek } from "@ai-sdk/deepseek";
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+} from "ai";
+
+// First AI streaming endpoint in the app, backing the experimental Copilot
+// surface (src/app/[locale]/copilot). Deliberately minimal — a bare,
+// provider-agnostic stream — until the runtime plan (tools, system prompt,
+// query splitting) lands. Runs on the Cloudflare workerd runtime via OpenNext,
+// so streaming must be validated with `npm run preview`, not just `next dev`.
+export async function POST(req: Request) {
+  // A global secret has exactly one source of truth; a missing key is a config
+  // bug, so fail loudly here instead of letting the stream error opaquely.
+  if (!process.env.DEEPSEEK_API_KEY) {
+    return Response.json({ error: "DEEPSEEK_API_KEY is not set" }, { status: 500 });
+  }
+
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: deepseek("deepseek-chat"),
+    messages: await convertToModelMessages(messages),
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({
+      stream: result.stream,
+      // Forward the real provider error during bring-up; the SDK otherwise
+      // masks it as an opaque "An error occurred". Tighten before public ship.
+      onError: (error) =>
+        error instanceof Error ? error.message : String(error),
+    }),
+  });
+}

--- a/src/components/copilot/CopilotChat.tsx
+++ b/src/components/copilot/CopilotChat.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { useState } from "react";
+
+// Bare hello-world chat against /api/chat. No domain logic yet — this exists to
+// de-risk the stack (AI SDK + DeepSeek + workerd streaming) before the lens
+// tools and system prompt land. useChat's default transport POSTs to /api/chat.
+export default function CopilotChat() {
+  const [input, setInput] = useState("");
+  const { messages, sendMessage, status } = useChat();
+
+  const isBusy = status === "submitted" || status === "streaming";
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const text = input.trim();
+    if (!text || isBusy) {
+      return;
+    }
+    sendMessage({ text });
+    setInput("");
+  }
+
+  return (
+    <div className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-lg font-semibold">Copilot</h1>
+        <p className="text-muted-foreground text-sm">
+          Experimental — streaming hello world.
+        </p>
+      </header>
+
+      <div className="flex-1 space-y-4">
+        {messages.map((message) => (
+          <div key={message.id} className="whitespace-pre-wrap text-sm">
+            <span className="text-muted-foreground mr-2 font-medium">
+              {message.role === "user" ? "You" : "AI"}
+            </span>
+            {message.parts.map((part, i) =>
+              part.type === "text" ? (
+                <span key={`${message.id}-${i}`}>{part.text}</span>
+              ) : null,
+            )}
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-6 flex gap-2">
+        <input
+          className="border-input flex-1 rounded-md border px-3 py-2 text-sm"
+          value={input}
+          placeholder="Say something…"
+          onChange={(event) => setInput(event.currentTarget.value)}
+          disabled={isBusy}
+        />
+        <button
+          type="submit"
+          disabled={isBusy || !input.trim()}
+          className="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm disabled:opacity-50"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/ai/model.ts
+++ b/src/lib/ai/model.ts
@@ -1,0 +1,22 @@
+import { deepseek } from "@ai-sdk/deepseek";
+import type { LanguageModel } from "ai";
+
+// Single source of truth for the Copilot's language model. Route handlers import
+// from here and never name a provider, so swapping provider or model id is a
+// one-line change confined to this file (the AI SDK keeps call sites
+// provider-agnostic). The provider reads its own API key from the environment
+// (DeepSeek → DEEPSEEK_API_KEY).
+//
+// `deepseek-v4-flash` is the forward model id: the legacy `deepseek-chat` /
+// `deepseek-reasoner` aliases are retired after 2026-07-24 and already route to
+// v4-flash.
+export const copilotModel: LanguageModel = deepseek("deepseek-v4-flash");
+
+// v4-flash is dual-mode and defaults to *thinking* (it emits reasoning tokens
+// before answering). We disable it: the copilot's tool-driven recall wants fast,
+// cheap turns, and non-thinking already chains tools reliably. The interesting
+// §7 knob is `adaptive` (think only when the query warrants it) — revisit once
+// query-splitting and perf metrics exist.
+export const copilotProviderOptions = {
+  deepseek: { thinking: { type: "disabled" } },
+} as const;


### PR DESCRIPTION
## What

Scaffolds the experimental **AI lens Copilot** and the app's first AI streaming endpoint. This is Sprint 0: a de-risk pass for the AI stack, not the product runtime yet (tools, system prompt, query splitting come in a follow-up PR).

- `src/app/[locale]/copilot` — URL-direct surface (`/en/copilot`, `/zh/copilot`), **`noindex`, no nav entry** by design. Minimal `useChat` client.
- `src/app/api/chat` — first AI streaming route. `streamText` + AI SDK v7 (`createUIMessageStreamResponse` + `toUIMessageStream`, the non-deprecated path). Missing key fails loudly (no silent fallback).
- `src/lib/ai/model.ts` — single provider-agnostic seam; the route names no provider, so swapping provider/model is a one-line change here.

## De-risked in this PR

- **Streaming on real workerd** verified via `npm run preview` (not just `next dev`) — the CF-only regression class from #397.
- **DeepSeek multi-step tool calling** chained two dependent tools 3/3, via both `generateText` and `streamText`.

## Non-obvious notes

- **Model = `deepseek-v4-flash`**, not `deepseek-chat` (that alias retires 2026-07-24 and already routes to v4-flash). Bare v4-flash **defaults to thinking**; disabled via `providerOptions` for fast/cheap tool turns. (Thinking+tools is a separate, still-unverified path — a follow-up concern.)
- **Env: one `.env.local` feeds both `next dev` and `npm run preview`.** Wrangler 4.x reads `.env.local` itself, and `.dev.vars` would *shadow* it (mutually exclusive per CF docs) — so no `.dev.vars`.
- **Not live in prod until a `DEEPSEEK_API_KEY` secret is set** (CF Dashboard / `wrangler secret put`). Without it the route returns 500; the noindex page has no entry point, so this is inert until then.

## Test plan

- [x] `npm run check` (lint + typecheck) clean
- [x] Streaming verified on `next dev` and `npm run preview` (workerd)
- [x] DeepSeek multi-step tool calling verified (3/3)
- [ ] Set `DEEPSEEK_API_KEY` prod secret before relying on the live route

🤖 Generated with [Claude Code](https://claude.com/claude-code)