### PR TITLE
fix(test): scope Vitest collection to this tree's src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "typecheck": "wrangler types --env-interface CloudflareEnv && tsc --noEmit",
-    "test": "vitest run src",
-    "test:watch": "vitest src",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
   test: {
     environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
+    // Anchored at the project root, so only this tree's src/ is collected.
+    // Vitest's default is `**/*.{test,spec}...`, whose leading `**/` also
+    // matches src/ copies inside nested git worktrees — those sit on older
+    // commits and fail against the current tree. Anchoring fixes that for any
+    // nested checkout regardless of where it lives; .gitignore has no effect
+    // on test collection. e2e/ is Playwright's, run by `test:e2e`.
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem

Running `pnpm run test` in the main checkout collects test files from the git worktrees nested under it and reports them as failures. On `main` that was 12 failures across 2 files — all from worktree copies, none from the actual tree:

```
❯ .claude/worktrees/sleepy-wishing-tiger/src/hooks/__tests__/useCompareLensSearch.test.tsx (6 failed)
❯ .claude/worktrees/pnpm-migration/src/hooks/__tests__/useCompareLensSearch.test.tsx  (6 failed)
```

Those worktrees sit on older commits, so their tests no longer match the current implementation. The runs are real — just of stale code. The suite therefore cannot be trusted whenever a worktree exists, which for this repo is most of the time.

## Cause

Vitest's default `include` is `**/*.{test,spec}.?(c|m)[jt]s?(x)`. The leading `**/` matches a `src/` at **any depth**, including inside a nested checkout.

Two things that look like they should prevent this do not:

- The `src` argument in `vitest run src` is a **path filter, not a directory scope** — `.claude/worktrees/<name>/src/…` contains `src`, so it matches.
- **`.gitignore` has no bearing on test collection.** This repo already lists `.claude/` (`.gitignore:61`), which is why the directory is otherwise invisible, but Vitest never consults it.

## Fix

Anchor `include` at the project root:

```ts
include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
```

The pattern is resolved relative to the Vitest root, so it matches only this tree's `src/` — a nested checkout at any depth is out of scope by construction.

**Why not exclude a known path.** Excluding `.claude/**` fixes today's layout only. It assumes worktrees live where Claude Code happens to put them; a different agent, or a different configured location, and the problem returns silently. Anchoring the include describes what *should* be collected rather than enumerating what should not.

That difference is measurable. With four stale copies planted under `.claude/`, `.codex/`, `.cursor/` and `wt/`:

| Approach | Collected the stale copies? |
|---|---|
| `exclude: [...configDefaults.exclude, '**/.claude/**']` | 14 files failed of 31 — three of four leaked through |
| `include: ['src/**/…']` (this PR) | none — 17 files / 392 tests |

`vitest run src` becomes `vitest run`: the config now scopes collection, so the CLI argument is redundant and having both invites them to drift apart. `test:watch` likewise drops its `src`.

`e2e/` holds 11 Playwright specs, run separately by `test:e2e`, and is unaffected — it was already outside what `vitest run src` matched.

## Verification

- Reproduced the exact failure shape with a planted failing test, then confirmed the fix excludes it — across all four locations above.
- Real suite unchanged at **17 files / 392 tests**, confirming the anchored pattern does not over-match.
- `pnpm run lint` (0 errors) and `pnpm run typecheck` pass.

Note that CI cannot exercise this: its checkout has no nested worktrees, so the bug never appears there. Green checks here only show nothing else broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)