### PR TITLE
refactor(askiris): follow the repo's own client-component conventions

### DIFF
--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -276,20 +276,10 @@ export default function AskIrisChat({
               item.kind === "divider" ? (
                 <AskIrisDivider key={`d${i}`} label={item.label} />
               ) : (
-                <AskIrisThread
-                  key={`s${i}`}
-                  messages={item.messages}
-                  locale={locale}
-                  debug={debug}
-                />
+                <AskIrisThread key={`s${i}`} messages={item.messages} debug={debug} />
               ),
             )}
-            <AskIrisThread
-              messages={renderMessages}
-              locale={locale}
-              debug={debug}
-              busy={isBusy}
-            />
+            <AskIrisThread messages={renderMessages} debug={debug} busy={isBusy} />
             {/* Surface a failed turn: useChat catches request/stream errors into
                 status "error" but renders nothing on its own. Only the transient
                 case offers a retry (inline verb, re-runs the last turn with

--- a/src/components/askiris/AskIrisThread.tsx
+++ b/src/components/askiris/AskIrisThread.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   getToolName,
   isToolUIPart,
@@ -69,11 +71,9 @@ function ToolTrace({ part }: { part: ToolUIPart | DynamicToolUIPart }) {
 // of a turn inspectable without changing what a normal reader sees.
 function ToolPart({
   part,
-  locale,
   debug,
 }: {
   part: ToolUIPart | DynamicToolUIPart;
-  locale: string;
   debug: boolean;
 }) {
   if (part.state === "output-available") {
@@ -85,7 +85,7 @@ function ToolPart({
         // so without this they glue to the cards.
         return (
           <div className="mb-4 w-full">
-            <RecommendationDeck recommendations={recommendations} locale={locale} />
+            <RecommendationDeck recommendations={recommendations} />
           </div>
         );
       }
@@ -143,12 +143,10 @@ function activityKey(messages: UIMessage[], busy: boolean, debug: boolean): Acti
 
 export default function AskIrisThread({
   messages,
-  locale,
   debug = false,
   busy = false,
 }: {
   messages: UIMessage[];
-  locale: string;
   debug?: boolean;
   busy?: boolean;
 }) {
@@ -198,7 +196,7 @@ export default function AskIrisThread({
                 );
               }
               if (isToolUIPart(part)) {
-                return <ToolPart key={key} part={part} locale={locale} debug={debug} />;
+                return <ToolPart key={key} part={part} debug={debug} />;
               }
               return null;
             })}

--- a/src/components/askiris/Markdown.tsx
+++ b/src/components/askiris/Markdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";

--- a/src/components/askiris/RecommendationDeck.tsx
+++ b/src/components/askiris/RecommendationDeck.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useLocale } from "next-intl";
 import { Weight } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { track } from "@/lib/analytics/analytics";
@@ -17,15 +18,13 @@ import type { Recommendation } from "@/lib/ai/recall";
 // essay the reader has to map back onto a card.
 export default function RecommendationDeck({
   recommendations,
-  locale,
 }: {
   recommendations: Recommendation[];
-  locale: string;
 }) {
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {recommendations.map((rec) => (
-        <RecommendationCard key={rec.id} rec={rec} locale={locale} />
+        <RecommendationCard key={rec.id} rec={rec} />
       ))}
     </div>
   );
@@ -49,7 +48,8 @@ function priceParts(
 // Two rows: a header (thumbnail + name + price/weight) and the reason on its own
 // full-width row below, so the reason spans the whole card instead of a narrow
 // column beside the thumbnail — fewer wrapped lines, better use of the space.
-function RecommendationCard({ rec, locale }: { rec: Recommendation; locale: string }) {
+function RecommendationCard({ rec }: { rec: Recommendation }) {
+  const locale = useLocale();
   const weight = rec.weightG != null ? weightDisplay(rec.weightG, "g") : null;
   const price = rec.price ? priceParts(rec.price, locale) : null;
 


### PR DESCRIPTION
Two places where the AskIris components diverge from what the rest of `src/components` already does. No behaviour change.

## `locale` was drilled three levels

```
AskIrisChat          uses it (sendMessage body)
  └─ AskIrisThread     signature + forward only
       └─ ToolPart          signature + forward only
            └─ RecommendationDeck   uses it (currency/condition wording)
```

Twelve client components elsewhere — `PriceCell`, `CompareTable`, `ShareButton`, `CompareCollections`, … — call `useLocale()` instead, and `NextIntlClientProvider` wraps the tree from `[locale]/layout.tsx`. `RecommendationDeck` now does the same, and the prop drops out of three signatures.

## Two modules used client-only hooks without `"use client"`

`AskIrisThread` (`useTranslations`) and `Markdown` (`useLensLinks` → `useContext`). They work today only because every importer is itself a client component — a server component importing either would fail the build. Across the 89 component files these were two of the three without the directive.

## Test plan

- `pnpm test` — 405 pass
- `pnpm run build` — clean