### PR TITLE
feat(askiris): reach Google and OpenRouter models, pin the temperature

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@ai-sdk/deepseek": "^3.0.2",
+    "@ai-sdk/google": "^4.0.27",
     "@ai-sdk/openai": "^4.0.7",
     "@ai-sdk/react": "^4.0.9",
     "@base-ui/react": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/deepseek':
         specifier: ^3.0.2
         version: 3.0.2(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: ^4.0.27
+        version: 4.0.27(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^4.0.7
         version: 4.0.7(zod@4.4.3)
@@ -162,6 +165,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/google@4.0.27':
+    resolution: {integrity: sha512-u44UuLypwwHqEaHPRV1iZ1N+xO9dCKzQX6L2DtPPxvlsSdSzNobUBz8oaDv6NzC35qYSb6JFs7TG1Tz2Nxlg/Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/mcp@2.0.4':
     resolution: {integrity: sha512-o5edIxgQrssKl/DABaXOzTUG/DUOyn25ilnnczQeLpnlSEUNXqYc3TSOZ7u6aBB+vkersQ7MXkfNMzqulR6CKw==}
     engines: {node: '>=22'}
@@ -170,6 +179,12 @@ packages:
 
   '@ai-sdk/openai@4.0.7':
     resolution: {integrity: sha512-55K0j8RRjcKosUvIl8u/+SMaS1wedq77xN2iuhlOvB/USbIgSmjkWKV9lqGhhp+Qxhnm3qg5NzrqOI1jmra9fQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.14':
+    resolution: {integrity: sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -192,6 +207,10 @@ packages:
 
   '@ai-sdk/provider@4.0.2':
     resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/react@4.0.9':
@@ -5701,6 +5720,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/google@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/mcp@2.0.4(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.1
@@ -5712,6 +5737,14 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.2(zod@4.4.3)':
@@ -5735,6 +5768,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.2':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,7 +10,7 @@ import {
 import { z } from "zod";
 import { getTranslations } from "next-intl/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { getAgentModel, agentProviderOptions } from "@/lib/ai/model";
+import { getAgentModel, agentProviderOptions, AGENT_TEMPERATURE } from "@/lib/ai/model";
 import { systemPrompt } from "@/lib/ai/system-prompt";
 import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
@@ -110,6 +110,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: getAgentModel(),
     providerOptions: agentProviderOptions,
+    temperature: AGENT_TEMPERATURE,
     system: systemPrompt(mount, locale),
     messages: modelMessages,
     tools,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,7 +13,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import {
   getAgentModel,
   agentProviderOptions,
-  agentModelProblem,
+  missingAgentModelKey,
   AGENT_TEMPERATURE,
 } from "@/lib/ai/model";
 import { systemPrompt } from "@/lib/ai/system-prompt";
@@ -53,11 +53,10 @@ const STEP_BUDGET = 8;
 const STREAM_TIMEOUT_MS = 120_000;
 
 export async function POST(req: Request) {
-  // Whichever provider AGENT_MODEL selects, not a hardcoded one — the model layer owns
-  // which key its active provider needs.
-  const modelProblem = agentModelProblem();
-  if (modelProblem) {
-    console.error(`[askiris] ${modelProblem}`);
+  // Whichever provider AGENT_MODEL selects, not a hardcoded one.
+  const missingKey = missingAgentModelKey();
+  if (missingKey) {
+    console.error(`[askiris] ${missingKey} is not set`);
     return chatErrorResponse("unavailable", 500);
   }
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,7 +10,12 @@ import {
 import { z } from "zod";
 import { getTranslations } from "next-intl/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { getAgentModel, agentProviderOptions, AGENT_TEMPERATURE } from "@/lib/ai/model";
+import {
+  getAgentModel,
+  agentProviderOptions,
+  agentModelProblem,
+  AGENT_TEMPERATURE,
+} from "@/lib/ai/model";
 import { systemPrompt } from "@/lib/ai/system-prompt";
 import { buildLensTools } from "@/lib/ai/tools";
 import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
@@ -48,8 +53,11 @@ const STEP_BUDGET = 8;
 const STREAM_TIMEOUT_MS = 120_000;
 
 export async function POST(req: Request) {
-  if (!process.env.DEEPSEEK_API_KEY) {
-    console.error("[askiris] DEEPSEEK_API_KEY is not set");
+  // Whichever provider AGENT_MODEL selects, not a hardcoded one — the model layer owns
+  // which key its active provider needs.
+  const modelProblem = agentModelProblem();
+  if (modelProblem) {
+    console.error(`[askiris] ${modelProblem}`);
     return chatErrorResponse("unavailable", 500);
   }
 

--- a/src/lib/ai/__tests__/model.test.ts
+++ b/src/lib/ai/__tests__/model.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { agentModelProblem, getAgentModel } from "../model";
+
+// The chat route refuses a turn when the model it is about to call has no key. The
+// check has to follow AGENT_MODEL rather than name one provider: with a hardcoded
+// DEEPSEEK_API_KEY it passed while an override pointed at a provider whose key was
+// missing, and the turn then failed mid-stream instead of at the door.
+
+const AGENT_KEYS = [
+  "AGENT_MODEL",
+  "DEEPSEEK_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "OPENROUTER_API_KEY",
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of AGENT_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of AGENT_KEYS) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+});
+
+describe("agentModelProblem", () => {
+  it("names the default provider's key when nothing overrides it", () => {
+    expect(agentModelProblem()).toContain("DEEPSEEK_API_KEY");
+    process.env.DEEPSEEK_API_KEY = "set";
+    expect(agentModelProblem()).toBeNull();
+  });
+
+  it("follows the override rather than the default provider", () => {
+    // The deployed provider's key is present; the overridden one's is not.
+    process.env.DEEPSEEK_API_KEY = "set";
+    process.env.AGENT_MODEL = "google:gemini-3.5-flash-lite";
+    expect(agentModelProblem()).toContain("GOOGLE_GENERATIVE_AI_API_KEY");
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "set";
+    expect(agentModelProblem()).toBeNull();
+  });
+
+  it("reports a provider the table does not know", () => {
+    process.env.AGENT_MODEL = "anthropic:claude";
+    expect(agentModelProblem()).toContain("unknown provider");
+    expect(() => getAgentModel()).toThrow(/unknown provider/);
+  });
+});

--- a/src/lib/ai/__tests__/model.test.ts
+++ b/src/lib/ai/__tests__/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { agentModelProblem, getAgentModel } from "../model";
+import { missingAgentModelKey, getAgentModel } from "../model";
 
 // The chat route refuses a turn when the model it is about to call has no key. The
 // check has to follow AGENT_MODEL rather than name one provider: with a hardcoded
@@ -33,25 +33,25 @@ afterEach(() => {
   }
 });
 
-describe("agentModelProblem", () => {
+describe("missingAgentModelKey", () => {
   it("names the default provider's key when nothing overrides it", () => {
-    expect(agentModelProblem()).toContain("DEEPSEEK_API_KEY");
+    expect(missingAgentModelKey()).toBe("DEEPSEEK_API_KEY");
     process.env.DEEPSEEK_API_KEY = "set";
-    expect(agentModelProblem()).toBeNull();
+    expect(missingAgentModelKey()).toBeNull();
   });
 
   it("follows the override rather than the default provider", () => {
     // The deployed provider's key is present; the overridden one's is not.
     process.env.DEEPSEEK_API_KEY = "set";
     process.env.AGENT_MODEL = "google:gemini-3.5-flash-lite";
-    expect(agentModelProblem()).toContain("GOOGLE_GENERATIVE_AI_API_KEY");
+    expect(missingAgentModelKey()).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
     process.env.GOOGLE_GENERATIVE_AI_API_KEY = "set";
-    expect(agentModelProblem()).toBeNull();
+    expect(missingAgentModelKey()).toBeNull();
   });
 
-  it("reports a provider the table does not know", () => {
+  it("has nothing to check for a provider it does not know, which getAgentModel rejects", () => {
     process.env.AGENT_MODEL = "anthropic:claude";
-    expect(agentModelProblem()).toContain("unknown provider");
+    expect(missingAgentModelKey()).toBeNull();
     expect(() => getAgentModel()).toThrow(/unknown provider/);
   });
 });

--- a/src/lib/ai/model.ts
+++ b/src/lib/ai/model.ts
@@ -1,16 +1,19 @@
 import { deepseek } from "@ai-sdk/deepseek";
-import { openai } from "@ai-sdk/openai";
+import { google } from "@ai-sdk/google";
+import { openai, createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
 
 // Iris's production model — the single source of truth. DeepSeek v4-flash is cheap
 // and chains tools reliably; swapping it is a one-line change confined here.
 //
 // AGENT_MODEL is an OPTIONAL local override ("provider:modelId", e.g.
-// "openai:gpt-4.1-mini") for A/B-ing providers or sweeping the eval harness across
-// candidates without a code edit. Unset — the normal case, including all of
-// production — means "use the model below", so prod needs no extra env var and
-// OpenAI never enters the deployed path. This is the sanctioned optional-override
-// case, not a config fallback: an unset value is normal, not a bug.
+// "google:gemini-3.5-flash-lite") for A/B-ing providers or sweeping the eval harness
+// across candidates without a code edit. Unset — the normal case, including all of
+// production — means "use the model below", so prod needs no extra env var and no
+// provider but DeepSeek enters the deployed path. This is the sanctioned
+// optional-override case, not a config fallback: an unset value is normal, not a bug.
+// Which model production serves is decided here in code, never inferred from whether
+// some other provider's key happens to be present.
 export function getAgentModel(): LanguageModel {
   const override = process.env.AGENT_MODEL;
   if (!override) {
@@ -24,15 +27,37 @@ export function getAgentModel(): LanguageModel {
       return deepseek(modelId);
     case "openai":
       return openai(modelId);
+    case "google":
+      // Google's own provider rather than an OpenAI-compatible shim: Gemini 3 requires
+      // its thought signatures to be echoed back on later requests for tool calling to
+      // stay reliable, and a translation layer in between is where they get dropped.
+      return google(modelId);
+    case "openrouter":
+      // OpenRouter speaks the OpenAI wire format, so the same provider talks to it with
+      // a different base URL — one gateway key reaches every vendor's model, which is
+      // what makes a candidate sweep cheap.
+      return createOpenAI({
+        baseURL: "https://openrouter.ai/api/v1",
+        apiKey: process.env.OPENROUTER_API_KEY,
+      }).chat(modelId);
     default:
-      throw new Error(`AGENT_MODEL has an unknown provider "${provider}" (expected deepseek|openai)`);
+      throw new Error(
+        `AGENT_MODEL has an unknown provider "${provider}" (expected deepseek|openai|google|openrouter)`,
+      );
   }
 }
 
+// Iris follows format rules and picks tools off a decision axis, so she wants the
+// deterministic end of the sampler, not the conversational one. DeepSeek's own
+// per-task guidance puts that work near its coding/math setting; leaving this unset
+// would hand the choice to the provider default (1.0) instead of making it here.
+// https://api-docs.deepseek.com/quick_start/parameter_settings/
+export const AGENT_TEMPERATURE = 0;
+
 // Provider-specific knobs passed to streamText; the SDK reads only the block that
-// matches the active provider, so this is inert under an OpenAI override. DeepSeek
-// v4-flash defaults to *thinking* (it emits reasoning tokens before answering); we
-// disable it for fast, cheap, tool-driven turns.
+// matches the active provider, so this is inert under any override. v4-flash emits
+// reasoning tokens before answering — it costs tokens and latency, and it is what
+// buys the instruction adherence the tool and format rules depend on.
 export const agentProviderOptions = {
-  deepseek: { thinking: { type: "disabled" } },
+  deepseek: { thinking: { type: "enabled" } },
 } as const;

--- a/src/lib/ai/model.ts
+++ b/src/lib/ai/model.ts
@@ -9,75 +9,63 @@ import type { LanguageModel } from "ai";
 // AGENT_MODEL is an OPTIONAL local override ("provider:modelId", e.g.
 // "google:gemini-3.5-flash-lite") for A/B-ing providers or sweeping the eval harness
 // across candidates without a code edit. Unset — the normal case, including all of
-// production — means "use DEFAULT_MODEL", so prod needs no extra env var and no
+// production — means "use the model below", so prod needs no extra env var and no
 // provider but DeepSeek enters the deployed path. This is the sanctioned
 // optional-override case, not a config fallback: an unset value is normal, not a bug.
 // Which model production serves is decided here in code, never inferred from whether
 // some other provider's key happens to be present.
 
-// Each provider paired with the env var whose absence makes it uncallable — the same
-// name its SDK reads, so the route can report which key to set without knowing which
-// provider is active. One table, so adding a provider cannot leave the readiness check
-// behind: a new entry has to name its key to compile.
-const PROVIDERS = {
-  deepseek: { keyVar: "DEEPSEEK_API_KEY", model: (id: string) => deepseek(id) },
-  openai: { keyVar: "OPENAI_API_KEY", model: (id: string) => openai(id) },
-  // Google's own provider rather than an OpenAI-compatible shim: Gemini 3 requires its
-  // thought signatures to be echoed back on later requests for tool calling to stay
-  // reliable, and a translation layer in between is where they get dropped.
-  google: { keyVar: "GOOGLE_GENERATIVE_AI_API_KEY", model: (id: string) => google(id) },
-  // OpenRouter speaks the OpenAI wire format, so the same provider talks to it with a
-  // different base URL — one gateway key reaches every vendor's model, which is what
-  // makes a candidate sweep cheap.
-  openrouter: {
-    keyVar: "OPENROUTER_API_KEY",
-    model: (id: string) =>
-      createOpenAI({
-        baseURL: "https://openrouter.ai/api/v1",
-        apiKey: process.env.OPENROUTER_API_KEY,
-      }).chat(id),
-  },
-} as const satisfies Record<string, { keyVar: string; model: (id: string) => LanguageModel }>;
-
-type ProviderName = keyof typeof PROVIDERS;
-
-const DEFAULT_MODEL = { provider: "deepseek", modelId: "deepseek-v4-flash" } as const;
-
-// The model this process will call, resolved from the override or the default. Returns
-// the raw provider string when it names nothing we have, so the caller can say so.
-function activeModel(): { provider: ProviderName | string; modelId: string } {
+function activeProvider(): string {
   const override = process.env.AGENT_MODEL;
-  if (!override) {
-    return DEFAULT_MODEL;
-  }
-  const sep = override.indexOf(":");
-  return { provider: override.slice(0, sep), modelId: override.slice(sep + 1) };
-}
-
-function isKnown(provider: string): provider is ProviderName {
-  return provider in PROVIDERS;
+  return override ? override.slice(0, override.indexOf(":")) : "deepseek";
 }
 
 export function getAgentModel(): LanguageModel {
-  const { provider, modelId } = activeModel();
-  if (!isKnown(provider)) {
-    throw new Error(
-      `AGENT_MODEL has an unknown provider "${provider}" (expected ${Object.keys(PROVIDERS).join("|")})`,
-    );
+  const override = process.env.AGENT_MODEL;
+  if (!override) {
+    return deepseek("deepseek-v4-flash");
   }
-  return PROVIDERS[provider].model(modelId);
+  const modelId = override.slice(override.indexOf(":") + 1);
+  switch (activeProvider()) {
+    case "deepseek":
+      return deepseek(modelId);
+    case "openai":
+      return openai(modelId);
+    case "google":
+      // Google's own provider rather than an OpenAI-compatible shim: Gemini 3 requires
+      // its thought signatures to be echoed back on later requests for tool calling to
+      // stay reliable, and a translation layer in between is where they get dropped.
+      return google(modelId);
+    case "openrouter":
+      // OpenRouter speaks the OpenAI wire format, so the same provider talks to it with
+      // a different base URL — one gateway key reaches every vendor's model, which is
+      // what makes a candidate sweep cheap.
+      return createOpenAI({
+        baseURL: "https://openrouter.ai/api/v1",
+        apiKey: process.env.OPENROUTER_API_KEY,
+      }).chat(modelId);
+    default:
+      throw new Error(
+        `AGENT_MODEL has an unknown provider "${activeProvider()}" (expected deepseek|openai|google|openrouter)`,
+      );
+  }
 }
 
-// Why the active model can't be called, or null when it can be. Only a config check —
-// a key that is present but wrong still fails at request time, which is the provider's
-// error to report, not something worth a preflight round trip on every turn.
-export function agentModelProblem(): string | null {
-  const { provider } = activeModel();
-  if (!isKnown(provider)) {
-    return `AGENT_MODEL names an unknown provider "${provider}"`;
-  }
-  const { keyVar } = PROVIDERS[provider];
-  return process.env[keyVar] ? null : `${keyVar} is not set (required by provider "${provider}")`;
+// The env var each provider's SDK reads. A provider constructor does NOT throw when its
+// key is missing — the error surfaces on the first request, by which point the response
+// has started streaming and can no longer become a clean 500. Hence the name here, so
+// the route can check before it opens the stream.
+const KEY_VAR: Record<string, string> = {
+  deepseek: "DEEPSEEK_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GOOGLE_GENERATIVE_AI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+};
+
+// The env var the active model needs but does not have, or null when it is set.
+export function missingAgentModelKey(): string | null {
+  const keyVar = KEY_VAR[activeProvider()];
+  return keyVar && !process.env[keyVar] ? keyVar : null;
 }
 
 // Iris follows format rules and picks tools off a decision axis, so she wants the

--- a/src/lib/ai/model.ts
+++ b/src/lib/ai/model.ts
@@ -9,42 +9,75 @@ import type { LanguageModel } from "ai";
 // AGENT_MODEL is an OPTIONAL local override ("provider:modelId", e.g.
 // "google:gemini-3.5-flash-lite") for A/B-ing providers or sweeping the eval harness
 // across candidates without a code edit. Unset — the normal case, including all of
-// production — means "use the model below", so prod needs no extra env var and no
+// production — means "use DEFAULT_MODEL", so prod needs no extra env var and no
 // provider but DeepSeek enters the deployed path. This is the sanctioned
 // optional-override case, not a config fallback: an unset value is normal, not a bug.
 // Which model production serves is decided here in code, never inferred from whether
 // some other provider's key happens to be present.
-export function getAgentModel(): LanguageModel {
-  const override = process.env.AGENT_MODEL;
-  if (!override) {
-    return deepseek("deepseek-v4-flash");
-  }
-  const sep = override.indexOf(":");
-  const provider = override.slice(0, sep);
-  const modelId = override.slice(sep + 1);
-  switch (provider) {
-    case "deepseek":
-      return deepseek(modelId);
-    case "openai":
-      return openai(modelId);
-    case "google":
-      // Google's own provider rather than an OpenAI-compatible shim: Gemini 3 requires
-      // its thought signatures to be echoed back on later requests for tool calling to
-      // stay reliable, and a translation layer in between is where they get dropped.
-      return google(modelId);
-    case "openrouter":
-      // OpenRouter speaks the OpenAI wire format, so the same provider talks to it with
-      // a different base URL — one gateway key reaches every vendor's model, which is
-      // what makes a candidate sweep cheap.
-      return createOpenAI({
+
+// Each provider paired with the env var whose absence makes it uncallable — the same
+// name its SDK reads, so the route can report which key to set without knowing which
+// provider is active. One table, so adding a provider cannot leave the readiness check
+// behind: a new entry has to name its key to compile.
+const PROVIDERS = {
+  deepseek: { keyVar: "DEEPSEEK_API_KEY", model: (id: string) => deepseek(id) },
+  openai: { keyVar: "OPENAI_API_KEY", model: (id: string) => openai(id) },
+  // Google's own provider rather than an OpenAI-compatible shim: Gemini 3 requires its
+  // thought signatures to be echoed back on later requests for tool calling to stay
+  // reliable, and a translation layer in between is where they get dropped.
+  google: { keyVar: "GOOGLE_GENERATIVE_AI_API_KEY", model: (id: string) => google(id) },
+  // OpenRouter speaks the OpenAI wire format, so the same provider talks to it with a
+  // different base URL — one gateway key reaches every vendor's model, which is what
+  // makes a candidate sweep cheap.
+  openrouter: {
+    keyVar: "OPENROUTER_API_KEY",
+    model: (id: string) =>
+      createOpenAI({
         baseURL: "https://openrouter.ai/api/v1",
         apiKey: process.env.OPENROUTER_API_KEY,
-      }).chat(modelId);
-    default:
-      throw new Error(
-        `AGENT_MODEL has an unknown provider "${provider}" (expected deepseek|openai|google|openrouter)`,
-      );
+      }).chat(id),
+  },
+} as const satisfies Record<string, { keyVar: string; model: (id: string) => LanguageModel }>;
+
+type ProviderName = keyof typeof PROVIDERS;
+
+const DEFAULT_MODEL = { provider: "deepseek", modelId: "deepseek-v4-flash" } as const;
+
+// The model this process will call, resolved from the override or the default. Returns
+// the raw provider string when it names nothing we have, so the caller can say so.
+function activeModel(): { provider: ProviderName | string; modelId: string } {
+  const override = process.env.AGENT_MODEL;
+  if (!override) {
+    return DEFAULT_MODEL;
   }
+  const sep = override.indexOf(":");
+  return { provider: override.slice(0, sep), modelId: override.slice(sep + 1) };
+}
+
+function isKnown(provider: string): provider is ProviderName {
+  return provider in PROVIDERS;
+}
+
+export function getAgentModel(): LanguageModel {
+  const { provider, modelId } = activeModel();
+  if (!isKnown(provider)) {
+    throw new Error(
+      `AGENT_MODEL has an unknown provider "${provider}" (expected ${Object.keys(PROVIDERS).join("|")})`,
+    );
+  }
+  return PROVIDERS[provider].model(modelId);
+}
+
+// Why the active model can't be called, or null when it can be. Only a config check —
+// a key that is present but wrong still fails at request time, which is the provider's
+// error to report, not something worth a preflight round trip on every turn.
+export function agentModelProblem(): string | null {
+  const { provider } = activeModel();
+  if (!isKnown(provider)) {
+    return `AGENT_MODEL names an unknown provider "${provider}"`;
+  }
+  const { keyVar } = PROVIDERS[provider];
+  return process.env[keyVar] ? null : `${keyVar} is not set (required by provider "${provider}")`;
 }
 
 // Iris follows format rules and picks tools off a decision axis, so she wants the


### PR DESCRIPTION
`AGENT_MODEL` already exists as a local override for A/B-ing providers and sweeping the eval harness across candidates. It gains two:

- **`google`** — Google's own provider, not an OpenAI-compatible shim. Gemini 3 requires its thought signatures echoed back on later requests for tool calling to stay reliable, and a translation layer is where they get dropped.
- **`openrouter`** — speaks the OpenAI wire format, so one gateway key reaches every vendor's model behind a different base URL.

**Production is untouched by both.** It sets no `AGENT_MODEL`, so `deepseek-v4-flash` stays its only path; the new cases are unreachable without the env var. Which model serves users is decided in code, never inferred from whether some other provider's key happens to be present — so no Cloudflare secret is needed to merge this.

## What production does see

| | before | after |
|---|---|---|
| `temperature` | provider default (1.0) | **0** |
| DeepSeek reasoning tokens | disabled | **enabled** |

Temperature 0 because Iris follows format rules and picks tools off a decision axis — the deterministic end of the sampler — and because a repeatable turn is what makes an eval comparison mean anything. Reasoning tokens because they cost latency and tokens but buy the instruction adherence the tool and format rules depend on; that one is a standing decision for DeepSeek, independent of which model ends up default.

## The readiness guard follows the override too

`route.ts` refuses a turn when the model it is about to call has no key, and it named `DEEPSEEK_API_KEY` — so with `AGENT_MODEL` pointing elsewhere it passed on the wrong key, and the turn failed mid-stream rather than at the door.

A `try/catch` around `getAgentModel()` would be the small fix, but it catches nothing. Probed against the SDKs:

```
deepseek(id) constructed  -> no throw
google(id)   constructed  -> no throw
generateText called       -> throws: DeepSeek API key API key is missing.
```

The key is only read on the first request, by which point the response is already streaming and can no longer become a 500. So the check needs the env var name up front:

```ts
const KEY_VAR: Record<string, string> = {
  deepseek: "DEEPSEEK_API_KEY",
  openai: "OPENAI_API_KEY",
  google: "GOOGLE_GENERATIVE_AI_API_KEY",
  openrouter: "OPENROUTER_API_KEY",
};
```

| AGENT_MODEL | keys present | verdict |
|---|---|---|
| unset | none | `DEEPSEEK_API_KEY is not set` |
| unset | DeepSeek | ✅ |
| `google:…` | DeepSeek only | `GOOGLE_GENERATIVE_AI_API_KEY is not set` |
| `google:…` | DeepSeek + Google | ✅ |

Config check only: a key that is present but wrong still fails at request time, which is the provider's error to report. Production sets no `AGENT_MODEL`, so it still checks `DEEPSEEK_API_KEY`.

## Test plan

- `pnpm test` — 417 pass, including the table above as `model.test.ts`
- `pnpm run build` — clean, 447 routes prerendered

