### PR TITLE
feat(askiris): connect-layer timeout on the DeepSeek provider

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -95,9 +95,10 @@ const chatRequestSchema = z.object({
 // calls). Bounds worst-case cost/latency; shared by stopWhen and the budget-hit log.
 const STEP_BUDGET = 8;
 
-// Hard ceiling on one turn's streaming, so a stuck provider connection can't hang the
-// request indefinitely. Generous — a legit multi-step turn on a slow provider runs
-// tens of seconds; this only bites a true hang.
+// Backstop ceiling on one whole turn's streaming, so a connection that stalls MID-stream
+// can't hang the request forever. Generous — a legit multi-step turn runs tens of seconds.
+// Time-to-first-response is bounded separately, per model call, by the provider connect
+// timeout (see src/lib/ai/model.ts); this only catches a stall after a good start.
 const STREAM_TIMEOUT_MS = 120_000;
 
 export async function POST(req: Request) {

--- a/src/lib/ai/__tests__/connect-timeout.test.ts
+++ b/src/lib/ai/__tests__/connect-timeout.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { connectTimeoutFetch } from "../connect-timeout";
+
+// Fake fetch: resolves with a Response `headersDelayMs` after it's called, unless its signal
+// aborts first — in which case it rejects with the abort reason, like a real aborted fetch.
+function fakeFetch(headersDelayMs: number): typeof fetch {
+  return (_input, init) =>
+    new Promise<Response>((resolve, reject) => {
+      const signal = init?.signal;
+      const t = setTimeout(() => resolve(new Response("ok")), headersDelayMs);
+      signal?.addEventListener("abort", () => {
+        clearTimeout(t);
+        reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+      });
+    });
+}
+
+describe("connectTimeoutFetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("passes through when headers arrive before the connect timeout", async () => {
+    const wrapped = connectTimeoutFetch(1000, fakeFetch(200));
+    const p = wrapped("https://example.test");
+    await vi.advanceTimersByTimeAsync(200);
+    const res = await p;
+    expect(res.ok).toBe(true);
+  });
+
+  it("aborts with a TimeoutError when headers don't arrive in time", async () => {
+    const wrapped = connectTimeoutFetch(1000, fakeFetch(5000));
+    const p = wrapped("https://example.test");
+    const assertion = expect(p).rejects.toMatchObject({ name: "TimeoutError" });
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+  });
+
+  it("propagates an upstream abort (the caller's total timeout / disconnect)", async () => {
+    const upstream = new AbortController();
+    const wrapped = connectTimeoutFetch(10_000, fakeFetch(5000));
+    const p = wrapped("https://example.test", { signal: upstream.signal });
+    const assertion = expect(p).rejects.toMatchObject({ name: "AbortError" });
+    upstream.abort(new DOMException("upstream", "AbortError"));
+    await assertion;
+  });
+});

--- a/src/lib/ai/connect-timeout.ts
+++ b/src/lib/ai/connect-timeout.ts
@@ -1,0 +1,40 @@
+// A fetch wrapper that gives up if the server hasn't returned response HEADERS within
+// `connectMs`. That catches a hung or unreachable provider — distinct from a legitimate
+// long turn, which returns headers quickly and then streams. `fetch()` resolves on the
+// headers, before the body is read, so clearing the timer there caps time-to-first-response,
+// NOT total stream time: once headers arrive the body streams under whatever total timeout
+// the caller already applies via `init.signal`.
+//
+// `fetchImpl` is injectable purely so the timeout behaviour can be unit-tested with a fake.
+export function connectTimeoutFetch(
+  connectMs: number,
+  fetchImpl: typeof fetch = fetch,
+): typeof fetch {
+  return (input, init) => {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(new DOMException("Provider connect timeout", "TimeoutError")),
+      connectMs,
+    );
+    // Chain the caller's own abort (total-stream timeout / client disconnect) into ours, so
+    // aborting upstream still cancels the request.
+    const upstream = init?.signal;
+    if (upstream) {
+      if (upstream.aborted) {
+        controller.abort(upstream.reason);
+      } else {
+        upstream.addEventListener("abort", () => controller.abort(upstream.reason), { once: true });
+      }
+    }
+    return fetchImpl(input, { ...init, signal: controller.signal }).then(
+      (res) => {
+        clearTimeout(timer);
+        return res;
+      },
+      (err) => {
+        clearTimeout(timer);
+        throw err;
+      },
+    );
+  };
+}

