### PR TITLE
refactor(askiris): move the error UI and fixture plumbing out of the chat

### DIFF
--- a/src/app/[locale]/askiris/page.tsx
+++ b/src/app/[locale]/askiris/page.tsx
@@ -28,11 +28,5 @@ export default async function AskIrisPage({
   setRequestLocale(locale);
   const { q } = await searchParams;
   const initialQuery = (Array.isArray(q) ? q[0] : q)?.trim() || undefined;
-  return (
-    <AskIrisChat
-      locale={locale}
-      initialQuery={initialQuery}
-      lensIndex={getLensLinkIndex(locale)}
-    />
-  );
+  return <AskIrisChat initialQuery={initialQuery} lensIndex={getLensLinkIndex(locale)} />;
 }

--- a/src/components/askiris/AskIrisChat.tsx
+++ b/src/components/askiris/AskIrisChat.tsx
@@ -3,10 +3,9 @@
 import { useChat } from "@ai-sdk/react";
 import { track } from "@/lib/analytics/analytics";
 import type { UIMessage } from "ai";
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import { isChatErrorKind, type ChatErrorKind } from "@/lib/ai/chat-errors";
 import { useEffectiveMount } from "@/hooks/useMountParam";
 import { useScrollAffordance } from "@/hooks/useScrollAffordance";
 import { useTestHookOption } from "@/context/TestHookProvider";
@@ -16,59 +15,28 @@ import type { LensLinkIndex } from "@/lib/ai/lens-ref";
 import AskIrisComposer from "@/components/askiris/AskIrisComposer";
 import AskIrisEmptyState from "@/components/askiris/AskIrisEmptyState";
 import AskIrisDivider from "@/components/askiris/AskIrisDivider";
-import {
-  subscribe,
-  getSnapshot,
-  getServerSnapshot,
-  publishLive,
-  resolveFixture,
-} from "@/components/askiris/fixtureStore";
+import AskIrisError, { classifyError } from "@/components/askiris/AskIrisError";
+import { useFixtureMessages } from "@/components/askiris/fixtureStore";
 
 type ThreadItem = { kind: "seg"; messages: UIMessage[] } | { kind: "divider"; label: string };
 
-// "transient" is an untagged stream or network error, where a retry may succeed.
-type ErrorDisplay = ChatErrorKind | "transient";
-
-// A Record, so adding a ChatErrorKind server-side won't typecheck until a message
-// is chosen here too.
-const ERROR_MESSAGE_KEY: Record<ChatErrorKind, "rateLimited" | "errorUnavailable"> = {
-  rate_limit: "rateLimited",
-  unavailable: "errorUnavailable",
-};
-
-// The transport throws with the raw response body as the Error message and no status
-// code, so the route tags those bodies with a `kind` and we read it back out here.
-function classifyError(error: Error | undefined): ErrorDisplay {
-  if (error) {
-    try {
-      const body = JSON.parse(error.message) as { kind?: unknown };
-      if (isChatErrorKind(body.kind)) {
-        return body.kind;
-      }
-    } catch {
-      // Not a tagged body — fall through to transient.
-    }
-  }
-  return "transient";
-}
+const SHELL_CLS =
+  "mx-auto flex h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] w-full max-w-[800px] flex-col px-4";
 
 // Two states on one route: an empty-state landing (centered hero) before the first
 // message, and the chat thread after.
 export default function AskIrisChat({
-  locale,
   initialQuery,
   lensIndex,
 }: {
-  locale: string;
   initialQuery?: string;
   lensIndex: LensLinkIndex;
 }) {
   const t = useTranslations("AskIris");
   const tMount = useTranslations("MountSwitcher");
+  const locale = useLocale();
   const mount = useEffectiveMount();
-  // Both gated behind the test-hook panel's "AskIris debug" section.
   const debug = useTestHookOption("askIrisTrace") === "on";
-  const { selected } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const [input, setInput] = useState("");
   // Closed-off segments, rendered read-only above the live thread and never re-sent
   // to the model.
@@ -82,15 +50,10 @@ export default function AskIrisChat({
   const isBusy = status === "submitted" || status === "streaming";
   const errorKind = status === "error" ? classifyError(error) : null;
 
-  // Sent with every turn so the server can group turns into sessions. In a ref: it
-  // must not trigger a re-render, and is read lazily at send time.
-  const segmentIdRef = useRef<string>("");
-  function currentSegmentId(): string {
-    if (!segmentIdRef.current) {
-      segmentIdRef.current = crypto.randomUUID();
-    }
-    return segmentIdRef.current;
-  }
+  // The segment id groups turns into sessions server-side; a new one starts at each
+  // segment boundary.
+  const [segmentId, setSegmentId] = useState(() => crypto.randomUUID());
+  const turnBody = { mount, locale, segmentId };
 
   // One per load; a mount switch or new chat is in-page and doesn't re-fire it.
   useEffect(() => {
@@ -102,25 +65,30 @@ export default function AskIrisChat({
     if (!trimmed || isBusy) {
       return;
     }
-    sendMessage({ text: trimmed }, { body: { mount, locale, segmentId: currentSegmentId() } });
+    sendMessage({ text: trimmed }, { body: turnBody });
     track("askiris_message", { query: trimmed, method: "typed" });
     setInput("");
   }
 
-  // /askiris?q=… (a Browse-page hand-off) auto-sends once. The param is stripped from
-  // the URL afterwards so a refresh doesn't re-fire it.
-  const queryFired = useRef(false);
+  // /askiris?q=… arrives as a prop off the server render and auto-sends. The param is
+  // then stripped so a refresh doesn't re-fire it. The ref keeps the send out of the
+  // dev double-mount, and is a ref rather than a module flag because navigating away
+  // and returning with a new query should send again.
+  const submitInitialQuery = useEffectEvent((query: string) => {
+    sendMessage({ text: query }, { body: turnBody });
+    track("askiris_message", { query, method: "handoff" });
+  });
+  const initialQuerySent = useRef(false);
   useEffect(() => {
-    if (queryFired.current || !initialQuery) {
+    if (initialQuerySent.current || !initialQuery) {
       return;
     }
-    queryFired.current = true;
-    sendMessage({ text: initialQuery }, { body: { mount, locale, segmentId: currentSegmentId() } });
-    track("askiris_message", { query: initialQuery, method: "handoff" });
+    initialQuerySent.current = true;
+    submitInitialQuery(initialQuery);
     const url = new URL(window.location.href);
     url.searchParams.delete("q");
     window.history.replaceState(null, "", url.toString());
-  }, [initialQuery, sendMessage, mount, locale]);
+  }, [initialQuery]);
 
   // Lets the switch below read the live segment without re-running on every streamed
   // message.
@@ -154,7 +122,7 @@ export default function AskIrisChat({
       });
       setMessages([]);
       setInput("");
-      segmentIdRef.current = crypto.randomUUID();
+      setSegmentId(crypto.randomUUID());
     },
     [stop, setMessages],
   );
@@ -170,17 +138,7 @@ export default function AskIrisChat({
     startNewSegment(t("switchedMount", { mount: mount === "G" ? tMount("gfx") : tMount("x") }));
   }, [mount, startNewSegment, t, tMount]);
 
-  // Dev-only: publish live messages so the test-hook panel can capture them into a
-  // fixture, and replay a selected one through the real page shell — deterministic
-  // UI work (decks, tables) with no LLM call.
-  useEffect(() => {
-    publishLive(messages);
-  }, [messages]);
-  const fixtureMessages =
-    process.env.NODE_ENV !== "production" && selected !== "off"
-      ? (resolveFixture(selected) ?? null)
-      : null;
-  const renderMessages = fixtureMessages ?? messages;
+  const renderMessages = useFixtureMessages(messages);
 
   // Follow the stream only while the user is pinned to the bottom — scrolling up to
   // read mid-stream must not yank them back down.
@@ -215,13 +173,11 @@ export default function AskIrisChat({
     }
   }, [archived]);
 
-  const shell = "mx-auto flex h-[calc(100svh-var(--nav-height)-var(--safe-inset-bottom))] w-full max-w-[800px] flex-col px-4";
-
   // Skip the hero when a hand-off query is pending: it fires on mount and fills the
   // thread, so rendering the empty state first would just flash before the reply.
   if (archived.length === 0 && renderMessages.length === 0 && !initialQuery) {
     return (
-      <div className={shell}>
+      <div className={SHELL_CLS}>
         <AskIrisEmptyState
           input={input}
           onInputChange={setInput}
@@ -235,7 +191,7 @@ export default function AskIrisChat({
 
   return (
     <LensLinkProvider index={lensIndex}>
-      <div className={shell}>
+      <div className={SHELL_CLS}>
         <div className="relative min-h-0 flex-1">
           <div
             ref={scrollRef}
@@ -250,27 +206,8 @@ export default function AskIrisChat({
               ),
             )}
             <AskIrisThread messages={renderMessages} debug={debug} busy={isBusy} />
-            {/* useChat catches request and stream errors into status "error" but
-                renders nothing on its own. Only a transient failure is worth a retry:
-                a rate-limit needs a wait, an outage will fail identically. */}
             {errorKind && (
-              <div role="alert" className="px-1 text-sm text-zinc-500 dark:text-zinc-400">
-                {errorKind === "transient" ? (
-                  t.rich("errorRetry", {
-                    retry: (chunks) => (
-                      <button
-                        type="button"
-                        onClick={() => regenerate({ body: { mount, locale, segmentId: currentSegmentId() } })}
-                        className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
-                      >
-                        {chunks}
-                      </button>
-                    ),
-                  })
-                ) : (
-                  <span>{t(ERROR_MESSAGE_KEY[errorKind])}</span>
-                )}
-              </div>
+              <AskIrisError kind={errorKind} onRetry={() => regenerate({ body: turnBody })} />
             )}
           </div>
           {/* Overlays rather than a container mask, so the scrollbar stays crisp;

--- a/src/components/askiris/AskIrisError.tsx
+++ b/src/components/askiris/AskIrisError.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { isChatErrorKind, type ChatErrorKind } from "@/lib/ai/chat-errors";
+
+// "transient" is an untagged stream or network error, where a retry may succeed.
+type ErrorDisplay = ChatErrorKind | "transient";
+
+// A Record, so adding a ChatErrorKind server-side won't typecheck until a message
+// is chosen here too.
+const ERROR_MESSAGE_KEY: Record<ChatErrorKind, "rateLimited" | "errorUnavailable"> = {
+  rate_limit: "rateLimited",
+  unavailable: "errorUnavailable",
+};
+
+// The transport throws with the raw response body as the Error message and no status
+// code, so the route tags those bodies with a `kind` and we read it back out here.
+export function classifyError(error: Error | undefined): ErrorDisplay {
+  if (error) {
+    try {
+      const body = JSON.parse(error.message) as { kind?: unknown };
+      if (isChatErrorKind(body.kind)) {
+        return body.kind;
+      }
+    } catch {
+      // Not a tagged body — fall through to transient.
+    }
+  }
+  return "transient";
+}
+
+// useChat catches request and stream errors into status "error" but renders nothing
+// on its own. Only a transient failure is worth a retry: a rate-limit needs a wait,
+// an outage will fail identically.
+export default function AskIrisError({
+  kind,
+  onRetry,
+}: {
+  kind: ErrorDisplay;
+  onRetry: () => void;
+}) {
+  const t = useTranslations("AskIris");
+  return (
+    <div role="alert" className="px-1 text-sm text-zinc-500 dark:text-zinc-400">
+      {kind === "transient" ? (
+        t.rich("errorRetry", {
+          retry: (chunks) => (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="font-medium text-zinc-700 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
+            >
+              {chunks}
+            </button>
+          ),
+        })
+      ) : (
+        <span>{t(ERROR_MESSAGE_KEY[kind])}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/askiris/fixtureStore.ts
+++ b/src/components/askiris/fixtureStore.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { UIMessage } from "ai";
+import { useEffect, useSyncExternalStore } from "react";
 import { TESTHOOK_ALLOWED } from "@/lib/testhook";
 
 // Dev-only fixture store shared between AskIrisChat (publishes its live messages,
@@ -87,9 +88,9 @@ export function getServerSnapshot(): FixtureSnapshot {
   return SERVER_SNAPSHOT;
 }
 
-// AskIrisChat publishes on every change; not reactive (no emit) so streaming
-// doesn't churn the panel — the panel reads `live` only when Save is pressed.
-export function publishLive(messages: UIMessage[]) {
+// Not reactive (no emit) so streaming doesn't churn the panel — it reads `live`
+// only when Save is pressed.
+function publishLive(messages: UIMessage[]) {
   live = messages;
 }
 
@@ -98,7 +99,7 @@ export function setSelected(name: string) {
   emit();
 }
 
-export function resolveFixture(name: string): UIMessage[] | undefined {
+function resolveFixture(name: string): UIMessage[] | undefined {
   if (name === "off") {
     return undefined;
   }
@@ -136,4 +137,16 @@ export function renameFixture(from: string, to: string) {
   }
   emit();
   void post({ action: "rename", from, to });
+}
+
+// The chat's whole contact with this module: hand it the live thread, render what
+// comes back. In dev that is a selected fixture replayed through the real page shell
+// — deterministic UI work (decks, tables) with no LLM call.
+export function useFixtureMessages(messages: UIMessage[]): UIMessage[] {
+  const { selected } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  useEffect(() => {
+    publishLive(messages);
+  }, [messages]);
+  const fixture = TESTHOOK_ALLOWED && selected !== "off" ? resolveFixture(selected) : undefined;
+  return fixture ?? messages;
 }


### PR DESCRIPTION
`AskIrisChat` carried three concerns that touched nothing else in it. 316 → 246 lines.

## What moved

**Error display → `AskIrisError.tsx`**, taking the `ErrorDisplay` bucket, the message `Record` and `classifyError` with it. The chat keeps one line: `errorKind = status === "error" ? classifyError(error) : null`.

**Fixture capture and replay → `useFixtureMessages`**, now owned by `fixtureStore` along with `publishLive` and `resolveFixture` (both no longer exported). The chat imports one name instead of five, and the dev-only `NODE_ENV` branch sits with the rest of the dev tooling rather than mid-component.

**The per-turn request body → one `turnBody` object.** It was spelled out at three call sites (`submitText`, the hand-off effect, the retry button), so a fourth field meant remembering three places.

**`locale` stops being a prop** and comes from `useLocale()` — the same move #439 made for `RecommendationDeck`. The page still resolves `locale` server-side for `getLensLinkIndex`.

**The shell class string** is a module constant rather than a per-render local.

## The segment id moves from a ref to state

The ref forced `turnBody` to be a function with a lazy-init guard inside it. Nothing reads the id synchronously — `startNewSegment` never sends in the same tick, and the next send is always a later user event — so state works, `turnBody` becomes a plain object, and `startNewSegment` is now uniformly declarative alongside its three other setters.

One semantic change: the id is minted on mount rather than at first send, and once more during SSR before the client discards it. Nothing renders it, so there is no hydration mismatch, and it still only leaves the browser attached to a turn.

Note `useState(crypto.randomUUID)` does **not** work — the method throws `Illegal invocation` when detached from `crypto`. It needs the arrow form.

## useEffectEvent

Building `turnBody` during render moved `mount`/`locale` out of the hand-off Effect's body, so `exhaustive-deps` started asking for it. That Effect is a one-shot guarded by `queryFired` and wants the values as of fire time, so its send is now a `useEffectEvent` and the dependencies shrink to `[initialQuery]`.

First use of the API here. It fits because `sendHandoff` is only ever called from an Effect. The `messagesRef` latest-ref below is *not* replaceable the same way: `startNewSegment` is called from both an Effect and the composer's `onNewTopic`, and Effect Events may not be called during render or from event handlers.

## Verification

Dev server, end to end:

- a live turn posts `{"mount":"X","locale":"en","segmentId":"03f34a1d-…"}`; thread and recommendation deck render
- **"New chat" → next turn carries a different segment id** (`1e20c2a2-…`), `messages` holds only the new turn, and the `New topic` divider renders with the archived thread still scrollable above it
- `/askiris?q=…` fires **exactly one** `/api/chat` request, strips `q` from the URL, and lands on the thread rather than the hero
- saving a fixture from the test-hook panel writes it to `.askiris-fixtures/`; reloading with `?fixture=<name>` replays it on a page with zero live messages
- with no fixture selected the hero renders as before

417 unit tests, typecheck, lint and `pnpm run build` pass.

## Still to come

The scroll-follow logic and the conversation-segment state machine are the other two extractions from the same review. They change runtime behavior rather than just moving it, so they get their own PR.