### PR TITLE
feat(analytics): drop rate-bypass traffic from all dashboards

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -254,13 +254,14 @@ const Q_PWA_LAUNCH = `
 
 // AskIris — per-turn agent metrics written straight to AE from the chat route's
 // onEnd (not via /api/track), so these rows carry their own positional layout:
-// blob1=mount, blob2=locale, blob3=sid, blob4=segment_id; double1..6 =
+// blob1=mount, blob2=locale, blob3=sid, blob4=segment_id, blob5=internal; double1..6 =
 // total/input/output/cacheRead tokens, step_count, budget_hit. Counts weight by
 // _sample_interval; summed metrics weight each row's value by it too, to stay correct
 // if AE ever samples this dataset. The funnel's page-view entry is a separate
-// askiris_view event on the general /api/track layout (blob1=sid).
-const ASKIRIS_FILTER = `index1 = '${ASKIRIS_TURN_EVENT}' AND timestamp > NOW() - ${WINDOW}`;
-const ASKIRIS_VIEW_FILTER = `index1 = 'askiris_view' AND timestamp > NOW() - ${WINDOW}`;
+// Both drop internal rows (dogfooding / load tests). The turn layout carries the
+// flag in blob5; askiris_view rides the general /api/track layout, where it's blob7.
+const ASKIRIS_FILTER = `index1 = '${ASKIRIS_TURN_EVENT}' AND timestamp > NOW() - ${WINDOW} AND blob5 != '1'`;
+const ASKIRIS_VIEW_FILTER = `index1 = 'askiris_view' AND timestamp > NOW() - ${WINDOW} AND blob7 != '1'`;
 
 const Q_ASKIRIS_OVERVIEW = `
   SELECT

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -15,7 +15,7 @@ import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
 import { askirisTurnDataPoint } from "@/lib/analytics/events";
-import { parseSid } from "@/lib/analytics/session";
+import { parseSid, parseInternal } from "@/lib/analytics/session";
 import { MOUNTS } from "@/lib/mount";
 import { routing } from "@/i18n/routing";
 import type { Mount } from "@/lib/types";
