### PR TITLE
test(recall): component-level recall/precision + truncation-bias eval

### DIFF
--- a/src/lib/ai/__tests__/recall.test.ts
+++ b/src/lib/ai/__tests__/recall.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { recallLenses, type LensConstraints, type ResolvedLens } from "../recall";
+
+// Component-level eval for the recall layer — the engine behind the queryLenses tool.
+// recallLenses is a pure, deterministic function over the static lens catalogue (no LLM),
+// so recall, precision, and truncation behaviour can be asserted directly against ground
+// truth in CI, without a DeepSeek call or a judge.
+//
+// Ground truth without hand-labelling: recallLenses' own maxCount is the seam. A call with
+// maxCount = ALL returns the complete match set M (evaluate() is the deterministic oracle);
+// a call with maxCount = RECALL_LIMIT returns what the model actually receives. recall@N and
+// truncation loss are then M vs the capped set — no re-implementation of the filter to drift.
+
+const MOUNT = "X" as const;
+const LOCALE = "en";
+const RECALL_LIMIT = 20; // mirrors tools.ts — what the model receives per queryLenses call
+const ALL = Number.POSITIVE_INFINITY; // uncapped: the full ground-truth match set
+const TOL = 0.1; // FOCAL_MATCH_TOLERANCE in recall.ts — coversFocals is matched within this
+const tBrand = (brand: string) => brand; // brand translation isn't under test
+
+function recall(constraints: LensConstraints, maxCount: number) {
+  return recallLenses(MOUNT, LOCALE, constraints, tBrand, maxCount);
+}
+const idsOf = (lenses: ResolvedLens[]) => lenses.map((l) => l.id);
+const wideAperture = (a: ResolvedLens["maxAperture"]): number | null =>
+  a == null ? null : Array.isArray(a) ? a[0] : a;
+// Mirrors evaluate()'s coversFocals predicate: the point sits inside the lens's native
+// focal range, widened by the tolerance at both ends.
+const coversNative = (lens: ResolvedLens, point: number) => {
+  const [min, max] = lens.focalNativeMm;
+  return min * (1 - TOL) <= point && point <= max * (1 + TOL);
+};
+
+describe("recallLenses · filter correctness (precision / recall on labelled queries)", () => {
+  it("fast portrait primes: prime, covers 56mm native, wide aperture <= f/1.4", () => {
+    const c: LensConstraints = { type: "prime", coversFocals: [56], maxApertureF: { wide: 1.4 } };
+    const { matches } = recall(c, ALL);
+    const ids = idsOf(matches);
+
+    // must-include: the canonical 56mm portrait primes across brands
+    expect(ids).toContain("fujifilm-xf-56mmf12-r-x");
+    expect(ids).toContain("viltrox-af-56mm-f14-x");
+    expect(ids).toContain("sigma-contemporary-56mm-f14-dc-dn-x");
+
+    // must-exclude: a 56mm prime a hair too slow (f/1.7), and a telephoto zoom
+    expect(ids).not.toContain("viltrox-af-56mm-f17-air-x");
+    expect(ids).not.toContain("fujifilm-xf-70-300mmf4-56-r-lm-ois-wr-x");
+
+    // precision: every returned lens genuinely satisfies the query
+    for (const lens of matches) {
+      const [min, max] = lens.focalNativeMm;
+      expect(min).toBe(max); // prime
+      expect(coversNative(lens, 56)).toBe(true);
+      expect(wideAperture(lens.maxAperture)).not.toBeNull();
+      expect(wideAperture(lens.maxAperture) as number).toBeLessThanOrEqual(1.4);
+    }
+  });
+
+  it("telephoto zooms reaching 300mm native: includes the long Fuji zooms, excludes primes", () => {
+    const c: LensConstraints = { type: "zoom", coversFocals: [300] };
+    const { matches } = recall(c, ALL);
+    const ids = idsOf(matches);
+
+    expect(ids).toContain("fujifilm-xf-70-300mmf4-56-r-lm-ois-wr-x");
+    expect(ids).toContain("fujifilm-xf-100-400mmf45-56-r-lm-ois-wr-x");
+    expect(ids).toContain("fujifilm-xf-150-600mmf56-8-r-lm-ois-wr-x");
+    expect(ids).not.toContain("fujifilm-xf-56mmf12-r-x"); // a prime
+
+    for (const lens of matches) {
+      const [min, max] = lens.focalNativeMm;
+      expect(min).not.toBe(max); // zoom
+      expect(coversNative(lens, 300)).toBe(true);
+    }
+  });
+
+  it("compact & light primes under 200g: every returned lens obeys the weight bound", () => {
+    const c: LensConstraints = { type: "prime", maxWeightG: 200 };
+    const { matches } = recall(c, ALL);
+
+    expect(matches.length).toBeGreaterThan(0);
+    expect(idsOf(matches)).toContain("viltrox-af-56mm-f17-air-x"); // a known 171g prime
+    for (const lens of matches) {
+      // maxWeightG demotes missing-weight lenses to `maybe`, so every match has a weight.
+      expect(lens.weightG).not.toBeNull();
+      expect(lens.weightG as number).toBeLessThanOrEqual(200);
+    }
+  });
+});
+
+describe("recallLenses · truncation (the wideEnd-bias validation vehicle)", () => {
+  // "Show me zooms" over-matches (35 zooms > RECALL_LIMIT). The default sort is wideEnd
+  // ascending, so the cap keeps the 20 widest zooms and silently drops the most telephoto
+  // ones — regardless of what the user actually wanted.
+  const zooms: LensConstraints = { type: "zoom" };
+
+  it("caps at RECALL_LIMIT while reporting the honest full match count", () => {
+    const full = recall(zooms, ALL);
+    const capped = recall(zooms, RECALL_LIMIT);
+
+    expect(full.totalMatched).toBeGreaterThan(RECALL_LIMIT); // truncation is actually active
+    expect(capped.matches.length).toBe(RECALL_LIMIT);
+    expect(capped.totalMatched).toBe(full.totalMatched); // count stays honest under the cap
+    // the capped set is exactly the top slice of the full set — nothing conjured, only dropped
+    expect(idsOf(capped.matches)).toEqual(idsOf(full.matches).slice(0, RECALL_LIMIT));
+  });
+
+  it("recall@20 < 1: the cap drops real matches", () => {
+    const full = recall(zooms, ALL);
+    const capped = recall(zooms, RECALL_LIMIT);
+    expect(capped.matches.length / full.totalMatched).toBeLessThan(1);
+  });
+
+  it("documents the directional bias: a genuine telephoto match is dropped by the wide-first cap", () => {
+    // This lens is a true match (a zoom) sitting at the tele extreme — widest focal 150mm
+    // native = 225mm-equiv, the largest wideEnd among zooms — so the wideEnd-asc sort ranks
+    // it last and the cap removes it. For a user asking about reach, the single most relevant
+    // lens is the one that disappears: the bug the truncation-bias task fixes. When the cap is
+    // made intent-aware, this expectation flips (the tele lens should be kept) — update it then.
+    const tele = "fujifilm-xf-150-600mmf56-8-r-lm-ois-wr-x";
+    expect(idsOf(recall(zooms, ALL).matches)).toContain(tele); // it IS a match
+    expect(idsOf(recall(zooms, RECALL_LIMIT).matches)).not.toContain(tele); // but the cap drops it
+  });
+});

