### PR TITLE
feat(askiris): per-turn metrics to Analytics Engine + stream timeout

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -121,12 +121,12 @@ export async function POST(req: Request) {
   const ip = clientIp(req);
   let rateKv: KVNamespace | undefined;
   let ae: AnalyticsEngineDataset | undefined;
-  let waitUntil: ((p: Promise<unknown>) => void) | undefined;
+  let ctx: ExecutionContext | undefined;
   try {
-    const { env, ctx } = getCloudflareContext();
-    rateKv = (env as CloudflareEnv).RATE_KV;
-    ae = (env as CloudflareEnv).ANALYTICS;
-    waitUntil = ctx.waitUntil.bind(ctx);
+    const cf = getCloudflareContext();
+    rateKv = (cf.env as CloudflareEnv).RATE_KV;
+    ae = (cf.env as CloudflareEnv).ANALYTICS;
+    ctx = cf.ctx;
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);
       if (!verdict.ok) {
@@ -190,8 +190,8 @@ export async function POST(req: Request) {
         }
       }
       const tokens = usage.totalTokens;
-      if (rateKv && ip && waitUntil && typeof tokens === "number") {
-        waitUntil(
+      if (rateKv && ip && ctx && typeof tokens === "number") {
+        ctx.waitUntil(
           recordTokens(rateKv, ip, tokens).catch((error) =>
             console.error("[askiris] failed to record tokens", error),
           ),

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -124,8 +124,8 @@ export async function POST(req: Request) {
   let ctx: ExecutionContext | undefined;
   try {
     const cf = getCloudflareContext();
-    rateKv = (cf.env as CloudflareEnv).RATE_KV;
-    ae = (cf.env as CloudflareEnv).ANALYTICS;
+    rateKv = cf.env.RATE_KV;
+    ae = cf.env.ANALYTICS;
     ctx = cf.ctx;
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import { getAgentModel, agentProviderOptions } from "@/lib/ai/model";
 import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
+import { askirisTurnDataPoint } from "@/lib/analytics/events";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
 import type { Mount } from "@/lib/types";
@@ -94,6 +95,11 @@ const chatRequestSchema = z.object({
 // calls). Bounds worst-case cost/latency; shared by stopWhen and the budget-hit log.
 const STEP_BUDGET = 8;
 
+// Hard ceiling on one turn's streaming, so a stuck provider connection can't hang the
+// request indefinitely. Generous — a legit multi-step turn on a slow provider runs
+// tens of seconds; this only bites a true hang.
+const STREAM_TIMEOUT_MS = 120_000;
+
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
     console.error("[askiris] DEEPSEEK_API_KEY is not set");
@@ -114,10 +120,12 @@ export async function POST(req: Request) {
   // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
   const ip = clientIp(req);
   let rateKv: KVNamespace | undefined;
+  let ae: AnalyticsEngineDataset | undefined;
   let waitUntil: ((p: Promise<unknown>) => void) | undefined;
   try {
     const { env, ctx } = getCloudflareContext();
     rateKv = (env as CloudflareEnv).RATE_KV;
+    ae = (env as CloudflareEnv).ANALYTICS;
     waitUntil = ctx.waitUntil.bind(ctx);
     if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
       const verdict = await checkRateLimit(rateKv, ip);
@@ -150,19 +158,36 @@ export async function POST(req: Request) {
     messages: modelMessages,
     tools,
     stopWhen: stepCountIs(STEP_BUDGET),
+    // Cap total streaming time so a stuck provider connection can't hang the request.
+    abortSignal: AbortSignal.timeout(STREAM_TIMEOUT_MS),
     // Reserve the last allowed step for a text answer: forcing toolChoice "none" means a
     // turn that reaches the budget ends with a synthesis, not a frozen dangling tool call.
     prepareStep: ({ stepNumber }) =>
       stepNumber >= STEP_BUDGET - 1 ? { toolChoice: "none" } : undefined,
-    // Fold the finished turn's real token usage (summed across all steps) into the
-    // daily budgets. waitUntil keeps the write alive past the streamed response.
+    // On turn end: emit one metrics row to AE and fold the token usage into the daily
+    // budgets. waitUntil keeps the KV write alive past the streamed response.
     onEnd: ({ usage, stepNumber }) => {
-      // The last allowed step is forced to a text answer (prepareStep), so a turn that
-      // spends its whole budget ends on that wrap-up step. Detect the budget biting by
-      // the final step index reaching the cap — the model was still calling tools and
-      // got cut off. (finishReason can't reveal this: the forced step ends on "stop".)
-      if (stepNumber >= STEP_BUDGET - 1) {
-        console.warn(`[askiris] step budget (${STEP_BUDGET}) reached — turn forced to wrap up at final step`);
+      // Record the finished turn as one AE row (server-only — the client can't see
+      // token usage). The last allowed step is forced to a text answer, so a turn that
+      // spent its whole budget ends on that wrap-up step; the final step index reaching
+      // the cap is how the budget biting is detected (finishReason can't — it's "stop").
+      if (ae) {
+        try {
+          ae.writeDataPoint(
+            askirisTurnDataPoint({
+              mount,
+              locale,
+              totalTokens: usage.totalTokens ?? 0,
+              inputTokens: usage.inputTokens ?? 0,
+              outputTokens: usage.outputTokens ?? 0,
+              cacheReadTokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
+              stepCount: stepNumber + 1,
+              budgetHit: stepNumber >= STEP_BUDGET - 1,
+            }),
+          );
+        } catch (error) {
+          console.error("[askiris] failed to write turn metrics", error);
+        }
       }
       const tokens = usage.totalTokens;
       if (rateKv && ip && waitUntil && typeof tokens === "number") {

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -135,7 +135,7 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   try {
     const { env } = getCloudflareContext();
-    const ae = (env as CloudflareEnv).ANALYTICS;
+    const ae = env.ANALYTICS;
     if (ae) {
       ae.writeDataPoint(toDataPoint(event, sid, locale, props, internal));
     }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -124,3 +124,42 @@ export function toDataPoint(
     doubles: [primaryNumber],
   };
 }
+
+// AskIris per-turn metrics, written straight to AE from the chat route's onEnd —
+// server-only (the client never sees token usage), so it skips the /api/track path.
+// Its own positional layout in the same dataset; query it by the index. Token counts
+// can be missing from a provider, recorded as 0.
+//   indexes: [askiris_turn]
+//   blobs:   [mount, locale]
+//   doubles: [total, input, output, cacheRead tokens, step_count, budget_hit]
+export const ASKIRIS_TURN_EVENT = "askiris_turn";
+
+export interface AskIrisTurnMetrics {
+  mount: string;
+  locale: string;
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  stepCount: number;
+  budgetHit: boolean;
+}
+
+export function askirisTurnDataPoint(m: AskIrisTurnMetrics): {
+  indexes: [string];
+  blobs: [string, string];
+  doubles: [number, number, number, number, number, number];
+} {
+  return {
+    indexes: [ASKIRIS_TURN_EVENT],
+    blobs: [m.mount, m.locale],
+    doubles: [
+      m.totalTokens,
+      m.inputTokens,
+      m.outputTokens,
+      m.cacheReadTokens,
+      m.stepCount,
+      m.budgetHit ? 1 : 0,
+    ],
+  };
+}


### PR DESCRIPTION
## What
Wave 1.3 — the telemetry root. The chat route's `onEnd` now records one Analytics Engine row per finished turn, and a hard timeout caps a single turn's streaming.

## Metrics
- Written straight to AE from `onEnd` (server-only — the client never sees token usage), on the same `ANALYTICS` binding as `/api/track` but with its own positional layout, documented in `events.ts` and queried by index:
  - `indexes: [askiris_turn]`
  - `blobs: [mount, locale]`
  - `doubles: [total, input, output, cacheRead tokens, step_count, budget_hit]`
- The step-budget signal moves off `console.warn` into the `budget_hit` double.
- AE `writeDataPoint` is synchronous fire-and-forget (guarded — a missing binding in `next dev` just skips it).

## Timeout
- `abortSignal: AbortSignal.timeout(120_000)` on `streamText` — generous ceiling so a stuck provider connection can't hang the request; a legit multi-step turn stays well under it.

## Follow-up (not in this PR)
- The admin dashboard consuming these rows (`WHERE index1 = 'askiris_turn'`) — the layout in `events.ts` is its contract.

## Test plan
- `tsc --noEmit` + eslint clean; CI's workerd smoke test exercises the route on the real runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)