@@ -128,9 +128,15 @@ export async function POST(req: Request) {
   // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
   // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
   const ip = clientIp(req);
+  const cookieHeader = req.headers.get("cookie");
   // Read the anonymous visit id set by /api/track; "" for a turn before its first
   // call. We only read it here — /api/track owns minting and refreshing the cookie.
-  const sid = parseSid(req.headers.get("cookie")) ?? "";
+  const sid = parseSid(cookieHeader) ?? "";
+  // Secret-gated bypass: skips the rate limiter AND (as internal traffic) drops the
+  // turn from the dashboard. xg_internal can also mark a turn internal, but must not
+  // grant the bypass — so the limiter checks `bypassed` only, not `internal`.
+  const bypassed = isBypassed(req, process.env.RATE_LIMIT_BYPASS);
+  const internal = parseInternal(cookieHeader) || bypassed;
   let rateKv: KVNamespace | undefined;
   let ae: AnalyticsEngineDataset | undefined;
   let ctx: ExecutionContext | undefined;
@@ -139,7 +145,7 @@ export async function POST(req: Request) {
     rateKv = cf.env.RATE_KV;
     ae = cf.env.ANALYTICS;
     ctx = cf.ctx;
-    if (rateKv && ip && !isBypassed(req, process.env.RATE_LIMIT_BYPASS)) {
+    if (rateKv && ip && !bypassed) {
       const verdict = await checkRateLimit(rateKv, ip);
       if (!verdict.ok) {
         return chatErrorResponse("rate_limit", 429);
@@ -191,6 +197,7 @@ export async function POST(req: Request) {
               locale,
               sid,
               segmentId: segmentId ?? "",
+              internal,
               totalTokens: usage.totalTokens ?? 0,
               inputTokens: usage.inputTokens ?? 0,
               outputTokens: usage.outputTokens ?? 0,

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -17,7 +17,8 @@ import {
   type EventProps,
   type TrackPayload,
 } from "@/lib/analytics/events";
-import { SID_COOKIE, SID_TTL_SECONDS, parseSid } from "@/lib/analytics/session";
+import { SID_COOKIE, SID_TTL_SECONDS, parseSid, parseInternal } from "@/lib/analytics/session";
+import { isBypassed } from "@/lib/ai/rate-limit";
 
 const MAX_BODY_BYTES = 4096;
 const MAX_STRING_LEN = 256;
@@ -54,19 +55,6 @@ function isValidPayload(p: unknown): p is TrackPayload {
     return false;
   }
   return true;
-}
-
-function parseInternal(cookieHeader: string | null): boolean {
-  if (!cookieHeader) {
-    return false;
-  }
-  for (const part of cookieHeader.split(";")) {
-    const [k, v] = part.trim().split("=");
-    if (k === "xg_internal" && v === "1") {
-      return true;
-    }
-  }
-  return false;
 }
 
 function sanitizeProps(raw: unknown): EventProps {
@@ -117,7 +105,11 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   const cookieHeader = req.headers.get("cookie");
   const sid = parseSid(cookieHeader) ?? crypto.randomUUID();
-  const internal = parseInternal(cookieHeader);
+  // A valid rate-limit bypass (secret-gated) also counts as internal, so load
+  // tests / dogfooding done with that cookie vanish from every dashboard, not
+  // just AskIris. The xg_internal flag stays an independent, weaker trigger.
+  const internal =
+    parseInternal(cookieHeader) || isBypassed(req, process.env.RATE_LIMIT_BYPASS);
 
   try {
     const { env } = getCloudflareContext();

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -131,7 +131,7 @@ export function toDataPoint(
 // Its own positional layout in the same dataset; query it by the index. Token counts
 // can be missing from a provider, recorded as 0.
 //   indexes: [askiris_turn]
-//   blobs:   [mount, locale, sid, segment_id]
+//   blobs:   [mount, locale, sid, segment_id, internal]
 //   doubles: [total, input, output, cacheRead tokens, step_count, budget_hit]
 export const ASKIRIS_TURN_EVENT = "askiris_turn";
 
@@ -145,6 +145,9 @@ export interface AskIrisTurnMetrics {
   // when unknown (no cookie yet / a legacy client), which the queries filter out.
   sid: string;
   segmentId: string;
+  // Keep this row out of the dashboards (dogfooding / load tests via the bypass or
+  // xg_internal cookie). The row is still written — the AskIris queries filter it.
+  internal: boolean;
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;
@@ -155,12 +158,12 @@ export interface AskIrisTurnMetrics {
 
 export function askirisTurnDataPoint(m: AskIrisTurnMetrics): {
   indexes: [string];
-  blobs: [string, string, string, string];
+  blobs: [string, string, string, string, string];
   doubles: [number, number, number, number, number, number];
 } {
   return {
     indexes: [ASKIRIS_TURN_EVENT],
-    blobs: [m.mount, m.locale, m.sid, m.segmentId],
+    blobs: [m.mount, m.locale, m.sid, m.segmentId, m.internal ? "1" : ""],
     doubles: [
       m.totalTokens,
       m.inputTokens,

--- a/src/lib/analytics/session.ts
+++ b/src/lib/analytics/session.ts
@@ -20,3 +20,23 @@ export function parseSid(cookieHeader: string | null): string | null {
   }
   return null;
 }
+
+// Marks traffic to keep out of the dashboards (dogfooding, load tests). A mere
+// presence flag — forgeable, but the only privilege it grants is self-exclusion
+// from analytics, so a forged one is harmless. A valid rate-limit bypass also
+// implies internal (the callers OR it in); the reverse is deliberately not true —
+// this flag must never grant the bypass, which is why bypass checks a secret.
+export const INTERNAL_COOKIE = "xg_internal";
+
+export function parseInternal(cookieHeader: string | null): boolean {
+  if (!cookieHeader) {
+    return false;
+  }
+  for (const part of cookieHeader.split(";")) {
+    const [k, v] = part.trim().split("=");
+    if (k === INTERNAL_COOKIE && v === "1") {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
+import { INTERNAL_COOKIE } from "@/lib/analytics/session";
 
 // INTERNAL PARAM — xg_internal is the internal-user gate cookie (set here after
-// passing Cloudflare Access on /admin). When changing how it is set/named, keep
-// the Atlens Obsidian doc "Internal params & cookies" (Engineering/) in sync.
-const INTERNAL_COOKIE = "xg_internal";
+// passing Cloudflare Access on /admin), read by the analytics routes to drop the
+// traffic from dashboards. When changing how it is set/named, keep the Atlens
+// Obsidian doc "Internal params & cookies" (Engineering/) in sync.
 const COUNTRY_COOKIE = "xg_country";
 const ONE_YEAR = 60 * 60 * 24 * 365;
 


### PR DESCRIPTION
## What

A valid `rate_bypass` cookie (secret-gated) now also marks traffic as **internal**, so load tests / dogfooding done with that cookie fall out of **every** first-party dashboard — not just AskIris.

`xg_internal` stays an independent, weaker trigger. The rate limiter still checks the bypass **secret** only, so the forgeable `xg_internal` flag can never grant a bypass — trust flows strong→weak, never the reverse.

## Changes

- Extract `parseInternal` + `INTERNAL_COOKIE` into `analytics/session.ts` (single source), shared by `middleware`, `/api/track`, `/api/chat`; remove the duplicated copies.
- `/api/track` and `/api/chat`: `internal = parseInternal(cookie) || isBypassed(req, secret)`.
- `askiris_turn` gains an internal blob (`blob5`); the AskIris turn queries filter it.
- **Fix pre-existing bug**: the `askiris_view` query never excluded internal (`blob7`), so internal page views were polluting AskIris PV/UV.

## Notes

- **tag-and-filter, not drop**: rows are still written and filtered at query time, so bypass traffic stays auditable via an internal-only query.
- Site-wide general dashboards need no query change — they already filter `blob7 != '1'`; only the recording side (the `||` in `/api/track`) is new. Only AskIris needed the two query fixes.
- Internal-params registry (Obsidian `Engineering/内部调试参数与 Cookie`) updated: `rate_bypass` registered, `xg_internal` semantics + single-source noted.

## Test

- `tsc --noEmit`, `eslint`, `vitest` (392 passed), `next build` (447 routes prerendered, middleware compiles) all green locally.
- Analytics only visible on preview/prod, not `next dev` — verify on the CF preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)