### PR TITLE
feat(askiris): DeepSeek circuit breaker with fail-fast degraded reply

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import { getAgentModel, agentProviderOptions } from "@/lib/ai/model";
 import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
+import { isCircuitOpen, recordProviderFailure, recordProviderSuccess } from "@/lib/ai/circuit";
 import { askirisTurnDataPoint } from "@/lib/analytics/events";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
@@ -133,6 +134,11 @@ export async function POST(req: Request) {
         return chatErrorResponse("rate_limit", 429);
       }
     }
+    // Fail fast when the DeepSeek circuit is open: a clean "unavailable" beats hanging on a
+    // known-failing provider until the stream timeout. onEnd/onError below feed the breaker.
+    if (rateKv && (await isCircuitOpen(rateKv))) {
+      return chatErrorResponse("unavailable", 503);
+    }
   } catch {
     // Never let a missing binding or KV error break chat.
   }
@@ -197,6 +203,14 @@ export async function POST(req: Request) {
           ),
         );
       }
+      // A completed turn means DeepSeek is healthy — clear any failure streak.
+      if (rateKv && ctx) {
+        ctx.waitUntil(
+          recordProviderSuccess(rateKv).catch((error) =>
+            console.error("[askiris] failed to record circuit success", error),
+          ),
+        );
+      }
     },
   });
 
@@ -210,6 +224,15 @@ export async function POST(req: Request) {
       // bare constant is enough, not prose.
       onError: (error) => {
         console.error("[askiris] stream error", error);
+        // A stream error is a DeepSeek failure — feed the breaker so a sustained outage trips
+        // it and later requests fail fast instead of each hanging to the timeout.
+        if (rateKv && ctx) {
+          ctx.waitUntil(
+            recordProviderFailure(rateKv).catch((e) =>
+              console.error("[askiris] failed to record circuit failure", e),
+            ),
+          );
+        }
         return "Stream error";
       },
     }),

--- a/src/lib/ai/__tests__/circuit.test.ts
+++ b/src/lib/ai/__tests__/circuit.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  CIRCUIT,
+  isCircuitOpen,
+  recordProviderFailure,
+  recordProviderSuccess,
+} from "../circuit";
+
+// Minimal in-memory KVNamespace that honours expirationTtl against the (fake) clock, so
+// the cooldown / half-open transitions are exercised deterministically.
+function fakeKv(): KVNamespace {
+  const store = new Map<string, { value: string; expiresAt: number | null }>();
+  return {
+    async get(key: string) {
+      const e = store.get(key);
+      if (!e) {
+        return null;
+      }
+      if (e.expiresAt !== null && Date.now() >= e.expiresAt) {
+        store.delete(key);
+        return null;
+      }
+      return e.value;
+    },
+    async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+      const expiresAt = opts?.expirationTtl ? Date.now() + opts.expirationTtl * 1000 : null;
+      store.set(key, { value, expiresAt });
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+}
+
+async function fail(kv: KVNamespace, times: number) {
+  for (let i = 0; i < times; i++) {
+    await recordProviderFailure(kv);
+  }
+}
+
+describe("DeepSeek circuit breaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("guards its own invariant: the fail window must outlive the cooldown", () => {
+    // Half-open re-open depends on the failure streak surviving the cooldown.
+    expect(CIRCUIT.failWindowSeconds).toBeGreaterThan(CIRCUIT.cooldownSeconds);
+  });
+
+  it("stays closed below the failure threshold", async () => {
+    const kv = fakeKv();
+    await fail(kv, CIRCUIT.failureThreshold - 1);
+    expect(await isCircuitOpen(kv)).toBe(false);
+  });
+
+  it("opens once the failure threshold is reached", async () => {
+    const kv = fakeKv();
+    await fail(kv, CIRCUIT.failureThreshold);
+    expect(await isCircuitOpen(kv)).toBe(true);
+  });
+
+  it("a success resets the streak so intermittent blips don't accumulate", async () => {
+    const kv = fakeKv();
+    await fail(kv, CIRCUIT.failureThreshold - 1);
+    await recordProviderSuccess(kv);
+    await fail(kv, CIRCUIT.failureThreshold - 1);
+    expect(await isCircuitOpen(kv)).toBe(false);
+  });
+
+  it("half-opens after the cooldown, then re-opens on a single failed probe", async () => {
+    const kv = fakeKv();
+    await fail(kv, CIRCUIT.failureThreshold);
+    expect(await isCircuitOpen(kv)).toBe(true);
+
+    vi.setSystemTime(CIRCUIT.cooldownSeconds * 1000 + 1); // cooldown elapses
+    expect(await isCircuitOpen(kv)).toBe(false); // half-open: a probe is allowed through
+
+    await recordProviderFailure(kv); // the probe fails
+    expect(await isCircuitOpen(kv)).toBe(true); // re-opens immediately, no fresh threshold
+  });
+
+  it("a successful half-open probe closes the circuit and clears the streak", async () => {
+    const kv = fakeKv();
+    await fail(kv, CIRCUIT.failureThreshold);
+
+    vi.setSystemTime(CIRCUIT.cooldownSeconds * 1000 + 1);
+    await recordProviderSuccess(kv); // the probe succeeds
+    expect(await isCircuitOpen(kv)).toBe(false);
+
+    // streak cleared: it now takes a full fresh threshold to open again
+    await fail(kv, CIRCUIT.failureThreshold - 1);
+    expect(await isCircuitOpen(kv)).toBe(false);
+  });
+});

