### PR TITLE
feat(askiris): launch prep — rate-limit /api/chat + nav entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ GITHUB_FEEDBACK_REPO=owner/repo-name
 
 # Optional comma-separated GitHub usernames to assign to feedback issues.
 GITHUB_FEEDBACK_ASSIGNEES=your-github-username
+
+# Optional. Exempts your own testing from the /api/chat rate limit: set a
+# `rate_bypass` cookie to this exact value in your browser. High-entropy secret;
+# in production set it via `wrangler secret put RATE_LIMIT_BYPASS`. Unset = no bypass.
+RATE_LIMIT_BYPASS=

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -8,8 +8,10 @@ import {
 } from "ai";
 import { z } from "zod";
 import { getTranslations } from "next-intl/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { getAgentModel, agentProviderOptions } from "@/lib/ai/model";
 import { buildLensTools } from "@/lib/ai/tools";
+import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
 import type { Mount } from "@/lib/types";
@@ -29,7 +31,9 @@ function systemPrompt(mount: Mount, locale: string): string {
   return [
     `You help users find lenses for ${MOUNT_LABEL[mount]}. You recall and compare`,
     `candidates by their specs — you never tell the user which one to buy, and you`,
-    `never state a spec that isn't in a tool result.`,
+    `never state a spec that isn't in a tool result. If a request isn't about`,
+    `choosing or comparing lenses, say plainly that your knowledge only covers lens`,
+    `questions and don't attempt it.`,
     ``,
     `Turn the user's needs into tool calls. The mount and the user's region are`,
     `fixed by context — don't ask about them.`,
@@ -90,6 +94,27 @@ export async function POST(req: Request) {
   }
   const { messages, mount, locale } = parsed.data;
 
+  // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
+  // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
+  // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
+  const ip = clientIp(req);
+  let rateKv: KVNamespace | undefined;
+  let waitUntil: ((p: Promise<unknown>) => void) | undefined;
+  try {
+    const { env, ctx } = getCloudflareContext();
+    rateKv = (env as CloudflareEnv).RATE_KV;
+    waitUntil = ctx.waitUntil.bind(ctx);
+    if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
+      const verdict = await checkRateLimit(rateKv, ip);
+      if (!verdict.ok) {
+        const tRate = await getTranslations({ locale, namespace: "AskIris" });
+        return Response.json({ error: tRate("rateLimited") }, { status: 429 });
+      }
+    }
+  } catch {
+    // Never let a missing binding or KV error break chat.
+  }
+
   const tBrand = await getTranslations({ locale, namespace: "Brands" });
   const tools = buildLensTools(mount, locale, tBrand);
 
@@ -102,6 +127,14 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(messages, { tools }),
     tools,
     stopWhen: stepCountIs(8),
+    // Fold the finished turn's real token usage (summed across all steps) into the
+    // daily budgets. waitUntil keeps the write alive past the streamed response.
+    onFinish: ({ totalUsage }) => {
+      const tokens = totalUsage.totalTokens;
+      if (rateKv && ip && waitUntil && typeof tokens === "number") {
+        waitUntil(recordTokens(rateKv, ip, tokens));
+      }
+    },
   });
 
   return createUIMessageStreamResponse({

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Menu } from "@base-ui/react/menu";
-import { EllipsisVertical, Flag, Info, Download } from "lucide-react";
+import { EllipsisVertical, Flag, Info, Download, Columns2 } from "lucide-react";
 import { Link, usePathname } from "@/i18n/navigation";
 import Iris from "@/components/iris/Iris";
 import { IRIS_NAV } from "@/config/iris-config";
@@ -96,6 +96,7 @@ export default function Nav() {
 
   const isBrowseActive = pathname.startsWith("/lenses") && !pathname.includes("/compare");
   const isCompareActive = pathname.includes("/compare");
+  const isAskIrisActive = pathname.startsWith("/askiris");
   const showMountSwitcher =
     pathname === "/" || pathname.startsWith("/lenses") || pathname.startsWith("/askiris");
 
@@ -150,7 +151,19 @@ export default function Nav() {
           <Link href={browseHref} className={linkCls(isBrowseActive)}>
             {t("lenses")}
           </Link>
-          <Link href={compareHref} onClick={handleCompareLinkClick} className={linkCls(isCompareActive)}>
+          <Link href="/askiris" className={linkCls(isAskIrisActive)}>
+            {t("askIris")}
+            <sup className="relative -top-1.5 ml-0.5 text-[8px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+              Beta
+            </sup>
+          </Link>
+          {/* Compare is a late-funnel utility, so on mobile it folds into the ⋮
+              overflow to make room for the Ask AI entry; stays inline on desktop. */}
+          <Link
+            href={compareHref}
+            onClick={handleCompareLinkClick}
+            className={cn(linkCls(isCompareActive), "hidden sm:inline")}
+          >
             {t("compare")}
           </Link>
 
@@ -191,6 +204,14 @@ export default function Nav() {
             <Menu.Portal>
               <Menu.Positioner side="bottom" align="end" sideOffset={6} className="z-50 sm:hidden">
                 <Menu.Popup className={cn(MENU_POPUP_CLS, "w-36")}>
+                  <Menu.LinkItem
+                    render={<Link href={compareHref} />}
+                    onClick={handleCompareLinkClick}
+                    className={mobileLinkCls(isCompareActive)}
+                  >
+                    <Columns2 className="h-4 w-4 shrink-0" />
+                    {t("compare")}
+                  </Menu.LinkItem>
                   <Menu.LinkItem
                     render={<Link href="/about" />}
                     className={mobileLinkCls(pathname === "/about")}

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -1,0 +1,94 @@
+// Abuse guard for the (public, no-login) /api/chat endpoint, keyed off the caller's
+// Cloudflare edge IP and backed by the RATE_KV namespace.
+//
+// Two axes, because they bound different things:
+//   - burst (a request COUNT per minute) bounds the RATE. It's the only check we can
+//     make BEFORE spending anything, and it caps how much a flood can overshoot the
+//     token budgets before their post-request accounting catches up.
+//   - per-IP and global daily TOKEN budgets bound the SPEND (the wallet). Token usage
+//     is only known once a request finishes, so these are checked proactively ("are
+//     we already over?") and incremented afterwards via recordTokens().
+//
+// KV has no atomic increment, so the counters are read-modify-write and thus loose
+// under concurrency — fine here, since the burst gate bounds concurrency and this is
+// deterrence, not strict metering.
+
+export const RATE_LIMIT = {
+  burstPerMinute: 6,
+  perIpDailyTokens: 400_000,
+  globalDailyTokens: 15_000_000,
+} as const;
+
+const BYPASS_COOKIE = "rate_bypass";
+const DAY_TTL_SECONDS = 2 * 24 * 60 * 60;
+const BURST_TTL_SECONDS = 120;
+
+// Cloudflare sets CF-Connecting-IP to the real client IP and strips any client-sent
+// copy, so it can't be spoofed at the edge. Absent off-Cloudflare (e.g. `next dev`).
+export function clientIp(req: Request): string | null {
+  return req.headers.get("CF-Connecting-IP");
+}
+
+// A request is exempt only if it carries the bypass cookie whose value EQUALS the
+// server-side secret — never mere presence of a known cookie, which a script could
+// forge on a raw request. No secret configured = no bypass.
+export function isBypassed(req: Request, secret: string | undefined): boolean {
+  if (!secret) {
+    return false;
+  }
+  const cookie = req.headers.get("cookie");
+  if (!cookie) {
+    return false;
+  }
+  for (const part of cookie.split(";")) {
+    const [name, value] = part.trim().split("=");
+    if (name === BYPASS_COOKIE && value === secret) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function toCount(raw: string | null): number {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Proactive gate: reject if the burst rate or either daily token budget is already
+// spent. Reserves the burst slot only when letting the request through.
+export async function checkRateLimit(
+  kv: KVNamespace,
+  ip: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const now = Date.now();
+  const minute = Math.floor(now / 60_000);
+  const day = Math.floor(now / 86_400_000);
+
+  const burstKey = `burst:${ip}:${minute}`;
+  const burst = toCount(await kv.get(burstKey));
+  if (burst >= RATE_LIMIT.burstPerMinute) {
+    return { ok: false, reason: "burst" };
+  }
+  if (toCount(await kv.get(`tok:ip:${ip}:${day}`)) >= RATE_LIMIT.perIpDailyTokens) {
+    return { ok: false, reason: "ip-daily" };
+  }
+  if (toCount(await kv.get(`tok:global:${day}`)) >= RATE_LIMIT.globalDailyTokens) {
+    return { ok: false, reason: "global" };
+  }
+
+  await kv.put(burstKey, String(burst + 1), { expirationTtl: BURST_TTL_SECONDS });
+  return { ok: true };
+}
+
+// Post-request accounting: fold the finished request's real token usage into the
+// per-IP and global daily counters. Call from streamText's onFinish.
+export async function recordTokens(kv: KVNamespace, ip: string, tokens: number): Promise<void> {
+  if (!Number.isFinite(tokens) || tokens <= 0) {
+    return;
+  }
+  const day = Math.floor(Date.now() / 86_400_000);
+  for (const key of [`tok:ip:${ip}:${day}`, `tok:global:${day}`]) {
+    const next = toCount(await kv.get(key)) + tokens;
+    await kv.put(key, String(next), { expirationTtl: DAY_TTL_SECONDS });
+  }
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -41,7 +41,8 @@
     "beta": "Beta",
     "switchedMount": "Switched to {mount}",
     "newChat": "New chat",
-    "newTopic": "New topic"
+    "newTopic": "New topic",
+    "rateLimited": "Iris is taking a lot of questions right now — please try again in a little while."
   },
   "Search": {
     "open": "Open lens search",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -20,6 +20,7 @@
   },
   "Nav": {
     "lenses": "Browse",
+    "askIris": "Ask AI",
     "allLenses": "All Lenses",
     "collections": "Collections",
     "compare": "Compare",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -41,7 +41,8 @@
     "beta": "Beta",
     "switchedMount": "已切换到 {mount}",
     "newChat": "新对话",
-    "newTopic": "新话题"
+    "newTopic": "新话题",
+    "rateLimited": "Iris 现在有点忙，稍后再试。"
   },
   "Search": {
     "open": "打开镜头搜索",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -20,6 +20,7 @@
   },
   "Nav": {
     "lenses": "镜头库",
+    "askIris": "AI 选镜头",
     "allLenses": "全部镜头",
     "collections": "主题合集",
     "compare": "对比",
@@ -30,7 +31,7 @@
   "AskIris": {
     "heading": "Hi，我是 Iris<beta></beta>",
     "subtitle": "你的专属镜头顾问 —— 用大白话说需求，我帮你精准匹配",
-    "placeholder": "Ask Iris",
+    "placeholder": "问问 Iris",
     "send": "发送",
     "chips": [
       { "emoji": "🌌", "label": "拍星空银河", "prompt": "第一次拍银河，需要广角大光圈，预算 6000 左右，机身 X-T5。" },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,6 +19,13 @@ GITHUB_FEEDBACK_ASSIGNEES = "sentacraft"
 binding = "ANALYTICS"
 dataset = "xglass_events"
 
+# Rate-limit counters for /api/chat (per-IP burst + per-IP/global daily token
+# budgets). The RATE_LIMIT_BYPASS secret (dashboard / `wrangler secret put`) exempts
+# the developer's own testing.
+[[kv_namespaces]]
+binding = "RATE_KV"
+id = "b4eeeb3afdca4f038de649dd3ecbea5f"
+
 [observability]
 enabled = false
 head_sampling_rate = 1


### PR DESCRIPTION
Launch prep for the experimental AskIris surface: guard the public endpoint against abuse, then make it discoverable. Two independent commits.

## 1. Abuse guard for `/api/chat`
The endpoint is public and unauthenticated, so add IP-based rate limiting (backed by a KV namespace) that bounds both request rate and token spend, per-IP and globally. Token accounting folds in each finished turn's real usage. The guard **fails open** — an infra hiccup proceeds rather than break chat — and supports a **secret-based bypass** for internal testing (a value match, not mere cookie presence, so it can't be forged). Also tightens the system prompt so clearly non-lens requests are politely declined.

## 2. Nav entry + placeholder localisation
- Adds a nav item linking to `/askiris`, so the surface is discoverable rather than URL-only.
- On **mobile**, a late-funnel item folds into the `⋮` overflow to make room; **desktop** keeps every item inline.
- Localises the composer placeholder that was hardcoded English.

## Test
- Rate-limit logic unit-tested against a mock KV; off-topic query declines, normal lens query still recommends — verified vs local `/api/chat`.
- Nav verified across the responsive matrix (mobile / desktop × zh / en): no wrap/overflow.
- `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)