### PR TITLE
feat(askiris): session funnel metrics + native CNY cost

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -254,10 +254,13 @@ const Q_PWA_LAUNCH = `
 
 // AskIris — per-turn agent metrics written straight to AE from the chat route's
 // onEnd (not via /api/track), so these rows carry their own positional layout:
-// blob1=mount, blob2=locale; double1..6 = total/input/output/cacheRead tokens,
-// step_count, budget_hit. Counts weight by _sample_interval; summed metrics weight
-// each row's value by it too, to stay correct if AE ever samples this dataset.
+// blob1=mount, blob2=locale, blob3=sid, blob4=segment_id; double1..6 =
+// total/input/output/cacheRead tokens, step_count, budget_hit. Counts weight by
+// _sample_interval; summed metrics weight each row's value by it too, to stay correct
+// if AE ever samples this dataset. The funnel's page-view entry is a separate
+// askiris_view event on the general /api/track layout (blob1=sid).
 const ASKIRIS_FILTER = `index1 = '${ASKIRIS_TURN_EVENT}' AND timestamp > NOW() - ${WINDOW}`;
+const ASKIRIS_VIEW_FILTER = `index1 = 'askiris_view' AND timestamp > NOW() - ${WINDOW}`;
 
 const Q_ASKIRIS_OVERVIEW = `
   SELECT
@@ -291,6 +294,27 @@ const Q_ASKIRIS_BY_MOUNT = `
   ORDER BY turns DESC
 `;
 
