### PR TITLE
refactor(askiris): use Cloudflare rate limiting for bursts

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/ai/model";
 import { systemPrompt } from "@/lib/ai/system-prompt";
 import { buildLensTools } from "@/lib/ai/tools";
-import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
+import { clientIp, isBypassed, checkDailyTokenBudget, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
 import { askirisTurnDataPoint } from "@/lib/analytics/events";
 import { parseSid, parseInternal } from "@/lib/analytics/session";
@@ -69,9 +69,10 @@ export async function POST(req: Request) {
   }
   const { messages, mount, locale, segmentId } = parsed.data;
 
-  // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
-  // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
-  // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
+  // Abuse guard for this public, no-login endpoint. Fail-open by design: with no
+  // Cloudflare bindings (e.g. `next dev`) or on any binding hiccup we proceed rather
+  // than break the chat. The native binding handles the short request burst; KV handles
+  // the custom daily-token budgets. See src/lib/ai/rate-limit.ts.
   const ip = clientIp(req);
   const cookieHeader = req.headers.get("cookie");
   // Read the anonymous visit id set by /api/track; "" for a turn before its first
@@ -90,10 +91,19 @@ export async function POST(req: Request) {
     rateKv = cf.env.RATE_KV;
     ae = cf.env.ANALYTICS;
     ctx = cf.ctx;
-    if (rateKv && ip && !bypassed) {
-      const verdict = await checkRateLimit(rateKv, ip);
-      if (!verdict.ok) {
-        return chatErrorResponse("rate_limit", 429);
+    if (ip && !bypassed) {
+      const burstLimiter = cf.env.ASKIRIS_BURST;
+      if (burstLimiter) {
+        const verdict = await burstLimiter.limit({ key: ip });
+        if (!verdict.success) {
+          return chatErrorResponse("rate_limit", 429);
+        }
+      }
+      if (rateKv) {
+        const verdict = await checkDailyTokenBudget(rateKv, ip);
+        if (!verdict.ok) {
+          return chatErrorResponse("rate_limit", 429);
+        }
       }
     }
   } catch {

--- a/src/app/api/feedback/__tests__/route.test.ts
+++ b/src/app/api/feedback/__tests__/route.test.ts
@@ -1,15 +1,31 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 
+const { mockFeedbackRateLimit } = vi.hoisted(() => ({
+  mockFeedbackRateLimit: vi.fn(),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({
+    env: {
+      FEEDBACK_BURST: { limit: mockFeedbackRateLimit },
+    },
+  }),
+}));
+
+// Mock global fetch so the route never hits GitHub.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
 // Must set env before importing the route module.
 const env = process.env as Record<string, string | undefined>;
 beforeAll(() => {
   env.GITHUB_TOKEN = "test-token";
   env.GITHUB_FEEDBACK_REPO = "test/repo";
+  mockFeedbackRateLimit.mockResolvedValue({ success: true });
+  mockFetch.mockResolvedValue(
+    new Response(JSON.stringify({ number: 1 }), { status: 201 }),
+  );
 });
-
-// Mock global fetch so the route never hits GitHub.
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 // Import after env is set so the module picks up the vars.
 const { POST } = await import("../route");
@@ -22,7 +38,7 @@ function makeRequest(body: Record<string, unknown>): Request {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-forwarded-for": `10.0.${Math.floor(ipCounter / 256)}.${ipCounter % 256}`,
+      "CF-Connecting-IP": `10.0.${Math.floor(ipCounter / 256)}.${ipCounter % 256}`,
     },
     body: JSON.stringify(body),
   });
@@ -30,6 +46,24 @@ function makeRequest(body: Record<string, unknown>): Request {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("POST /api/feedback — Cloudflare rate limit", () => {
+  it("passes the edge IP to the native rate limiter", async () => {
+    await POST(makeRequest({ type: "general", description: "Great app!" }));
+    expect(mockFeedbackRateLimit).toHaveBeenCalledWith({
+      key: expect.stringMatching(/^10\.0\./),
+    });
+  });
+
+  it("rejects a request when the native rate limiter denies it", async () => {
+    mockFeedbackRateLimit.mockResolvedValueOnce({ success: false });
+
+    const res = await POST(makeRequest({ type: "general", description: "Great app!" }));
+
+    expect(res.status).toBe(429);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/feedback — description validation", () => {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,5 +1,6 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextResponse } from "next/server";
-import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
+import { RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
 type FeedbackType = "data_issue" | "general";
 
@@ -22,8 +23,6 @@ const MAX_DESCRIPTION_LENGTH = 2000;
 
 // Max length (in code points) of the description snippet used as an issue title.
 const TITLE_SNIPPET_MAX = 60;
-
-const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 5 });
 
 // Collapse a (possibly multi-line) description into a single-line title snippet,
 // truncating at a word boundary with an ellipsis when it exceeds the limit.
@@ -130,8 +129,20 @@ export function GET() {
 }
 
 export async function POST(req: Request) {
-  if (!checkRateLimit(req)) {
-    return RATE_LIMITED_RESPONSE;
+  // The endpoint creates GitHub issues, so rate limiting must be shared across Worker
+  // isolates. Cloudflare-Connecting-IP is edge-provided and cannot be spoofed by the
+  // client. The binding is optional in local development and fails open like /api/chat.
+  try {
+    const ip = req.headers.get("CF-Connecting-IP");
+    const { env } = getCloudflareContext();
+    if (ip && env.FEEDBACK_BURST) {
+      const { success } = await env.FEEDBACK_BURST.limit({ key: ip });
+      if (!success) {
+        return RATE_LIMITED_RESPONSE;
+      }
+    }
+  } catch {
+    // Binding may be unavailable outside the Cloudflare runtime.
   }
 
   let payload: FeedbackPayload;

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -1,27 +1,20 @@
 // Abuse guard for the (public, no-login) /api/chat endpoint, keyed off the caller's
 // Cloudflare edge IP and backed by the RATE_KV namespace.
 //
-// Two axes, because they bound different things:
-//   - burst (a request COUNT per minute) bounds the RATE. It's the only check we can
-//     make BEFORE spending anything, and it caps how much a flood can overshoot the
-//     token budgets before their post-request accounting catches up.
-//   - per-IP and global daily TOKEN budgets bound the SPEND (the wallet). Token usage
-//     is only known once a request finishes, so these are checked proactively ("are
-//     we already over?") and incremented afterwards via recordTokens().
+// The Cloudflare ASKIRIS_BURST binding owns the short-window request count. This module
+// keeps the two daily TOKEN budgets because their values are only known after a model
+// request finishes and they are not expressible through the native request limiter.
 //
 // KV has no atomic increment, so the counters are read-modify-write and thus loose
-// under concurrency — fine here, since the burst gate bounds concurrency and this is
-// deterrence, not strict metering.
+// under concurrency. This is cost deterrence, not strict metering.
 
 export const RATE_LIMIT = {
-  burstPerMinute: 6,
   perIpDailyTokens: 400_000,
   globalDailyTokens: 15_000_000,
 } as const;
 
 const BYPASS_COOKIE = "rate_bypass";
 const DAY_TTL_SECONDS = 2 * 24 * 60 * 60;
-const BURST_TTL_SECONDS = 120;
 
 // Cloudflare sets CF-Connecting-IP to the real client IP and strips any client-sent
 // copy, so it can't be spoofed at the edge. Absent off-Cloudflare (e.g. `next dev`).
@@ -54,21 +47,13 @@ function toCount(raw: string | null): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-// Proactive gate: reject if the burst rate or either daily token budget is already
-// spent. Reserves the burst slot only when letting the request through.
-export async function checkRateLimit(
+// Proactive gate: reject if either daily token budget is already spent. Token usage is
+// added after the request finishes by recordTokens().
+export async function checkDailyTokenBudget(
   kv: KVNamespace,
   ip: string,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
-  const now = Date.now();
-  const minute = Math.floor(now / 60_000);
-  const day = Math.floor(now / 86_400_000);
-
-  const burstKey = `burst:${ip}:${minute}`;
-  const burst = toCount(await kv.get(burstKey));
-  if (burst >= RATE_LIMIT.burstPerMinute) {
-    return { ok: false, reason: "burst" };
-  }
+  const day = Math.floor(Date.now() / 86_400_000);
   if (toCount(await kv.get(`tok:ip:${ip}:${day}`)) >= RATE_LIMIT.perIpDailyTokens) {
     return { ok: false, reason: "ip-daily" };
   }
@@ -76,7 +61,6 @@ export async function checkRateLimit(
     return { ok: false, reason: "global" };
   }
 
-  await kv.put(burstKey, String(burst + 1), { expirationTtl: BURST_TTL_SECONDS });
   return { ok: true };
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,6 +29,16 @@ namespace_id = "1001"
   limit = 6
   period = 60
 
+# Short-window request limit for the public feedback endpoint. The key is supplied
+# by the Worker at runtime; Cloudflare owns the counter and window.
+[[ratelimits]]
+name = "FEEDBACK_BURST"
+namespace_id = "1002"
+
+  [ratelimits.simple]
+  limit = 5
+  period = 60
+
 # KV counters for /api/chat's per-IP/global daily token budgets. The RATE_LIMIT_BYPASS
 # secret (dashboard / `wrangler secret put`) exempts the developer's own testing.
 [[kv_namespaces]]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,9 +19,18 @@ GITHUB_FEEDBACK_ASSIGNEES = "sentacraft"
 binding = "ANALYTICS"
 dataset = "xglass_events"
 
-# Rate-limit counters for /api/chat (per-IP burst + per-IP/global daily token
-# budgets). The RATE_LIMIT_BYPASS secret (dashboard / `wrangler secret put`) exempts
-# the developer's own testing.
+# Short-window request limit for the public /api/chat endpoint. The key is supplied
+# by the Worker at runtime; Cloudflare owns the counter and window.
+[[ratelimits]]
+name = "ASKIRIS_BURST"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 6
+  period = 60
+
+# KV counters for /api/chat's per-IP/global daily token budgets. The RATE_LIMIT_BYPASS
+# secret (dashboard / `wrangler secret put`) exempts the developer's own testing.
 [[kv_namespaces]]
 binding = "RATE_KV"
 id = "b4eeeb3afdca4f038de649dd3ecbea5f"


### PR DESCRIPTION
The public AskIris and feedback endpoints used hand-rolled in-memory or KV counters for short-window request limits. Those counters were local to a Worker isolate or required a read-modify-write, so they were not the right primitive for protecting public endpoints across a distributed deployment.

## What changed

**Cloudflare Rate Limiting bindings**

`ASKIRIS_BURST` now enforces 6 requests per 60 seconds per Cloudflare edge IP for `/api/chat`.

`FEEDBACK_BURST` now enforces 5 requests per 60 seconds per Cloudflare edge IP for `POST /api/feedback`, protecting the GitHub issue creation endpoint across Worker isolates.

The Worker passes the edge IP as the key; Cloudflare owns the request counters and windows.

**Daily token budgets stay in KV**

The per-IP and global daily token budgets remain in KV because they use custom post-request accounting based on actual model usage. The old AskIris burst key, TTL, and KV write have been removed.

**Feedback tests**

The feedback route tests now mock the native Cloudflare binding, verify the edge IP key, and verify that a denied request does not reach GitHub.

## Behaviour

- The existing AskIris bypass cookie skips the native AskIris burst limit and daily token checks.
- Missing bindings and binding failures remain fail-open so infrastructure issues do not take down chat or feedback.
- The `/api/lenses` and `/api/lenses/search` in-memory limiters remain unchanged because both endpoints return 404 in production and have no runtime consumers.

## Verification

- `pnpm run lint` — 0 errors; only unrelated existing warnings
- `pnpm run typecheck`
- `pnpm test -- src/app/api/feedback/__tests__/route.test.ts` — 419 passed across 21 files
- `pnpm exec opennextjs-cloudflare build`
- `pnpm exec wrangler deploy --dry-run` — confirmed both `ASKIRIS_BURST (6 requests/60s)` and `FEEDBACK_BURST (5 requests/60s)`

## Deployment note

`namespace_id = "1001"` and `namespace_id = "1002"` must be unique within the Cloudflare account. Change either value before deployment if another Rate Limiting binding already uses it.
