### PR TITLE
fix(lens-card): make the full card clickable, not just the area above the compare button

### DIFF
--- a/src/components/lens/LensCard.tsx
+++ b/src/components/lens/LensCard.tsx
@@ -74,17 +74,17 @@ export default memo(function LensCard({
   return (
     <div
       {...hookAttr("card")}
-      className={`relative rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] ${
+      className={`relative rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow,background-color] hover:bg-zinc-50 dark:hover:bg-zinc-800/50 ${
         isSelected
           ? CARD_SELECTED_BORDER_CLS
           : "border-zinc-200 dark:border-zinc-800"
       }`}
     >
-      {/* Stretched via ::after to cover the whole card incl. the footer below; compare buttons use z-10 to stay on top of it. */}
+      {/* Stretched via ::after to cover the whole card incl. the footer below; compare buttons use z-10 to stay on top of it. Hover background lives on the outer card, not here, so it spans the whole clickable area. */}
       <Link
         href={`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`}
         prefetch={false}
-        className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors max-xs:flex-row after:absolute after:inset-0 after:content-['']"
+        className="flex-1 flex flex-col max-xs:flex-row after:absolute after:inset-0 after:content-['']"
       >
         <div
           {...hookAttr("cardMedia")}

--- a/src/components/lens/LensCard.tsx
+++ b/src/components/lens/LensCard.tsx
@@ -74,17 +74,17 @@ export default memo(function LensCard({
   return (
     <div
       {...hookAttr("card")}
-      className={`rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] max-xs:relative ${
+      className={`relative rounded-2xl border bg-white dark:bg-zinc-900 flex flex-col overflow-hidden transition-[border-color,box-shadow] ${
         isSelected
           ? CARD_SELECTED_BORDER_CLS
           : "border-zinc-200 dark:border-zinc-800"
       }`}
     >
-      {/* Clickable detail area */}
+      {/* Stretched via ::after to cover the whole card incl. the footer below; compare buttons use z-10 to stay on top of it. */}
       <Link
         href={`/lenses/${mountToUrlSegment(lens.mount)}/${lens.id}`}
         prefetch={false}
-        className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors max-xs:flex-row"
+        className="flex-1 flex flex-col hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors max-xs:flex-row after:absolute after:inset-0 after:content-['']"
       >
         <div
           {...hookAttr("cardMedia")}
@@ -215,7 +215,7 @@ export default memo(function LensCard({
             size="sm"
             onClick={() => onToggle(lens.id)}
             disabled={selectionDisabled}
-            className={`w-full h-10 sm:h-9 font-medium ${
+            className={`relative z-10 w-full h-10 sm:h-9 font-medium ${
               isSelected
                 ? `text-xs ${ACTION_PRIMARY_CLS}`
                 : selectionDisabled


### PR DESCRIPTION
## Summary
- The compare-button footer was a sibling of the detail `Link`, not a descendant, so its surrounding padding (and, on narrow layouts, the icon-button corner) wasn't part of the clickable card area — only clicking directly on the "Add to Compare" button/icon or the content above it worked.
- Stretches the `Link` over the whole card via an absolute `::after` overlay (Bootstrap's "stretched-link" pattern) instead of nesting the button inside the anchor, which HTML5 disallows (`<a>` may not contain interactive content).
- Both compare buttons (desktop footer button, mobile icon button) get `z-10` so they stay above the overlay and still just toggle instead of navigating — no `stopPropagation` needed, since the topmost element at each pixel wins the click regardless of DOM nesting.

## Test plan
- [x] Verified via Playwright at desktop width (1440px): clicking empty footer padding around the button navigates to the lens detail page; clicking the button itself only toggles "Add/Remove from Compare" text with no navigation.
- [x] Verified at mobile width (390px): the absolute icon button still receives clicks directly; the area just below it still navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)