--- a/src/lib/ai/circuit.ts
+++ b/src/lib/ai/circuit.ts
@@ -1,0 +1,56 @@
+// Circuit breaker for the DeepSeek dependency, backed by RATE_KV (same namespace and
+// loose read-modify-write style as the rate limiter). It's a PASSIVE breaker: it learns
+// from real request outcomes rather than probing — when DeepSeek fails repeatedly the
+// circuit opens, and /api/chat fails fast with a clean "unavailable" instead of every
+// request hanging on a dead provider until the stream timeout.
+//
+// State in KV (global, not per-IP — this tracks the provider's health, not a caller):
+//   circuit:fails  consecutive-failure counter, TTL = failWindowSeconds so old blips decay.
+//   circuit:open   presence = open; its TTL IS the cooldown. Expiry auto-"half-opens" —
+//                  the next request probes DeepSeek for real, and onEnd/onError decides.
+//
+// The failure streak is deliberately NOT cleared when the circuit trips: it must outlive
+// the cooldown (failWindowSeconds > cooldownSeconds) so that a single failed half-open
+// probe re-opens immediately instead of needing another full threshold.
+
+const FAILS_KEY = "circuit:fails";
+const OPEN_KEY = "circuit:open";
+
+export const CIRCUIT = {
+  // Consecutive DeepSeek failures before the circuit opens. Above 1 so a lone transient
+  // blip doesn't trip it; low enough to open within a few requests of a real outage.
+  failureThreshold: 4,
+  // How long the circuit stays open before the next request is allowed to probe.
+  cooldownSeconds: 60,
+  // Failure-counter lifetime. MUST exceed cooldownSeconds (see half-open note above);
+  // also bounds "consecutive" to a rolling window rather than "ever".
+  failWindowSeconds: 180,
+} as const;
+
+function toCount(raw: string | null): number {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Fail-fast gate: is the circuit currently open? Read before touching the model.
+export async function isCircuitOpen(kv: KVNamespace): Promise<boolean> {
+  return (await kv.get(OPEN_KEY)) !== null;
+}
+
+// A DeepSeek turn completed — the provider is healthy, so clear the failure streak (a
+// success is what closes a half-open circuit). Write-free on the healthy path: with no
+// streak there's nothing to delete.
+export async function recordProviderSuccess(kv: KVNamespace): Promise<void> {
+  if ((await kv.get(FAILS_KEY)) !== null) {
+    await kv.delete(FAILS_KEY);
+  }
+}
+
+// A DeepSeek turn errored. Bump the failure streak; trip the circuit at the threshold.
+export async function recordProviderFailure(kv: KVNamespace): Promise<void> {
+  const fails = toCount(await kv.get(FAILS_KEY)) + 1;
+  await kv.put(FAILS_KEY, String(fails), { expirationTtl: CIRCUIT.failWindowSeconds });
+  if (fails >= CIRCUIT.failureThreshold) {
+    await kv.put(OPEN_KEY, "1", { expirationTtl: CIRCUIT.cooldownSeconds });
+  }
+}


### PR DESCRIPTION
## Problem

If DeepSeek starts failing, every `/api/chat` request still runs `streamText` and hangs on the dead provider until the 120s stream timeout, then the client shows a retry that walks straight back into the same wall. No fail-fast, no graceful "we're temporarily down."

## Fix — a passive circuit breaker

KV-backed (`RATE_KV`, same loose read-modify-write style as the rate limiter), tracking the provider's health globally (not per-IP):

- **stream `onError` → failure**: bumps a consecutive-failure streak.
- **`streamText` `onEnd` → success**: clears the streak.
- **trip**: at `failureThreshold` the circuit opens for `cooldownSeconds`.
- **fail-fast**: while open, the request returns a clean `503 unavailable` before touching the model — the client already renders `unavailable` as a no-retry message (from #419).
- **half-open for free**: the open flag's TTL *is* the cooldown, so its expiry lets the next request probe DeepSeek for real. A completed turn closes the circuit; a single failed probe re-opens it (the streak deliberately outlives the cooldown, `failWindowSeconds > cooldownSeconds`).

**No backup model.** Per the deliberate "OpenAI never enters the deployed path" decision, the fallback is graceful degradation (fail-fast unavailable), not a second provider.

## Tunables (judgment calls, flagged)

`failureThreshold: 4`, `cooldownSeconds: 60`, `failWindowSeconds: 180` — conservative enough not to trip on a lone blip, quick enough to open within a few requests of a real outage.

## Test plan

- `circuit.test.ts` — trip / streak-reset / half-open recover + re-open, over an in-memory KV honouring TTL against a fake clock. `npm test` → 395 passed (18 files).
- `tsc` + `eslint` clean.
- Live happy-path smoke against `/api/chat` (200, streamed tool calls + text) — the breaker is inert under `next dev` (no KV binding), so the open→fail-fast path is covered by the unit tests, not an integration run (a real DeepSeek outage can't be forced here); it activates in preview/prod where `RATE_KV` is bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)