### PR TITLE
feat(askiris): harden chat client error handling

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,6 +13,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { getAgentModel, agentProviderOptions } from "@/lib/ai/model";
 import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
+import { chatErrorResponse } from "@/lib/ai/chat-errors";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
 import type { Mount } from "@/lib/types";
@@ -96,7 +97,7 @@ const STEP_BUDGET = 8;
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
     console.error("[askiris] DEEPSEEK_API_KEY is not set");
-    return Response.json({ error: "Service temporarily unavailable", kind: "unavailable" }, { status: 500 });
+    return chatErrorResponse("Service temporarily unavailable", "unavailable", 500);
   }
 
   const parsed = chatRequestSchema.safeParse(await req.json());
@@ -104,7 +105,7 @@ export async function POST(req: Request) {
     // Keep the validator detail server-side; the client only ever sends this shape, so
     // a failure is a bug or abuse — surface a generic message, not the schema output.
     console.warn("[askiris] invalid request", z.prettifyError(parsed.error));
-    return Response.json({ error: "Invalid request", kind: "unavailable" }, { status: 400 });
+    return chatErrorResponse("Invalid request", "unavailable", 400);
   }
   const { messages, mount, locale } = parsed.data;
   const tAskIris = await getTranslations({ locale, namespace: "AskIris" });
@@ -122,7 +123,7 @@ export async function POST(req: Request) {
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);
       if (!verdict.ok) {
-        return Response.json({ error: tAskIris("rateLimited"), kind: "rate_limit" }, { status: 429 });
+        return chatErrorResponse(tAskIris("rateLimited"), "rate_limit", 429);
       }
     }
   } catch {
@@ -140,7 +141,7 @@ export async function POST(req: Request) {
     modelMessages = await convertToModelMessages(messages, { tools });
   } catch (error) {
     console.error("[askiris] failed to convert messages", error);
-    return Response.json({ error: "Invalid request", kind: "unavailable" }, { status: 400 });
+    return chatErrorResponse("Invalid request", "unavailable", 400);
   }
 
   const result = streamText({

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import {
   stepCountIs,
   streamText,
   toUIMessageStream,
+  type ModelMessage,
   type UIMessage,
 } from "ai";
 import { z } from "zod";
@@ -95,7 +96,7 @@ const STEP_BUDGET = 8;
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
     console.error("[askiris] DEEPSEEK_API_KEY is not set");
-    return Response.json({ error: "Service temporarily unavailable" }, { status: 500 });
+    return Response.json({ error: "Service temporarily unavailable", kind: "unavailable" }, { status: 500 });
   }
 
   const parsed = chatRequestSchema.safeParse(await req.json());
@@ -103,7 +104,7 @@ export async function POST(req: Request) {
     // Keep the validator detail server-side; the client only ever sends this shape, so
     // a failure is a bug or abuse — surface a generic message, not the schema output.
     console.warn("[askiris] invalid request", z.prettifyError(parsed.error));
-    return Response.json({ error: "Invalid request" }, { status: 400 });
+    return Response.json({ error: "Invalid request", kind: "unavailable" }, { status: 400 });
   }
   const { messages, mount, locale } = parsed.data;
   const tAskIris = await getTranslations({ locale, namespace: "AskIris" });
@@ -121,7 +122,7 @@ export async function POST(req: Request) {
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);
       if (!verdict.ok) {
-        return Response.json({ error: tAskIris("rateLimited") }, { status: 429 });
+        return Response.json({ error: tAskIris("rateLimited"), kind: "rate_limit" }, { status: 429 });
       }
     }
   } catch {
@@ -131,13 +132,22 @@ export async function POST(req: Request) {
   const tBrand = await getTranslations({ locale, namespace: "Brands" });
   const tools = buildLensTools(mount, locale, tBrand);
 
+  // Convert up front so a malformed history fails as a clean 400, not an uncaught
+  // throw. The same `tools` must reach convertToModelMessages and streamText:
+  // recommendLenses.toModelOutput runs during conversion to trim its model output.
+  let modelMessages: ModelMessage[];
+  try {
+    modelMessages = await convertToModelMessages(messages, { tools });
+  } catch (error) {
+    console.error("[askiris] failed to convert messages", error);
+    return Response.json({ error: "Invalid request", kind: "unavailable" }, { status: 400 });
+  }
+
   const result = streamText({
     model: getAgentModel(),
     providerOptions: agentProviderOptions,
     system: systemPrompt(mount, locale),
-    // Same `tools` on both calls: recommendLenses.toModelOutput runs inside
-    // convertToModelMessages, so it must see the tool to trim its model-facing output.
-    messages: await convertToModelMessages(messages, { tools }),
+    messages: modelMessages,
     tools,
     stopWhen: stepCountIs(STEP_BUDGET),
     // Reserve the last allowed step for a text answer: forcing toolChoice "none" means a
@@ -156,7 +166,11 @@ export async function POST(req: Request) {
       }
       const tokens = usage.totalTokens;
       if (rateKv && ip && waitUntil && typeof tokens === "number") {
-        waitUntil(recordTokens(rateKv, ip, tokens));
+        waitUntil(
+          recordTokens(rateKv, ip, tokens).catch((error) =>
+            console.error("[askiris] failed to record tokens", error),
+          ),
+        );
       }
     },
   });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -97,7 +97,7 @@ const STEP_BUDGET = 8;
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
     console.error("[askiris] DEEPSEEK_API_KEY is not set");
-    return chatErrorResponse("Service temporarily unavailable", "unavailable", 500);
+    return chatErrorResponse("unavailable", 500);
   }
 
   const parsed = chatRequestSchema.safeParse(await req.json());
