### PR TITLE
fix(askiris): name the end each sort leads with, drop sortDir

### DIFF
--- a/eval/promptfoo/promptfooconfig.yaml
+++ b/eval/promptfoo/promptfooconfig.yaml
@@ -166,9 +166,9 @@ tests:
         turns:
           - "想拍远处的野生动物和鸟，镜头要够长、够得着，越远越好，机身 X-T5，预算不太在意。"
     assert:
-      - type: javascript # steered recall with an explicit reach sort (not a coversFocals filter)
+      - type: javascript # steered recall toward the long end (not a coversFocals filter)
         metric: programmatic
-        value: 'context.metadata.sortBys.includes("reach")'
+        value: 'context.metadata.queries.some((q) => q.input.sortBy === "longestReach")'
       - type: javascript # at least one pick reaches >= 300mm native
         metric: programmatic
         value: "context.metadata.picks.some((p) => p.fmax != null && p.fmax >= 300)"

--- a/src/lib/ai/__tests__/recall.test.ts
+++ b/src/lib/ai/__tests__/recall.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { recallLenses, type LensConstraints, type RecalledLens } from "../recall";
+import {
+  recallLenses,
+  RECALL_SORTS,
+  RECALL_SORT_NAMES,
+  type LensConstraints,
+  type RecalledLens,
+} from "../recall";
 import { lensRef } from "../lens-ref";
 import { getLensesByMount } from "@/lib/lens/data";
 
@@ -92,29 +98,52 @@ describe("recallLenses · filter correctness (precision / recall on labelled que
   });
 });
 