--- a/src/lib/ai/model.ts
+++ b/src/lib/ai/model.ts
@@ -1,6 +1,17 @@
-import { deepseek } from "@ai-sdk/deepseek";
+import { createDeepSeek, deepseek } from "@ai-sdk/deepseek";
 import { openai } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
+import { connectTimeoutFetch } from "@/lib/ai/connect-timeout";
+
+// Give up on a DeepSeek call that hasn't returned response headers within this window — a
+// hung or unreachable provider, as opposed to a legit multi-step turn (which returns headers
+// fast, then streams). This bounds time-to-first-response per model call; streamText's own
+// abortSignal in the route still backstops total stream time.
+const CONNECT_TIMEOUT_MS = 18_000;
+
+// The prod DeepSeek provider, wrapped so a hung connection fails in ~18s instead of hanging
+// to the route's total timeout. apiKey still defaults to DEEPSEEK_API_KEY from the env.
+const deepseekProd = createDeepSeek({ fetch: connectTimeoutFetch(CONNECT_TIMEOUT_MS) });
 
 // Iris's production model — the single source of truth. DeepSeek v4-flash is cheap
 // and chains tools reliably; swapping it is a one-line change confined here.
@@ -14,7 +25,7 @@ import type { LanguageModel } from "ai";
 export function getAgentModel(): LanguageModel {
   const override = process.env.AGENT_MODEL;
   if (!override) {
-    return deepseek("deepseek-v4-flash");
+    return deepseekProd("deepseek-v4-flash");
   }
   const sep = override.indexOf(":");
   const provider = override.slice(0, sep);


### PR DESCRIPTION
## Why (and why not the circuit breaker)

A hung/unreachable DeepSeek would otherwise hang **every** `/api/chat` request to the 120s total-stream timeout, then the client nudges a retry into the same wall. The abandoned circuit breaker (#425) addressed this but is a poor fit at this traffic — it's passive, so it only protects requests *after* it has learned from ~4 failures, and it adds global KV state.

A **connect-layer timeout** is the cheaper fix and strictly better at what actually hurts: it's per-request and stateless, so it helps *every* caller immediately.

## What

`connectTimeoutFetch` wraps the prod DeepSeek provider's `fetch` (via `createDeepSeek({ fetch })`):

- Aborts a call whose response **headers** haven't arrived within **18s** — a dead connection.
- `fetch()` resolves on headers, *before* the body, so clearing the timer there caps **time-to-first-response**, not total stream time. A legit long turn (headers fast, then streaming) runs unaffected under the route's existing 120s total backstop.
- Chains the caller's own abort signal (the total timeout / client disconnect) through, so upstream aborts still cancel.

Two complementary layers now: **18s connect** (per model call, catches a hung start) + **120s total** (catches a mid-stream stall after a good start). No backup model — OpenAI stays out of the prod path.

## Tunable

`CONNECT_TIMEOUT_MS = 18_000` — a judgment call in the 15–20s range.

## Test plan

- `connect-timeout.test.ts` — pass-through when headers arrive in time, TimeoutError abort when they don't, upstream-abort propagation (fake fetch + fake timers). `npm test` → 392 passed (18 files).
- `tsc` + `eslint` clean.
- Live happy-path smoke against `/api/chat` (200, streamed tool calls + text) confirms the custom-fetch provider still authenticates (apiKey from env) and streams normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)