@@ -105,10 +105,9 @@ export async function POST(req: Request) {
     // Keep the validator detail server-side; the client only ever sends this shape, so
     // a failure is a bug or abuse — surface a generic message, not the schema output.
     console.warn("[askiris] invalid request", z.prettifyError(parsed.error));
-    return chatErrorResponse("Invalid request", "unavailable", 400);
+    return chatErrorResponse("unavailable", 400);
   }
   const { messages, mount, locale } = parsed.data;
-  const tAskIris = await getTranslations({ locale, namespace: "AskIris" });
 
   // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
   // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
@@ -123,7 +122,7 @@ export async function POST(req: Request) {
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);
       if (!verdict.ok) {
-        return chatErrorResponse(tAskIris("rateLimited"), "rate_limit", 429);
+        return chatErrorResponse("rate_limit", 429);
       }
     }
   } catch {
@@ -141,7 +140,7 @@ export async function POST(req: Request) {
     modelMessages = await convertToModelMessages(messages, { tools });
   } catch (error) {
     console.error("[askiris] failed to convert messages", error);
-    return chatErrorResponse("Invalid request", "unavailable", 400);
+    return chatErrorResponse("unavailable", 400);
   }
 
   const result = streamText({

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -178,12 +178,14 @@ export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: toUIMessageStream({
       stream: result.stream,
-      // Log the real provider error server-side (Workers Logs) but surface only a
-      // generic, localized message — this is a public endpoint, so the raw error
-      // (provider internals, quota/config hints) must not reach the client.
+      // Log the real provider error server-side (Workers Logs); this is a public
+      // endpoint, so the raw error (provider internals, quota/config hints) must not
+      // reach the client. The returned string only masks it in the stream — the
+      // client classifies a stream error as transient and shows its own copy — so a
+      // bare constant is enough, not prose.
       onError: (error) => {
         console.error("[askiris] stream error", error);
-        return tAskIris("streamError");
+        return "Stream error";
       },
     }),
   });

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -46,7 +46,13 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
   // transport — a mid-thread mount switch must reach the server on the very next
   // turn, and useChat doesn't re-adopt a rebuilt transport.
   const transport = useMemo(() => new DefaultChatTransport({ api: "/api/chat" }), []);
-  const { messages, sendMessage, status, setMessages, stop, regenerate } = useChat({ transport });
+  // Throttle message/store updates (~20fps): a long stream otherwise re-renders
+  // on every chunk, and with several message-derived effects that can trip React's
+  // update-depth limit on a slow connection.
+  const { messages, sendMessage, status, setMessages, stop, regenerate } = useChat({
+    transport,
+    experimental_throttle: 50,
+  });
 
   const isBusy = status === "submitted" || status === "streaming";
 
@@ -196,18 +202,21 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
           )}
           <AskIrisThread messages={renderMessages} locale={locale} debug={debug} busy={isBusy} />
           {/* Surface a failed turn: useChat catches request/stream errors into
-              status "error" but renders nothing on its own. Show a quiet line +
-              a retry that re-runs the last turn (with mount/locale, or it 400s). */}
+              status "error" but renders nothing on its own. The retry verb is
+              inline and re-runs the last turn (with mount/locale, or it 400s). */}
           {status === "error" && (
-            <div role="alert" className="flex items-center gap-3 px-1 text-sm text-zinc-500 dark:text-zinc-400">
-              <span>{t("streamError")}</span>
-              <button
-                type="button"
-                onClick={() => regenerate({ body: { mount, locale } })}
-                className="shrink-0 font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
-              >
-                {t("retry")}
-              </button>
+            <div role="alert" className="px-1 text-sm text-zinc-500 dark:text-zinc-400">
+              {t.rich("errorRetry", {
+                retry: (chunks) => (
+                  <button
+                    type="button"
+                    onClick={() => regenerate({ body: { mount, locale } })}
+                    className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
+                  >
+                    {chunks}
+                  </button>
+                ),
+              })}
             </div>
           )}
         </div>

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -6,6 +6,7 @@ import { DefaultChatTransport, type UIMessage } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
+import { isChatErrorKind, type ChatErrorKind } from "@/lib/ai/chat-errors";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { useScrollAffordance } from "@/hooks/useScrollAffordance";
 import { useTestHookOption } from "@/context/TestHookProvider";