+// Session funnel. Views (PV = loads, UV = distinct visitor sid) come from the
+// askiris_view event; the interacted side (visitors who sent a turn, and how those
+// turns group into sessions) comes from the turn rows keyed by sid + segment_id. A
+// session = one conversation segment (a new one starts on a mount switch / new chat).
+const Q_ASKIRIS_VIEWS = `
+  SELECT
+    SUM(_sample_interval) AS pv,
+    count(DISTINCT blob1) AS uv
+  FROM xglass_events
+  WHERE ${ASKIRIS_VIEW_FILTER}
+`;
+
+const Q_ASKIRIS_SESSIONS = `
+  SELECT
+    count(DISTINCT blob3) AS interacted_uv,
+    count(DISTINCT blob4) AS sessions,
+    SUM(_sample_interval) AS turns
+  FROM xglass_events
+  WHERE ${ASKIRIS_FILTER} AND blob4 != ''
+`;
+
 function pct(num: number, denom: number): string {
   if (denom <= 0) {
     return "—";
@@ -320,17 +344,17 @@ function fmtMaybe(v: unknown): string {
   return n.toLocaleString("en-US");
 }
 
-// DeepSeek V4-Flash list price, USD per 1M tokens (as of 2026-07 —
+// DeepSeek V4-Flash list price, CNY per 1M tokens (as of 2026-07 —
 // api-docs.deepseek.com/quick_start/pricing). Cache-hit input is billed ~98% off;
 // cache-miss input is (input − cacheRead). Update if the model or rates change.
-const DEEPSEEK_USD_PER_1M = { inputMiss: 0.14, cacheHit: 0.0028, output: 0.28 };
+const DEEPSEEK_CNY_PER_1M = { inputMiss: 1, cacheHit: 0.02, output: 2 };
 
-function askirisCostUsd(input: number, cacheRead: number, output: number): number {
+function askirisCostCny(input: number, cacheRead: number, output: number): number {
   const inputMiss = Math.max(0, input - cacheRead);
   return (
-    (inputMiss / 1e6) * DEEPSEEK_USD_PER_1M.inputMiss +
-    (cacheRead / 1e6) * DEEPSEEK_USD_PER_1M.cacheHit +
-    (output / 1e6) * DEEPSEEK_USD_PER_1M.output
+    (inputMiss / 1e6) * DEEPSEEK_CNY_PER_1M.inputMiss +
+    (cacheRead / 1e6) * DEEPSEEK_CNY_PER_1M.cacheHit +
+    (output / 1e6) * DEEPSEEK_CNY_PER_1M.output
   );
 }
 
@@ -443,6 +467,8 @@ export default async function AnalyticsDashboardPage() {
     askirisOverview,
     askirisByStep,
     askirisByMount,
+    askirisViews,
+    askirisSessions,
   ] = await Promise.all([
     queryAE(Q_OVERVIEW_TOTALS),
     queryAE(Q_OVERVIEW_UNIQUES),
@@ -468,6 +494,8 @@ export default async function AnalyticsDashboardPage() {
     queryAE(Q_ASKIRIS_OVERVIEW),
     queryAE(Q_ASKIRIS_BY_STEP),
     queryAE(Q_ASKIRIS_BY_MOUNT),
+    queryAE(Q_ASKIRIS_VIEWS),
+    queryAE(Q_ASKIRIS_SESSIONS),
   ]);
 
   if (overviewTotals.error === "missing_credentials") {
@@ -541,6 +569,8 @@ export default async function AnalyticsDashboardPage() {
       ["askirisOverview", askirisOverview],
       ["askirisByStep", askirisByStep],
       ["askirisByMount", askirisByMount],
+      ["askirisViews", askirisViews],
+      ["askirisSessions", askirisSessions],
     ] as const
   ).flatMap(([name, r]) =>
     r.error && r.error !== "missing_credentials" ? [{ name, code: r.error }] : [],
@@ -605,7 +635,17 @@ export default async function AnalyticsDashboardPage() {
   const aiCacheReadTokens = num(askirisRow?.cache_read_tokens);
   const aiTotalSteps = num(askirisRow?.total_steps);
   const aiBudgetHits = num(askirisRow?.budget_hits);
-  const aiCostUsd = askirisCostUsd(aiInputTokens, aiCacheReadTokens, aiOutputTokens);
+  const aiCostCny = askirisCostCny(aiInputTokens, aiCacheReadTokens, aiOutputTokens);
+  // Session funnel: page views/visitors (askiris_view) → interacted visitors →
+  // sessions → turns. "Person" is approximated by the visit sid (no login).
+  const aiViewsRow = askirisViews.data[0] as { pv?: number; uv?: number } | undefined;
+  const aiSessionsRow = askirisSessions.data[0] as
+    | { interacted_uv?: number; sessions?: number; turns?: number }
+    | undefined;
+  const aiUv = num(aiViewsRow?.uv);
+  const aiInteractedUv = num(aiSessionsRow?.interacted_uv);
+  const aiSessions = num(aiSessionsRow?.sessions);
+  const aiSessionTurns = num(aiSessionsRow?.turns);
   const askirisByMountRows = askirisByMount.data.map((r) => ({
     ...r,
     total_tokens: fmtNum(num(r.total_tokens)),
@@ -885,11 +925,32 @@ export default async function AnalyticsDashboardPage() {
         <div className="mb-4 grid grid-cols-2 gap-4 md:grid-cols-4">
           <Stat label="Turns" value={fmtMaybe(askirisRow?.turns)} />
           <Stat label="Tokens" value={fmtMaybe(askirisRow?.total_tokens)} />
-          <Stat label="Est. cost" value={aiTurns > 0 ? `$${aiCostUsd.toFixed(2)}` : "—"} />
+          <Stat label="Est. cost" value={aiTurns > 0 ? `¥${aiCostCny.toFixed(2)}` : "—"} />
           <Stat label="Budget-hit rate" value={pct(aiBudgetHits, aiTurns)} />
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Card title="AskIris · audience & sessions">
+            <dl className="grid grid-cols-[1fr_auto] gap-y-2 text-sm">
+              <dt className="text-zinc-500 dark:text-zinc-400">Page views (PV)</dt>
+              <dd className="text-right tabular-nums">{fmtMaybe(aiViewsRow?.pv)}</dd>
+              <dt className="text-zinc-500 dark:text-zinc-400">Visitors (UV)</dt>
+              <dd className="text-right tabular-nums">{fmtMaybe(aiViewsRow?.uv)}</dd>
+              <dt className="text-zinc-500 dark:text-zinc-400">Interacted visitors</dt>
+              <dd className="text-right tabular-nums">{fmtMaybe(aiSessionsRow?.interacted_uv)}</dd>
+              <dt className="text-zinc-500 dark:text-zinc-400">Activation (interacted / visited)</dt>
+              <dd className="text-right tabular-nums">{pct(aiInteractedUv, aiUv)}</dd>
+              <dt className="text-zinc-500 dark:text-zinc-400">Avg turns / session</dt>
+              <dd className="text-right tabular-nums">
+                {aiSessions > 0 ? (aiSessionTurns / aiSessions).toFixed(1) : "—"}
+              </dd>
+              <dt className="text-zinc-500 dark:text-zinc-400">Avg sessions / active visitor</dt>
+              <dd className="text-right tabular-nums">
+                {aiInteractedUv > 0 ? (aiSessions / aiInteractedUv).toFixed(1) : "—"}
+              </dd>
+            </dl>
+          </Card>
+
           <Card title="AskIris · efficiency">
             <dl className="grid grid-cols-[1fr_auto] gap-y-2 text-sm">
               <dt className="text-zinc-500 dark:text-zinc-400">Avg tokens / turn</dt>

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -15,6 +15,7 @@ import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
 import { askirisTurnDataPoint } from "@/lib/analytics/events";
+import { parseSid } from "@/lib/analytics/session";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
 import type { Mount } from "@/lib/types";
@@ -106,25 +107,6 @@ const STEP_BUDGET = 8;
 // tens of seconds; this only bites a true hang.
 const STREAM_TIMEOUT_MS = 120_000;
 
-// The anonymous visit id set by /api/track (xg_sid, HttpOnly, 30-min sliding). Read
-// only — we don't mint or refresh it here; a turn before the first /api/track call
-// records "". It's the session funnel's visitor key, joined with the segment id.
-function readSid(req: Request): string {
-  const cookie = req.headers.get("cookie");
-  if (!cookie) {
-    return "";
-  }
-  for (const part of cookie.split(";")) {
-    const eq = part.indexOf("=");
-    const key = part.slice(0, eq).trim();
-    const value = part.slice(eq + 1).trim();
-    if (key === "xg_sid" && /^[0-9a-f-]{36}$/i.test(value)) {
-      return value;
-    }
-  }
-  return "";
-}
-
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
     console.error("[askiris] DEEPSEEK_API_KEY is not set");
@@ -144,7 +126,9 @@ export async function POST(req: Request) {
   // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
   // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
   const ip = clientIp(req);
-  const sid = readSid(req);
+  // Read the anonymous visit id set by /api/track; "" for a turn before its first
+  // call. We only read it here — /api/track owns minting and refreshing the cookie.
+  const sid = parseSid(req.headers.get("cookie")) ?? "";
   let rateKv: KVNamespace | undefined;
   let ae: AnalyticsEngineDataset | undefined;
   let ctx: ExecutionContext | undefined;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -92,6 +92,9 @@ const chatRequestSchema = z.object({
   messages: z.array(z.custom<UIMessage>()),
   mount: z.enum(MOUNTS),
   locale: z.enum(routing.locales),
+  // Client-minted conversation-segment id (a fresh one per mount switch / "new
+  // chat"). Optional so a handoff or older client that omits it still succeeds.
+  segmentId: z.string().max(64).optional(),
 });
 
 // Max agentic steps per turn (one step = one model generation, possibly with tool
@@ -102,6 +105,25 @@ const STEP_BUDGET = 8;
 // request indefinitely. Generous — a legit multi-step turn on a slow provider runs
 // tens of seconds; this only bites a true hang.
 const STREAM_TIMEOUT_MS = 120_000;
+
+// The anonymous visit id set by /api/track (xg_sid, HttpOnly, 30-min sliding). Read
+// only — we don't mint or refresh it here; a turn before the first /api/track call
+// records "". It's the session funnel's visitor key, joined with the segment id.
+function readSid(req: Request): string {
+  const cookie = req.headers.get("cookie");
+  if (!cookie) {
+    return "";
+  }
+  for (const part of cookie.split(";")) {
+    const eq = part.indexOf("=");
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key === "xg_sid" && /^[0-9a-f-]{36}$/i.test(value)) {
+      return value;
+    }
+  }
+  return "";
+}
 
 export async function POST(req: Request) {
   if (!process.env.DEEPSEEK_API_KEY) {
@@ -116,12 +138,13 @@ export async function POST(req: Request) {
     console.warn("[askiris] invalid request", z.prettifyError(parsed.error));
     return chatErrorResponse("unavailable", 400);
   }
-  const { messages, mount, locale } = parsed.data;
+  const { messages, mount, locale, segmentId } = parsed.data;
 
   // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
   // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
   // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
   const ip = clientIp(req);
+  const sid = readSid(req);
   let rateKv: KVNamespace | undefined;
   let ae: AnalyticsEngineDataset | undefined;
   let ctx: ExecutionContext | undefined;
@@ -180,6 +203,8 @@ export async function POST(req: Request) {
             askirisTurnDataPoint({
               mount,
               locale,
+              sid,
+              segmentId: segmentId ?? "",
               totalTokens: usage.totalTokens ?? 0,
               inputTokens: usage.inputTokens ?? 0,
               outputTokens: usage.outputTokens ?? 0,

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -17,10 +17,9 @@ import {
   type EventProps,
   type TrackPayload,
 } from "@/lib/analytics/events";
+import { SID_COOKIE, SID_TTL_SECONDS, parseSid } from "@/lib/analytics/session";
 
 const MAX_BODY_BYTES = 4096;
-const SID_COOKIE = "xg_sid";
-const SID_TTL_SECONDS = 1800;
 const MAX_STRING_LEN = 256;
 
 const STRING_FIELDS = [
@@ -55,19 +54,6 @@ function isValidPayload(p: unknown): p is TrackPayload {
     return false;
   }
   return true;
-}
-
-function parseSid(cookieHeader: string | null): string | null {
-  if (!cookieHeader) {
-    return null;
-  }
-  for (const part of cookieHeader.split(";")) {
-    const [k, v] = part.trim().split("=");
-    if (k === SID_COOKIE && v && /^[0-9a-f-]{36}$/i.test(v)) {
-      return v;
-    }
-  }
-  return null;
 }
 
 function parseInternal(cookieHeader: string | null): boolean {

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -90,12 +90,29 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
   // bad-request/outage will fail identically, so those drop the retry affordance.
   const errorKind = status === "error" ? classifyError(error) : null;
 
+  // A conversation-segment id, minted per segment (a fresh one on each mount switch /
+  // "new chat") and sent with every turn so the server can group turns into sessions.
+  // Kept in a ref: it must not trigger re-renders and is read lazily at send time.
+  const segmentIdRef = useRef<string>("");
+  function currentSegmentId(): string {
+    if (!segmentIdRef.current) {
+      segmentIdRef.current = crypto.randomUUID();
+    }
+    return segmentIdRef.current;
+  }
+
+  // One page view per load — the funnel entry (PV; distinct sid gives UV). Not fired
+  // on a mount switch / new chat: those are in-page and don't reload the route.
+  useEffect(() => {
+    track("askiris_view");
+  }, []);
+
   function submitText(text: string) {
     const trimmed = text.trim();
     if (!trimmed || isBusy) {
       return;
     }
-    sendMessage({ text: trimmed }, { body: { mount, locale } });
+    sendMessage({ text: trimmed }, { body: { mount, locale, segmentId: currentSegmentId() } });
     track("askiris_message", { query: trimmed, method: "typed" });
     setInput("");
   }
@@ -111,7 +128,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
       return;
     }
     queryFired.current = true;
-    sendMessage({ text: initialQuery }, { body: { mount, locale } });
+    sendMessage({ text: initialQuery }, { body: { mount, locale, segmentId: currentSegmentId() } });
     track("askiris_message", { query: initialQuery, method: "handoff" });
     const url = new URL(window.location.href);
     url.searchParams.delete("q");
@@ -153,6 +170,8 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
       });
       setMessages([]);
       setInput("");
+      // The next turn belongs to a new session.
+      segmentIdRef.current = crypto.randomUUID();
     },
     [stop, setMessages],
   );
@@ -246,7 +265,7 @@ export default function AskIrisChat({ locale, initialQuery }: { locale: string; 
                   retry: (chunks) => (
                     <button
                       type="button"
-                      onClick={() => regenerate({ body: { mount, locale } })}
+                      onClick={() => regenerate({ body: { mount, locale, segmentId: currentSegmentId() } })}
                       className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
                     >
                       {chunks}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -28,8 +28,9 @@ export const EVENT_NAMES = [
   "mount_switch",
   "purchase_click",
   "pwa_launch",
-  // AskIris: one per user turn (query text + how it originated), and a click from a
-  // recommendation card through to a lens — the funnel's ask and value actions.
+  // AskIris funnel: a page view (funnel entry / PV + UV), one per user turn (query
+  // text + how it originated), and a click from a recommendation card through to a lens.
+  "askiris_view",
   "askiris_message",
   "askiris_rec_click",
 ] as const;
@@ -130,13 +131,20 @@ export function toDataPoint(
 // Its own positional layout in the same dataset; query it by the index. Token counts
 // can be missing from a provider, recorded as 0.
 //   indexes: [askiris_turn]
-//   blobs:   [mount, locale]
+//   blobs:   [mount, locale, sid, segment_id]
 //   doubles: [total, input, output, cacheRead tokens, step_count, budget_hit]
 export const ASKIRIS_TURN_EVENT = "askiris_turn";
 
 export interface AskIrisTurnMetrics {
   mount: string;
   locale: string;
+  // Session-funnel join keys: sid = the anonymous visit (xg_sid cookie, read
+  // server-side), segmentId = the conversation segment (a new one starts on a mount
+  // switch or "new chat"). Together they give visitors → sessions → turns, and are
+  // the same keys a future transcript replay would persist against. Either can be ""
+  // when unknown (no cookie yet / a legacy client), which the queries filter out.
+  sid: string;
+  segmentId: string;
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;
@@ -147,12 +155,12 @@ export interface AskIrisTurnMetrics {
 
 export function askirisTurnDataPoint(m: AskIrisTurnMetrics): {
   indexes: [string];
-  blobs: [string, string];
+  blobs: [string, string, string, string];
   doubles: [number, number, number, number, number, number];
 } {
   return {
     indexes: [ASKIRIS_TURN_EVENT],
-    blobs: [m.mount, m.locale],
+    blobs: [m.mount, m.locale, m.sid, m.segmentId],
     doubles: [
       m.totalTokens,
       m.inputTokens,

--- a/src/lib/analytics/session.ts
+++ b/src/lib/analytics/session.ts
@@ -1,0 +1,22 @@
+// The anonymous first-party session cookie (`xg_sid`) that ties one visitor's
+// events together. `/api/track` owns it — it mints and refreshes the cookie on a
+// sliding TTL; every other route only reads it. The cookie name, TTL, and parser
+// live here so each reader validates the same format and no route hardcodes a
+// second copy. Sid is the only identifier that crosses requests.
+export const SID_COOKIE = "xg_sid";
+export const SID_TTL_SECONDS = 1800;
+
+// Read a valid sid out of a Cookie header, or null if absent / malformed. A sid is
+// a v4-style uuid; anything else is ignored so a forged cookie can't inject junk.
+export function parseSid(cookieHeader: string | null): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+  for (const part of cookieHeader.split(";")) {
+    const [k, v] = part.trim().split("=");
+    if (k === SID_COOKIE && v && /^[0-9a-f-]{36}$/i.test(v)) {
+      return v;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Adds a session/audience funnel to the admin AskIris analytics section, and shows the cost estimate in CNY. Answers three questions the per-turn metrics couldn't:

- How many people **visit** AskIris vs how many actually **interact**?
- Among interactors, how many **turns per conversation session**?
- How many **sessions per person**?

## How

**Identity ladder (anonymous, no login):**
- `sid` = the `xg_sid` visit cookie (30-min sliding), read server-side in the chat route. Approximates a "person" — the coarsest identity available.
- `segment_id` = client-minted per conversation segment. A new one starts on a **mount switch** or **"new chat"** — the boundary where the agent's memory resets, so it is a genuine new conversation.
- `turn` = one POST /api/chat (already recorded).

**Changes:**
- `events.ts`: extend `askiris_turn` blobs to `[mount, locale, sid, segment_id]`; add an `askiris_view` event (funnel entry for PV/UV).
- `chat/route.ts`: read `xg_sid` from the cookie, accept `segmentId` in the request body, record both on the turn row.
- `AskIrisChat.tsx`: fire `askiris_view` once per page load; mint a `segment_id` per segment (new one on mount switch / new chat) and send it with every turn.
- `analytics/page.tsx`: two funnel queries (reusing the existing `count(DISTINCT)` idiom) + a new "audience & sessions" card. Cost now shown in CNY at DeepSeek V4-Flash native list price.

## Notes / caveats
- **"Person" ≈ visit sid** (no login). The card labels it "active visitor" and activation as "interacted / visited" — it does not claim true per-user numbers.
- **Forward-looking:** historical `askiris_turn` rows lack the keys and `askiris_view` is new, so the funnel fills once deployed and real traffic flows.
- **AE distinct counts are approximate under sampling** (as elsewhere on the dashboard); fine at current volume.
- `segment_id` doubles as the join key a future transcript-replay store would persist against — no rework needed there.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vitest run analytics-format.test.ts` passes (8/8)
- [ ] AE data is only visible on `wrangler preview` / prod, not `next dev` — verify the card populates after deploy