-// Sorting is on the raw value with asc as the default, so for four of the nine axes the
-// end a request usually wants — the longest reach, the most magnification, the widest
-// zoom range, the newest lens — is the one asc puts LAST, where the RECALL_LIMIT cap then
-// cuts it off. sortDir's description is what tells the model that; these pin the runtime
-// side of it so the two can't drift apart silently.
-describe("recallLenses · sort direction", () => {
-  const firstValue = (constraints: LensConstraints, read: (l: RecalledLens) => number | null) =>
+// Every sort name promises which end leads, and the RECALL_LIMIT cap makes that promise
+// load-bearing: whatever the sort puts last is what the model never sees. These assert the
+// promise against the catalogue, so a name can't come to mean its opposite the way
+// zoomRatio-ascending once did while its gloss read "most versatile".
+describe("recallLenses · each sort name leads with the end it names", () => {
+  const lead = (constraints: LensConstraints, read: (l: RecalledLens) => number | null) =>
     read(recall(constraints, RECALL_LIMIT).matches[0]);
 
   it.each([
-    ["reach", (l: RecalledLens) => l.focalNativeMm[1]],
-    ["zoomRatio", (l: RecalledLens) => l.focalNativeMm[1] / l.focalNativeMm[0]],
-  ] as const)("%s ranks low-end-first under asc and high-end-first under desc", (sortBy, read) => {
-    const asc = firstValue({ type: "zoom", sortBy }, read);
-    const desc = firstValue({ type: "zoom", sortBy, sortDir: "desc" }, read);
-    expect(asc).not.toBeNull();
-    expect(desc as number).toBeGreaterThan(asc as number);
+    ["longestReach", "widest", (l: RecalledLens) => l.focalNativeMm[1]],
+    ["widestZoomRange", "widest", (l: RecalledLens) => l.focalNativeMm[1] / l.focalNativeMm[0]],
+    ["heaviest", "lightest", (l: RecalledLens) => l.weightG],
+    ["priciest", "cheapest", (l: RecalledLens) => l.price?.amount ?? null],
+    ["newest", "oldest", (l: RecalledLens) => l.releaseYear ?? null],
+  ] as const)("%s leads with a larger value than %s", (high, low, read) => {
+    const hi = lead({ type: "zoom", sortBy: high }, read);
+    const lo = lead({ type: "zoom", sortBy: low }, read);
+    expect(hi).not.toBeNull();
+    expect(lo).not.toBeNull();
+    expect(hi as number).toBeGreaterThan(lo as number);
   });
 
-  it("weightG already leads with the lightest under asc, so it needs no sortDir", () => {
-    const asc = firstValue({ type: "prime", sortBy: "weightG" }, (l) => l.weightG);
-    const desc = firstValue({ type: "prime", sortBy: "weightG", sortDir: "desc" }, (l) => l.weightG);
-    expect(asc as number).toBeLessThan(desc as number);
+  // The two axes whose named end is the SMALLER value, so a sign error here reads as a
+  // pass on the table above.
+  it.each([
+    ["fastest", (l: RecalledLens) => wideAperture(l.maxAperture)],
+    ["mostCompact", (l: RecalledLens) => l.length?.mm ?? null],
+  ] as const)("%s leads with the smallest value on its axis", (sortBy, read) => {
+    const leadValue = lead({ type: "prime", sortBy }, read);
+    const rest = recall({ type: "prime", sortBy }, RECALL_LIMIT)
+      .matches.map(read)
+      .filter((v): v is number => v !== null);
+    expect(leadValue).not.toBeNull();
+    expect(leadValue as number).toBe(Math.min(...rest));
+  });
+
+  it("mostMagnification leads with the highest magnification", () => {
+    const { matches } = recall({ sortBy: "mostMagnification" }, RECALL_LIMIT);
+    const values = matches.map((l) => l.magnification).filter((v): v is number => v !== null);
+    expect(matches[0].magnification).toBe(Math.max(...values));
+  });
+
+  it("every name in the schema is covered by a runtime mapping", () => {
+    for (const name of RECALL_SORT_NAMES) {
+      expect(RECALL_SORTS[name], `${name} has no field/direction`).toBeDefined();
+    }
   });
 });
 

--- a/src/lib/ai/__tests__/recall.test.ts
+++ b/src/lib/ai/__tests__/recall.test.ts
@@ -92,6 +92,32 @@ describe("recallLenses · filter correctness (precision / recall on labelled que
   });
 });
 
+// Sorting is on the raw value with asc as the default, so for four of the nine axes the
+// end a request usually wants — the longest reach, the most magnification, the widest
+// zoom range, the newest lens — is the one asc puts LAST, where the RECALL_LIMIT cap then
+// cuts it off. sortDir's description is what tells the model that; these pin the runtime
+// side of it so the two can't drift apart silently.
+describe("recallLenses · sort direction", () => {
+  const firstValue = (constraints: LensConstraints, read: (l: RecalledLens) => number | null) =>
+    read(recall(constraints, RECALL_LIMIT).matches[0]);
+
+  it.each([
+    ["reach", (l: RecalledLens) => l.focalNativeMm[1]],
+    ["zoomRatio", (l: RecalledLens) => l.focalNativeMm[1] / l.focalNativeMm[0]],
+  ] as const)("%s ranks low-end-first under asc and high-end-first under desc", (sortBy, read) => {
+    const asc = firstValue({ type: "zoom", sortBy }, read);
+    const desc = firstValue({ type: "zoom", sortBy, sortDir: "desc" }, read);
+    expect(asc).not.toBeNull();
+    expect(desc as number).toBeGreaterThan(asc as number);
+  });
+
+  it("weightG already leads with the lightest under asc, so it needs no sortDir", () => {
+    const asc = firstValue({ type: "prime", sortBy: "weightG" }, (l) => l.weightG);
+    const desc = firstValue({ type: "prime", sortBy: "weightG", sortDir: "desc" }, (l) => l.weightG);
+    expect(asc as number).toBeLessThan(desc as number);
+  });
+});
+
 describe("recallLenses · truncation under the no-sortBy default", () => {
   // "Show me zooms" over-matches (35 zooms > RECALL_LIMIT). With no sortBy the default is
   // wideEnd-ascending, so in isolation the cap keeps the 20 widest zooms and drops the most

--- a/src/lib/ai/recall.ts
+++ b/src/lib/ai/recall.ts
@@ -29,18 +29,45 @@ const SPECIALTY_TRAITS: readonly OpticalTrait[] = [
 
 // Recall-local sort axes, NOT the UI's SORT_KEYS — recall needs unambiguous focal
 // ends (reach/wideEnd) plus axes the browse UI lacks (magnification, zoomRatio).
-export const RECALL_SORT_FIELDS = [
-  "reach", // longest focal reach (tele end)
-  "wideEnd", // widest focal (wide end)
-  "weightG",
-  "maxAperture",
-  "length",
-  "price",
-  "magnification",
-  "zoomRatio",
-  "releaseYear",
-] as const;
-export type SortField = (typeof RECALL_SORT_FIELDS)[number];
+export type SortField =
+  | "reach" // the lens's longest focal length (tele end)
+  | "wideEnd" // the lens's shortest focal length (wide end)
+  | "weightG"
+  | "maxAperture" // the f-number, so a faster lens is a smaller value
+  | "length"
+  | "price"
+  | "magnification"
+  | "zoomRatio"
+  | "releaseYear";
+
+// What the model picks from: each name states the end it puts first, and the direction is
+// baked in rather than left to a companion parameter. A field plus a direction lets a
+// request for the most versatile zoom arrive as zoomRatio ascending — the twenty least
+// versatile — and nothing about the call looks wrong. A name cannot be pointed backwards.
+//
+// A field appears twice only where both ends answer a question someone asks; the other
+// ends are reachable as constraints, where an "under 200g" intent belongs anyway.
+export const RECALL_SORTS = {
+  widest: ["wideEnd", "asc"],
+  longestReach: ["reach", "desc"],
+  lightest: ["weightG", "asc"],
+  heaviest: ["weightG", "desc"],
+  fastest: ["maxAperture", "asc"],
+  mostCompact: ["length", "asc"],
+  cheapest: ["price", "asc"],
+  priciest: ["price", "desc"],
+  mostMagnification: ["magnification", "desc"],
+  widestZoomRange: ["zoomRatio", "desc"],
+  newest: ["releaseYear", "desc"],
+  oldest: ["releaseYear", "asc"],
+} as const satisfies Record<string, readonly [SortField, "asc" | "desc"]>;
+
+export type RecallSort = keyof typeof RECALL_SORTS;
+export const RECALL_SORT_NAMES = Object.keys(RECALL_SORTS) as [RecallSort, ...RecallSort[]];
+
+// Applied when a call names no sort. Widest-first is the least opinionated ordering of a
+// focal-diverse result set, not a claim that wide is better.
+const DEFAULT_SORT: RecallSort = "widest";
 
 // Spec columns listLenses can lay side by side. The lens name is always the first
 // column (and a link), so these are the comparison fields the model picks from to
@@ -98,8 +125,7 @@ export interface LensConstraints {
   minApertureBladeCount?: number;
   // Only lenses released in or after this year.
   minReleaseYear?: number;
-  sortBy?: SortField;
-  sortDir?: "asc" | "desc";
+  sortBy?: RecallSort;
 }
 
 // The lens as the model and the card see it: a locale-resolved projection of the
@@ -524,8 +550,7 @@ export function recallLenses(
     }
   }
 
-  const key = constraints.sortBy ?? "wideEnd";
-  const dir = constraints.sortDir ?? "asc";
+  const [key, dir] = RECALL_SORTS[constraints.sortBy ?? DEFAULT_SORT];
   const sortedMatched = sortRecalled(matched, key, dir, locale);
   const sortedMaybe = sortRecalled(
     maybe.map((m) => m.lens),

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -147,13 +147,16 @@ export function buildLensTools(
           .enum(RECALL_SORT_FIELDS)
           .optional()
           .describe(
-            "Ranks the matches by a single axis; it orders the results, it never excludes any. " +
-              "reach = longest focal reach; wideEnd = widest; " +
-              "weightG = lightest; maxAperture = fastest; length = most compact; price = " +
-              "cheapest; magnification = best close-up; zoomRatio = most versatile / one-lens; " +
-              "releaseYear = newest (with sortDir: desc).",
+            "Ranks the matches by a single axis; it orders the results, it never excludes any.",
           ),
-        sortDir: z.enum(["asc", "desc"]).optional().describe("asc (default) = smallest first."),
+        sortDir: z
+          .enum(["asc", "desc"])
+          .optional()
+          .describe(
+            "asc (default) ranks from the smallest value: lightest, cheapest, most compact, " +
+              "widest, fastest. The other four axes — reach, magnification, zoomRatio, " +
+              "releaseYear — put their desirable end first only under desc.",
+          ),
       }),
       execute: (constraints) => {
         const result = recallLenses(mount, locale, constraints, tBrand, RECALL_LIMIT);
@@ -232,7 +235,7 @@ export function buildLensTools(
     recommendLenses: tool({
       description:
         "Present picks as a grid of recommendation cards (up to 6, ordered best-first). Pass each " +
-        "lens's id from a prior queryLenses/searchLensByName result and its reason, which is " +
+        "lens's ref from a prior queryLenses/searchLensByName result and its reason, which is " +
         "shown on the lens's card.",
       inputSchema: z.object({
         picks: z

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -9,7 +9,7 @@ import {
   listLenses,
   resolveLens,
   toRecalled,
-  RECALL_SORT_FIELDS,
+  RECALL_SORT_NAMES,
   LENS_TABLE_COLUMNS,
 } from "@/lib/ai/recall";
 import { lensRef, buildRefIndex } from "@/lib/ai/lens-ref";
@@ -144,18 +144,12 @@ export function buildLensTools(
           .optional()
           .describe("Only lenses released in or after this year; a hard lower bound."),
         sortBy: z
-          .enum(RECALL_SORT_FIELDS)
+          .enum(RECALL_SORT_NAMES)
           .optional()
           .describe(
-            "Ranks the matches by a single axis; it orders the results, it never excludes any.",
-          ),
-        sortDir: z
-          .enum(["asc", "desc"])
-          .optional()
-          .describe(
-            "asc (default) ranks from the smallest value: lightest, cheapest, most compact, " +
-              "widest, fastest. The other four axes — reach, magnification, zoomRatio, " +
-              "releaseYear — put their desirable end first only under desc.",
+            "Which lenses lead the results. It orders them, it never excludes any, so the " +
+              "cap keeps the ones this names. fastest = widest maximum aperture; " +
+              "widestZoomRange = highest ratio of longest to shortest focal.",
           ),
       }),
       execute: (constraints) => {


### PR DESCRIPTION
`sortBy` named a field and `sortDir` a direction, so *"the most versatile zoom"* could arrive as `zoomRatio` ascending — the twenty **least** versatile — with nothing about the call looking wrong.

`sortBy`'s glosses made that likely. Recall sorts on the raw value with `asc` as the default (`recall.ts`), but the glosses named the **largest** value on three axes:

| axis | old gloss | what the default `asc` returned |
|---|---|---|
| `reach` | longest focal reach | shortest tele end |
| `magnification` | best close-up | lowest magnification |
| `zoomRatio` | most versatile / one-lens | lowest zoom ratio |
| `releaseYear` | newest **(with sortDir: desc)** | the only one that said `desc` |

## One parameter whose values state their own direction

```
widest  longestReach  lightest  heaviest  fastest  mostCompact
cheapest  priciest  mostMagnification  widestZoomRange  newest  oldest
```

`sortDir` is gone. A name cannot be pointed backwards, so the failure mode is removed rather than documented — and the eval can now assert intent (`sortBy === "longestReach"`) instead of just the axis.

Six of the eighteen old field × direction combinations have no name:

| dropped | reachable how |
|---|---|
| `reach` asc — "not too long" | `focalWithin.max` |
| `wideEnd` desc — "starts long" | `minReach` / `focalWithin.min` |
| `zoomRatio` asc — "not a superzoom" | `maxApertureF` (approximately) |
| `magnification` asc | nothing asks for it |
| `maxAperture` desc — slowest first | no equivalent; genuinely dropped |
| `length` desc — longest barrel first | no equivalent; genuinely dropped |

The first four are intents that want *exclusion*, which is what a constraint does; sorting was the wrong tool for them anyway.

## Two fixes found on the way

- `recommendLenses`' description still told the model to pass each lens's **id**. Its schema has taken a **ref** since #437.
- The `reach-wildlife` assertion read `context.metadata.sortBys`, which **the provider has never set** — it threw rather than checked. It now reads `queries`, which the provider does expose. Two further assertions reference metadata keys that do not exist (`openedCine`, `overMatched`); those belong to the eval suite's own PR.

## Test plan

- `pnpm test` — 414 pass, including nine new ones asserting each name leads with the end it names, plus a check that every schema value has a runtime mapping.
- Mutation-verified: flipping `widestZoomRange` back to ascending and `fastest` to descending fails exactly those two tests.
- Schema cost: `queryLenses` 4359B → **4251B**; total tool surface 7372B → **7264B** (~1816 tokens/step).

Net token savings are incidental — the description slimming is a separate follow-up.