@@ -27,18 +28,27 @@ import {
 // fresh below it, with only the live segment sent to the model.
 type ThreadItem = { kind: "seg"; messages: UIMessage[] } | { kind: "divider"; label: string };
 
-type ErrorKind = "transient" | "rate_limit" | "unavailable";
+// The client's display bucket = the server's ChatErrorKind plus "transient" (an
+// untagged stream/network error, where a retry may actually succeed).
+type ErrorDisplay = ChatErrorKind | "transient";
+
+// Which localized copy each non-transient kind shows. A Record, so adding a
+// ChatErrorKind server-side won't typecheck until a message is chosen here too.
+const ERROR_MESSAGE_KEY: Record<ChatErrorKind, "rateLimited" | "errorUnavailable"> = {
+  rate_limit: "rateLimited",
+  unavailable: "errorUnavailable",
+};
 
 // Sort a failed turn into how the user should react. The transport throws with the
 // raw response body as the Error message on a non-2xx pre-flight failure (no status
 // code preserved), so the route tags those bodies with a `kind` and we read it back
 // here. A stream or network error carries no such body — JSON.parse fails and we
 // treat it as transient, where a retry may actually succeed.
-function classifyError(error: Error | undefined): ErrorKind {
+function classifyError(error: Error | undefined): ErrorDisplay {
   if (error) {
     try {
       const body = JSON.parse(error.message) as { kind?: unknown };
-      if (body.kind === "rate_limit" || body.kind === "unavailable") {
+      if (isChatErrorKind(body.kind)) {
         return body.kind;
       }
     } catch {
@@ -244,7 +254,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
                   ),
                 })
               ) : (
-                <span>{t(errorKind === "rate_limit" ? "rateLimited" : "errorUnavailable")}</span>
+                <span>{t(ERROR_MESSAGE_KEY[errorKind])}</span>
               )}
             </div>
           )}

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -27,6 +27,27 @@ import {
 // fresh below it, with only the live segment sent to the model.
 type ThreadItem = { kind: "seg"; messages: UIMessage[] } | { kind: "divider"; label: string };
 
+type ErrorKind = "transient" | "rate_limit" | "unavailable";
+
+// Sort a failed turn into how the user should react. The transport throws with the
+// raw response body as the Error message on a non-2xx pre-flight failure (no status
+// code preserved), so the route tags those bodies with a `kind` and we read it back
+// here. A stream or network error carries no such body — JSON.parse fails and we
+// treat it as transient, where a retry may actually succeed.
+function classifyError(error: Error | undefined): ErrorKind {
+  if (error) {
+    try {
+      const body = JSON.parse(error.message) as { kind?: unknown };
+      if (body.kind === "rate_limit" || body.kind === "unavailable") {
+        return body.kind;
+      }
+    } catch {
+      // Not a tagged body — fall through to transient.
+    }
+  }
+  return "transient";
+}
+
 // Experimental AskIris chat. Two states on one route: an empty-state landing
 // (centered hero) before the first message, and the chat thread after. mount
 // comes from the effective-mount preference and locale from the route; both go
@@ -49,12 +70,15 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
   // Throttle message/store updates (~20fps): a long stream otherwise re-renders
   // on every chunk, and with several message-derived effects that can trip React's
   // update-depth limit on a slow connection.
-  const { messages, sendMessage, status, setMessages, stop, regenerate } = useChat({
+  const { messages, sendMessage, status, setMessages, stop, regenerate, error } = useChat({
     transport,
     experimental_throttle: 50,
   });
 
   const isBusy = status === "submitted" || status === "streaming";
+  // Only a transient failure is worth a retry; a rate-limit needs a wait and a
+  // bad-request/outage will fail identically, so those drop the retry affordance.
+  const errorKind = status === "error" ? classifyError(error) : null;
 
   function submitText(text: string) {
     const trimmed = text.trim();
@@ -202,21 +226,26 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
           )}
           <AskIrisThread messages={renderMessages} locale={locale} debug={debug} busy={isBusy} />
           {/* Surface a failed turn: useChat catches request/stream errors into
-              status "error" but renders nothing on its own. The retry verb is
-              inline and re-runs the last turn (with mount/locale, or it 400s). */}
-          {status === "error" && (
+              status "error" but renders nothing on its own. Only the transient
+              case offers a retry (inline verb, re-runs the last turn with
+              mount/locale); a rate-limit or outage just states what happened. */}
+          {errorKind && (
             <div role="alert" className="px-1 text-sm text-zinc-500 dark:text-zinc-400">
-              {t.rich("errorRetry", {
-                retry: (chunks) => (
-                  <button
-                    type="button"
-                    onClick={() => regenerate({ body: { mount, locale } })}
-                    className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
-                  >
-                    {chunks}
-                  </button>
-                ),
-              })}
+              {errorKind === "transient" ? (
+                t.rich("errorRetry", {
+                  retry: (chunks) => (
+                    <button
+                      type="button"
+                      onClick={() => regenerate({ body: { mount, locale } })}
+                      className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
+                    >
+                      {chunks}
+                    </button>
+                  ),
+                })
+              ) : (
+                <span>{t(errorKind === "rate_limit" ? "rateLimited" : "errorUnavailable")}</span>
+              )}
             </div>
           )}
         </div>

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -46,7 +46,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
   // transport — a mid-thread mount switch must reach the server on the very next
   // turn, and useChat doesn't re-adopt a rebuilt transport.
   const transport = useMemo(() => new DefaultChatTransport({ api: "/api/chat" }), []);
-  const { messages, sendMessage, status, setMessages, stop } = useChat({ transport });
+  const { messages, sendMessage, status, setMessages, stop, regenerate } = useChat({ transport });
 
   const isBusy = status === "submitted" || status === "streaming";
 
@@ -195,6 +195,21 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
             ),
           )}
           <AskIrisThread messages={renderMessages} locale={locale} debug={debug} busy={isBusy} />
