### PR TITLE
feat(askiris): guard recommendations against un-recalled lenses

### DIFF
--- a/src/lib/ai/recall.ts
+++ b/src/lib/ai/recall.ts
@@ -458,24 +458,32 @@ export function recallLenses(
 }
 
 // Look up lenses by id and resolve them, attaching the model's authored reason.
-// Ids the model invented (not in this mount's set) are dropped.
+// recalledIds is every id this turn's tool calls have returned, so a pick outside it
+// is a lens the model never recalled here.
 export function recommendLenses(
   mount: Mount,
   locale: string,
   picks: { id: string; reason: string }[],
   tBrand: (brand: string) => string,
+  recalledIds: Set<string>,
 ): { recommendations: Recommendation[] } {
   const byId = new Map(getLensesByMount(mount, locale).map((lens) => [lens.id, lens]));
   const recommendations = picks.map((pick) => {
-    const lens = byId.get(pick.id);
-    // Fail loud on an id we can't resolve: dropping it silently would render fewer
-    // cards than the model intended (or none). The SDK surfaces this as a tool-error
-    // and the model retries with the exact id inside its step budget.
-    if (!lens) {
+    // Fail loud on a lens the model never recalled — one it conjured from memory or
+    // an id it altered. Only ids returned by a queryLenses/searchLensByName call this
+    // turn are allowed; the SDK surfaces the throw as a tool-error, so the model
+    // recalls the lens and retries with the exact id inside its step budget.
+    if (!recalledIds.has(pick.id)) {
       throw new Error(
-        `Unknown lens id "${pick.id}". Pass each id exactly as it appears in a prior ` +
-          `queryLenses/searchLensByName result — don't alter or shorten it.`,
+        `Lens id "${pick.id}" was not returned by any queryLenses/searchLensByName ` +
+          `call this turn. Recommend only lenses you've recalled — look it up first, ` +
+          `and pass the id exactly as it appears.`,
       );
+    }
+    const lens = byId.get(pick.id);
+    if (!lens) {
+      // recalledIds only ever holds ids from real tool results, so this is defensive.
+      throw new Error(`Unknown lens id "${pick.id}".`);
     }
     return { ...resolveLens(lens, locale, tBrand), reason: pick.reason };
   });

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -6,32 +6,6 @@ import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens/search";
 import { recallLenses, recommendLenses, resolveLens, RECALL_SORT_FIELDS } from "@/lib/ai/recall";
 import { OPTICAL_TRAITS, type Mount } from "@/lib/types";
 
-// Collect the lens ids in a tool's output. Shapes differ across tools — matches and
-// results hold the lens directly (item.id), maybe wraps it (item.lens.id) — so check
-// both, or a recalled "maybe" lens would look un-recalled to the recommend guard.
-function idsFromOutput(output: unknown): string[] {
-  const ids: string[] = [];
-  if (output && typeof output === "object") {
-    for (const value of Object.values(output as Record<string, unknown>)) {
-      if (!Array.isArray(value)) {
-        continue;
-      }
-      for (const item of value) {
-        if (item && typeof item === "object") {
-          const record = item as { id?: unknown; lens?: { id?: unknown } };
-          if (typeof record.id === "string") {
-            ids.push(record.id);
-          }
-          if (record.lens && typeof record.lens.id === "string") {
-            ids.push(record.lens.id);
-          }
-        }
-      }
-    }
-  }
-  return ids;
-}
-
 // The agent's tools, bound to the current mount + locale (both fixed by the
 // route, never model-supplied). Parameter semantics live in `.describe()` so the
 // model learns them from the tool schema, not the system prompt.
@@ -155,8 +129,13 @@ export function buildLensTools(
       }),
       execute: (constraints) => {
         const result = recallLenses(mount, locale, constraints, tBrand);
-        for (const id of idsFromOutput(result)) {
-          recalledIds.add(id);
+        // Record what this call surfaced so recommendLenses can check its picks. Both
+        // buckets are shown to the user; matches hold the lens directly, maybe wraps it.
+        for (const lens of result.matches) {
+          recalledIds.add(lens.id);
+        }
+        for (const { lens } of result.maybe) {
+          recalledIds.add(lens.id);
         }
         return result;
       },
@@ -173,11 +152,10 @@ export function buildLensTools(
       execute: ({ query, limit }) => {
         const index = buildLensSearchIndex(getLensesByMount(mount, locale));
         const results = searchLensIndex(index, query, limit ?? 8);
-        const output = { results: results.map((lens) => resolveLens(lens, locale, tBrand)) };
-        for (const id of idsFromOutput(output)) {
-          recalledIds.add(id);
+        for (const lens of results) {
+          recalledIds.add(lens.id);
         }
-        return output;
+        return { results: results.map((lens) => resolveLens(lens, locale, tBrand)) };
       },
     }),
 

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -6,6 +6,32 @@ import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens/search";
 import { recallLenses, recommendLenses, resolveLens, RECALL_SORT_FIELDS } from "@/lib/ai/recall";
 import { OPTICAL_TRAITS, type Mount } from "@/lib/types";
 
+// Collect the lens ids in a tool's output. Shapes differ across tools — matches and
+// results hold the lens directly (item.id), maybe wraps it (item.lens.id) — so check
+// both, or a recalled "maybe" lens would look un-recalled to the recommend guard.
+function idsFromOutput(output: unknown): string[] {
+  const ids: string[] = [];
+  if (output && typeof output === "object") {
+    for (const value of Object.values(output as Record<string, unknown>)) {
+      if (!Array.isArray(value)) {
+        continue;
+      }
+      for (const item of value) {
+        if (item && typeof item === "object") {
+          const record = item as { id?: unknown; lens?: { id?: unknown } };
+          if (typeof record.id === "string") {
+            ids.push(record.id);
+          }
+          if (record.lens && typeof record.lens.id === "string") {
+            ids.push(record.lens.id);
+          }
+        }
+      }
+    }
+  }
+  return ids;
+}
+
 // The agent's tools, bound to the current mount + locale (both fixed by the
 // route, never model-supplied). Parameter semantics live in `.describe()` so the
 // model learns them from the tool schema, not the system prompt.
@@ -14,6 +40,11 @@ export function buildLensTools(
   locale: string,
   tBrand: (brand: string) => string,
 ) {
+  // Every lens id this turn's query/search calls have returned, so recommendLenses
+  // can reject a pick the model never recalled. Turn-scoped: a lens recalled only in
+  // an earlier turn must be looked up again before it can be recommended.
+  const recalledIds = new Set<string>();
+
   return {
     queryLenses: tool({
       description:
@@ -122,7 +153,13 @@ export function buildLensTools(
           ),
         sortDir: z.enum(["asc", "desc"]).optional().describe("asc (default) = smallest first."),
       }),
-      execute: (constraints) => recallLenses(mount, locale, constraints, tBrand),
+      execute: (constraints) => {
+        const result = recallLenses(mount, locale, constraints, tBrand);
+        for (const id of idsFromOutput(result)) {
+          recalledIds.add(id);
+        }
+        return result;
+      },
     }),
 
     searchLensByName: tool({
@@ -136,7 +173,11 @@ export function buildLensTools(
       execute: ({ query, limit }) => {
         const index = buildLensSearchIndex(getLensesByMount(mount, locale));
         const results = searchLensIndex(index, query, limit ?? 8);
-        return { results: results.map((lens) => resolveLens(lens, locale, tBrand)) };
+        const output = { results: results.map((lens) => resolveLens(lens, locale, tBrand)) };
+        for (const id of idsFromOutput(output)) {
+          recalledIds.add(id);
+        }
+        return output;
       },
     }),
 
@@ -162,7 +203,7 @@ export function buildLensTools(
           .min(1)
           .max(6),
       }),
-      execute: ({ picks }) => recommendLenses(mount, locale, picks, tBrand),
+      execute: ({ picks }) => recommendLenses(mount, locale, picks, tBrand, recalledIds),
       // Full recommendations stream to the client (the cards); the model already
       // saw these lenses in the query result, so feed it a lean ack, not the specs
       // again. Requires passing this same ToolSet to convertToModelMessages.


### PR DESCRIPTION
## What
`recommendLenses` previously only rejected an id absent from the catalogue (a pure fabrication). It now rejects any pick the model didn't actually **recall this turn** — a pre-execution grounding guardrail that promotes the eval's *picks ⊆ recalled* check into a hard runtime guarantee.

## How
- `queryLenses` / `searchLensByName` accumulate their returned ids into a turn-scoped `recalledIds` set, held in the `buildLensTools` closure. The extractor handles both output shapes — a lens carried directly (`item.id`, matches/results) and wrapped (`item.lens.id`, `maybe`) — so a recalled "maybe" lens isn't falsely rejected.
- `recommendLenses` throws on a pick outside the set; the SDK surfaces that as a tool-error, so the model recalls the lens and retries with the exact id inside its step budget.

## Scope decision
Turn-scoped on purpose: a lens recalled only in an *earlier* turn must be looked up again before it can be recommended. This keeps the guard free of message-history reconstruction (and its coupling to output shapes); the cost is an occasional re-query when a user references a lens across turns, which the model self-heals.

## Test plan
- `tsc --noEmit` + eslint clean.
- Behavior is covered by the eval harness (`eval/askiris`, *picks ⊆ recalled*) — recommend running it to confirm the model self-heals rather than looping to budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)