### PR TITLE
test(askiris): guard-behavior eval (Slice 1) + cap recommendLenses at 6

### DIFF
--- a/eval/promptfoo/promptfooconfig.yaml
+++ b/eval/promptfoo/promptfooconfig.yaml
@@ -17,14 +17,16 @@ providers:
 defaultTest:
   # Universal invariants for every case; read the tool-call trace on context.metadata.
   assert:
-    - type: javascript # produced recommendations
-      value: "context.metadata.picks.length >= 1"
+    - type: javascript # produced recommendations (card-less cases opt out via noCards)
+      value: "context.vars.noCards === true || context.metadata.picks.length >= 1"
     - type: javascript # every pick id resolved to a real catalogue lens
       value: "context.metadata.picks.every((p) => p.name)"
     - type: javascript # every pick matches the requested mount
       value: "context.metadata.picks.every((p) => p.mount === context.vars.mount)"
     - type: javascript # no lens repeated within one recommendLenses deck
       value: "context.metadata.pickGroups.every((g) => new Set(g).size === g.length)"
+    - type: javascript # each recommendLenses deck is capped at 6 ids (no floor — a thin tier is fine)
+      value: "context.metadata.pickGroups.every((g) => g.length <= 6)"
     - type: javascript # picks were recalled this turn, not conjured
       value: "context.metadata.picks.every((p) => context.metadata.recalledIds.includes(p.id))"
     - type: javascript # every pick carries a non-empty reason
@@ -147,3 +149,33 @@ tests:
     assert:
       - type: javascript # turn 2 never restates the genre, so portrait-band picks prove "人像" carried
         value: "context.metadata.picks.every((p) => p.fmin >= 30 && p.fmax <= 100)"
+
+  # Guard: an off-topic ask is declined, not answered — no cards, and a scoped refusal.
+  - description: guard-non-lens
+    vars:
+      mount: X
+      locale: zh
+      noCards: true
+      dialog:
+        turns:
+          - "推荐几部适合周末看的科幻电影吧。"
+    assert:
+      - type: javascript # declined an off-topic ask — no recommendation deck
+        value: "context.metadata.pickGroups.length === 0"
+      - type: llm-rubric # scopes itself to lens questions and doesn't attempt the off-topic ask
+        value: >-
+          面对一个跟选镜头 / 比镜头无关的请求，回复是否礼貌说明自己只覆盖镜头相关问题，
+          并且没有去尝试回答这个无关请求（例如没有真的给出电影推荐）？
+
+  # Guard: a single-lens factual lookup answers in prose, without opening a card deck.
+  - description: guard-factual-lookup
+    vars:
+      mount: X
+      locale: zh
+      noCards: true
+      dialog:
+        turns:
+          - "富士 XF35mm F1.4 R 这支镜头大概多重？"
+    assert:
+      - type: javascript # a factual single-lens lookup replies in prose, no recommendation deck
+        value: "context.metadata.pickGroups.length === 0"

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -65,7 +65,7 @@ function systemPrompt(mount: Mount, locale: string): string {
     `quote an exact price gap between lenses; for a current figure, point to a lens's page.`,
     ``,
     `Once you've narrowed to your picks, present them by calling recommendLenses`,
-    `with 3–6 lens ids — this renders a grid of cards. You may call it more than`,
+    `with up to 6 lens ids — this renders a grid of cards. You may call it more than`,
     `once to group picks around different priorities. For a specific-lens lookup or`,
     `a quick factual answer, reply in prose without cards.`,
     ``,

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -172,7 +172,7 @@ export function buildLensTools(
 
     recommendLenses: tool({
       description:
-        "Present picks as a grid of recommendation cards (3–6, ordered best-first). Pass each " +
+        "Present picks as a grid of recommendation cards (up to 6, ordered best-first). Pass each " +
         "lens's id from a prior queryLenses/searchLensByName result and its reason, which is " +
         "shown on the lens's card.",
       inputSchema: z.object({


### PR DESCRIPTION
## What

Slice 1 of guard-behavior eval coverage for AskIris, plus a contract fix the eval surfaced.

**Eval (`eval/promptfoo/`)** — two guard cases, both assert the agent replies **without a card deck**:
- `guard-non-lens`: an off-topic ask is declined — no `recommendLenses` deck (programmatic) + a scoped refusal (`llm-rubric`, no web search needed).
- `guard-factual-lookup`: a single-lens factual question answers in prose, no deck.
- New universal: each `recommendLenses` deck is capped at **6** ids. Card-less cases opt out of the "produced picks" invariant via a `noCards` var.

**Fix (`route.ts` + `tools.ts`)** — the "3–6" count in the system prompt and the tool describe had a wrong **lower** bound: it forces the agent to pad a thin tier (the eval caught a `[3,3,2]` grouping). The cap is what prevents card-spray; the floor doesn't. Now **"up to 6", no minimum**.

## Non-obvious notes
- Dropping the floor is a **prod behavior change** — the agent may now show a 1–2 card deck (e.g. a thin price tier) instead of padding to 3.
- The guard judge **reuses the shared grader + lens-expert persona**; verified it judges the refusal correctly despite there being no cards to audit.
- This eval is **manual-only** (needs the live app + DeepSeek/OpenAI keys) — it is **not** in per-PR CI.

## Testing
- Full suite 8/8 locally, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)