+          {/* Surface a failed turn: useChat catches request/stream errors into
+              status "error" but renders nothing on its own. Show a quiet line +
+              a retry that re-runs the last turn (with mount/locale, or it 400s). */}
+          {status === "error" && (
+            <div role="alert" className="flex items-center gap-3 px-1 text-sm text-zinc-500 dark:text-zinc-400">
+              <span>{t("streamError")}</span>
+              <button
+                type="button"
+                onClick={() => regenerate({ body: { mount, locale } })}
+                className="shrink-0 font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
+              >
+                {t("retry")}
+              </button>
+            </div>
+          )}
         </div>
         {/* Edge fades as overlays (not a container mask) so the scrollbar stays
             crisp; each shows only when there's more thread that way. Inset from

--- a/src/lib/ai/chat-errors.ts
+++ b/src/lib/ai/chat-errors.ts
@@ -1,0 +1,21 @@
+// The wire contract for a tagged /api/chat error body. `kind` tells the client how
+// the user should react to a pre-flight failure — a single source of truth shared by
+// the route (which emits it) and the chat client (which maps it to a display bucket,
+// adding its own "transient" for an untagged stream/network error).
+//
+// A const array (not a TS enum) so the values are enumerable at runtime for the
+// client's membership check, matching how the rest of the app models closed sets
+// (MOUNTS, RECALL_SORT_FIELDS).
+export const CHAT_ERROR_KINDS = ["rate_limit", "unavailable"] as const;
+
+export type ChatErrorKind = (typeof CHAT_ERROR_KINDS)[number];
+
+export function isChatErrorKind(value: unknown): value is ChatErrorKind {
+  return typeof value === "string" && (CHAT_ERROR_KINDS as readonly string[]).includes(value);
+}
+
+// Build the tagged error body the client reads back off the thrown Error's message
+// (the transport surfaces a non-2xx body verbatim there). One place owns the shape.
+export function chatErrorResponse(message: string, kind: ChatErrorKind, status: number): Response {
+  return Response.json({ error: message, kind }, { status });
+}

--- a/src/lib/ai/chat-errors.ts
+++ b/src/lib/ai/chat-errors.ts
@@ -15,7 +15,9 @@ export function isChatErrorKind(value: unknown): value is ChatErrorKind {
 }
 
 // Build the tagged error body the client reads back off the thrown Error's message
-// (the transport surfaces a non-2xx body verbatim there). One place owns the shape.
-export function chatErrorResponse(message: string, kind: ChatErrorKind, status: number): Response {
-  return Response.json({ error: message, kind }, { status });
+// (the transport surfaces a non-2xx body verbatim there). The client keys its own
+// localized copy off `kind`, so the body carries only that — never a message the
+// user won't see. One place owns the shape.
+export function chatErrorResponse(kind: ChatErrorKind, status: number): Response {
+  return Response.json({ kind }, { status });
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -49,7 +49,8 @@
     "newChat": "New chat",
     "newTopic": "New topic",
     "rateLimited": "Iris is taking a lot of questions right now — please try again in a little while.",
-    "streamError": "Something went wrong on Iris's side — please try again."
+    "streamError": "Something went wrong on Iris's side — please try again.",
+    "retry": "Retry"
   },
   "Search": {
     "open": "Open lens search",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -50,7 +50,7 @@
     "newTopic": "New topic",
     "rateLimited": "Iris is taking a lot of questions right now — please try again in a little while.",
     "streamError": "Something went wrong on Iris's side — please try again.",
-    "retry": "Retry"
+    "errorRetry": "Something went wrong on Iris's side — please <retry>try again</retry>."
   },
   "Search": {
     "open": "Open lens search",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -50,7 +50,8 @@
     "newTopic": "New topic",
     "rateLimited": "Iris is taking a lot of questions right now — please try again in a little while.",
     "streamError": "Something went wrong on Iris's side — please try again.",
-    "errorRetry": "Something went wrong on Iris's side — please <retry>try again</retry>."
+    "errorRetry": "Something went wrong on Iris's side — please <retry>try again</retry>.",
+    "errorUnavailable": "Iris is unavailable right now — please try again later."
   },
   "Search": {
     "open": "Open lens search",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -49,7 +49,6 @@
     "newChat": "New chat",
     "newTopic": "New topic",
     "rateLimited": "Iris is taking a lot of questions right now — please try again in a little while.",
-    "streamError": "Something went wrong on Iris's side — please try again.",
     "errorRetry": "Something went wrong on Iris's side — please <retry>try again</retry>.",
     "errorUnavailable": "Iris is unavailable right now — please try again later."
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -50,7 +50,8 @@
     "newTopic": "新话题",
     "rateLimited": "Iris 现在有点忙，稍后再试。",
     "streamError": "Iris 这边出了点问题，请重试。",
-    "errorRetry": "Iris 这边出了点问题，请<retry>重试</retry>。"
+    "errorRetry": "Iris 这边出了点问题，请<retry>重试</retry>。",
+    "errorUnavailable": "Iris 暂时无法使用，请稍后再来。"
   },
   "Search": {
     "open": "打开镜头搜索",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -49,7 +49,6 @@
     "newChat": "新对话",
     "newTopic": "新话题",
     "rateLimited": "Iris 现在有点忙，稍后再试。",
-    "streamError": "Iris 这边出了点问题，请重试。",
     "errorRetry": "Iris 这边出了点问题，请<retry>重试</retry>。",
     "errorUnavailable": "Iris 暂时无法使用，请稍后再来。"
   },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -49,7 +49,8 @@
     "newChat": "新对话",
     "newTopic": "新话题",
     "rateLimited": "Iris 现在有点忙，稍后再试。",
-    "streamError": "Iris 这边出了点问题，请重试。"
+    "streamError": "Iris 这边出了点问题，请重试。",
+    "retry": "重试"
   },
   "Search": {
     "open": "打开镜头搜索",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -50,7 +50,7 @@
     "newTopic": "新话题",
     "rateLimited": "Iris 现在有点忙，稍后再试。",
     "streamError": "Iris 这边出了点问题，请重试。",
-    "retry": "重试"
+    "errorRetry": "Iris 这边出了点问题，请<retry>重试</retry>。"
   },
   "Search": {
     "open": "打开镜头搜索",


### PR DESCRIPTION
## What
Audited every error surface across the chat lifecycle and fixed how the client handles them. Previously any failure rendered one generic message with a retry — but retry only helps a *transient* failure.

## Changes
- **Classify errors into three buckets** (retry only where it helps):
  - `transient` (network drop, mid-stream provider blip) → generic message + **Retry**.
  - `rate_limit` (429) → "busy, try again later", **no retry** (an instant retry just re-429s).
  - `unavailable` (missing key 500, bad request 400) → "unavailable", **no retry** (an identical request fails identically).
  - The transport throws with the raw response body as the `Error` message and no status code, so the route tags error bodies with a `kind` and the client reads it back — defaulting to `transient` when there's no tagged body (a stream/network error).
- **Inline retry**: the retry verb lives in the sentence (`t.rich`), not a separate button.
- **Throttle streaming updates** (`experimental_throttle`): a long/slow stream re-rendered per chunk and, with several message-derived effects, could trip React's update-depth limit on a throttled connection (AI SDK's documented mitigation).
- **Edge guards** the audit surfaced: `convertToModelMessages` wrapped (malformed history → clean 400, not an uncaught throw); `recordTokens` rejections caught inside `waitUntil`.

## Test plan
- `tsc --noEmit` + eslint clean; both message JSONs valid.
- Reproduce error states via DevTools Network (Offline → transient/retry; a forced 429/500 → no-retry variants). Client-side visual confirmation still pending a browser check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)