### PR TITLE
feat(askiris): add analytics logging

### DIFF
--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
+import { track } from "@/lib/analytics/analytics";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
@@ -55,6 +56,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
       return;
     }
     sendMessage({ text: trimmed }, { body: { mount, locale } });
+    track("askiris_message", { query: trimmed, method: "typed" });
     setInput("");
   }
 
@@ -70,6 +72,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
     }
     queryFired.current = true;
     sendMessage({ text: initialQuery }, { body: { mount, locale } });
+    track("askiris_message", { query: initialQuery, method: "handoff" });
     const url = new URL(window.location.href);
     url.searchParams.delete("q");
     window.history.replaceState(null, "", url.toString());

--- a/src/components/askiris/RecommendationDeck.tsx
+++ b/src/components/askiris/RecommendationDeck.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Image from "next/image";
 import { Weight } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { track } from "@/lib/analytics/analytics";
 import { mountToUrlSegment } from "@/lib/mount";
 import { getLensImageUrl, lensImageStyle } from "@/lib/lens/image";
 import { weightDisplay } from "@/lib/lens/format";
@@ -54,6 +57,7 @@ function RecommendationCard({ rec, locale }: { rec: Recommendation; locale: stri
     <Link
       href={`/lenses/${mountToUrlSegment(rec.mount)}/${rec.id}`}
       prefetch={false}
+      onClick={() => track("askiris_rec_click", { lens_id: rec.id, source: "askiris" })}
       // Opens in a new tab: the AskIris thread is ephemeral client state, so a
       // same-tab nav would discard the conversation the user is working through.
       target="_blank"

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -28,6 +28,10 @@ export const EVENT_NAMES = [
   "mount_switch",
   "purchase_click",
   "pwa_launch",
+  // AskIris: one per user turn (query text + how it originated), and a click from a
+  // recommendation card through to a lens — the funnel's ask and value actions.
+  "askiris_message",
+  "askiris_rec_click",
 ] as const;
 
 export type EventName = (typeof EVENT_NAMES)[number];


### PR DESCRIPTION
Adds analytics logging to AskIris, which previously had none.

Two events, tied by the anonymous session id into a usage funnel:
- a per-turn interaction event
- a recommendation-card click-through (`lens_id` + `source`)

Reuses the existing analytics pipeline (same `/api/track` sink and `EventProps` fields already whitelisted); the only schema change is the two event names. `RecommendationDeck` becomes a client component to wire the card `onClick`.

## Test
- Events fire as expected end-to-end.
- `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)