--- a/src/lib/ai/recall.ts
+++ b/src/lib/ai/recall.ts
@@ -49,9 +49,10 @@ export interface LensConstraints {
   usage?: "photo" | "cine";
   features?: FilterFeatureKey[];
   opticalTraits?: OpticalTrait[];
-  // Full-frame-equivalent millimetres. The lens must be able to shoot at each.
+  // Native millimetres (the number printed on the lens). The lens must be able to
+  // shoot at each, matched within a small tolerance.
   coversFocals?: number[];
-  // Full-frame-equivalent millimetres. The lens's whole range must sit inside.
+  // Native millimetres. The lens's whole focal range must sit inside this window.
   focalWithin?: [number | null, number | null];
   maxWeightG?: number;
   // Physical barrel length ceiling in mm (compact / pocketable).
@@ -133,15 +134,12 @@ export type ResolvedLens = Pick<
 // A resolved lens the model has chosen to recommend, carrying its authored reason.
 export type Recommendation = ResolvedLens & { reason: string };
 
-// Cap per recall; totalMatched/totalMaybe still report the full counts.
-const MAX_RECALL_RESULTS = 20;
-
 // coversFocals is matched on native mm within this fraction, so a "56" request
 // still catches a 55mm lens (same class) and never misses a prime by a hair.
 const FOCAL_MATCH_TOLERANCE = 0.1;
 
 export interface RecallResult {
-  // Capped to the top MAX_RECALL_RESULTS by the active sort.
+  // Capped to the top `maxCount` (see recallLenses) by the active sort.
   matches: ResolvedLens[];
   maybe: { lens: ResolvedLens; missingFields: string[] }[];
   totalMatched: number;
@@ -419,6 +417,10 @@ export function recallLenses(
   locale: string,
   constraints: LensConstraints,
   tBrand: (brand: string) => string,
+  // Cap on matches and maybes returned, applied after the active sort;
+  // totalMatched/totalMaybe still report the full pre-cap counts. queryLenses fixes
+  // this at RECALL_LIMIT; tests vary it to inspect the full (uncapped) match set.
+  maxCount: number,
 ): RecallResult {
   const lenses = getLensesByMount(mount, locale);
   const matched: Lens[] = [];
@@ -446,9 +448,9 @@ export function recallLenses(
 
   return {
     matches: sortedMatched
-      .slice(0, MAX_RECALL_RESULTS)
+      .slice(0, maxCount)
       .map((lens) => resolveLens(lens, locale, tBrand)),
-    maybe: sortedMaybe.slice(0, MAX_RECALL_RESULTS).map((lens) => ({
+    maybe: sortedMaybe.slice(0, maxCount).map((lens) => ({
       lens: resolveLens(lens, locale, tBrand),
       missingFields: missingById.get(lens.id) ?? [],
     })),

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -6,6 +6,12 @@ import { buildLensSearchIndex, searchLensIndex } from "@/lib/lens/search";
 import { recallLenses, recommendLenses, resolveLens, RECALL_SORT_FIELDS } from "@/lib/ai/recall";
 import { OPTICAL_TRAITS, type Mount } from "@/lib/types";
 
+// How many recalled lenses one queryLenses call returns to the model, after the
+// active sort. Bounds tool-result size / token cost; totalMatched still tells the
+// model how many more matched beyond the cap. Tests call recallLenses with a
+// different cap to inspect the full match set.
+const RECALL_LIMIT = 20;
+
 // The agent's tools, bound to the current mount + locale (both fixed by the
 // route, never model-supplied). Parameter semantics live in `.describe()` so the
 // model learns them from the tool schema, not the system prompt.
@@ -26,7 +32,7 @@ export function buildLensTools(
         "user's described needs into these parameters. Returns { matches (meet every " +
         "constraint), maybe (a constrained field has no data for that lens — surface " +
         "these honestly, never drop them), totalMatched, totalMaybe }. matches/maybe are " +
-        "capped at the top 20 by your sort; if totalMatched is larger, tell the user the " +
+        `capped at the top ${RECALL_LIMIT} by your sort; if totalMatched is larger, tell the user the ` +
         "total and NARROW the query (add a constraint) — there is no paging.",
       inputSchema: z.object({
         brands: z
@@ -128,7 +134,7 @@ export function buildLensTools(
         sortDir: z.enum(["asc", "desc"]).optional().describe("asc (default) = smallest first."),
       }),
       execute: (constraints) => {
-        const result = recallLenses(mount, locale, constraints, tBrand);
+        const result = recallLenses(mount, locale, constraints, tBrand, RECALL_LIMIT);
         // Record what this call surfaced so recommendLenses can check its picks. Both
         // buckets are shown to the user; matches hold the lens directly, maybe wraps it.
         for (const lens of result.matches) {


### PR DESCRIPTION
## What

The recall layer — the engine behind the `queryLenses` tool — had no test. It's a pure, deterministic function over the static lens catalogue (no LLM), so its retrieval quality belongs in the committed CI suite, not the gitignored behavioural harness (which needs DeepSeek + a judge).

## Testability seam

To measure recall/precision against ground truth without hand-labelling every query, `recallLenses`'s result cap becomes a `maxCount` parameter:
- the `queryLenses` tool fixes it at `RECALL_LIMIT = 20` (what the model sees);
- tests pass `Infinity` for the complete match set M, then compare M against the capped set.

`evaluate()` stays private — there's no second implementation of the filter to drift out of sync.

## Coverage

- **Filter correctness** — portrait primes / telephoto zooms / light-primes, each with must-include + must-exclude anchors and property assertions (prime-vs-zoom, focal coverage, wide aperture, weight bound).
- **Truncation / wideEnd-bias** — quantifies recall@20 and documents the directional bias: for "show me zooms" (35 matches > 20, default `wideEnd`-asc sort) a genuine telephoto match (`xf-150-600`) is silently dropped by the wide-first cap. This is the validation vehicle for the truncation-bias fix — when the cap is made intent-aware the expectation flips.

## Incidental

- Fixed stale `coversFocals` / `focalWithin` JSDoc on `LensConstraints` (said "full-frame-equivalent"; the code and the tool schema the model reads both use native mm).
- Follows the existing `__tests__/` + relative-import convention.

## Test plan

- `npm test` → 389 passed (17 files), including the 6 new recall tests.
- `tsc --noEmit` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)