### PR TITLE
Revert "refactor(askiris): use Cloudflare rate limiting for bursts"

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/ai/model";
 import { systemPrompt } from "@/lib/ai/system-prompt";
 import { buildLensTools } from "@/lib/ai/tools";
-import { clientIp, isBypassed, checkDailyTokenBudget, recordTokens } from "@/lib/ai/rate-limit";
+import { clientIp, isBypassed, checkRateLimit, recordTokens } from "@/lib/ai/rate-limit";
 import { chatErrorResponse } from "@/lib/ai/chat-errors";
 import { askirisTurnDataPoint } from "@/lib/analytics/events";
 import { parseSid, parseInternal } from "@/lib/analytics/session";
@@ -69,10 +69,9 @@ export async function POST(req: Request) {
   }
   const { messages, mount, locale, segmentId } = parsed.data;
 
-  // Abuse guard for this public, no-login endpoint. Fail-open by design: with no
-  // Cloudflare bindings (e.g. `next dev`) or on any binding hiccup we proceed rather
-  // than break the chat. The native binding handles the short request burst; KV handles
-  // the custom daily-token budgets. See src/lib/ai/rate-limit.ts.
+  // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
+  // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
+  // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
   const ip = clientIp(req);
   const cookieHeader = req.headers.get("cookie");
   // Read the anonymous visit id set by /api/track; "" for a turn before its first
@@ -91,19 +90,10 @@ export async function POST(req: Request) {
     rateKv = cf.env.RATE_KV;
     ae = cf.env.ANALYTICS;
     ctx = cf.ctx;
-    if (ip && !bypassed) {
-      const burstLimiter = cf.env.ASKIRIS_BURST;
-      if (burstLimiter) {
-        const verdict = await burstLimiter.limit({ key: ip });
-        if (!verdict.success) {
-          return chatErrorResponse("rate_limit", 429);
-        }
-      }
-      if (rateKv) {
-        const verdict = await checkDailyTokenBudget(rateKv, ip);
-        if (!verdict.ok) {
-          return chatErrorResponse("rate_limit", 429);
-        }
+    if (rateKv && ip && !bypassed) {
+      const verdict = await checkRateLimit(rateKv, ip);
+      if (!verdict.ok) {
+        return chatErrorResponse("rate_limit", 429);
       }
     }
   } catch {

--- a/src/app/api/feedback/__tests__/route.test.ts
+++ b/src/app/api/feedback/__tests__/route.test.ts
@@ -1,31 +1,15 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 
-const { mockFeedbackRateLimit } = vi.hoisted(() => ({
-  mockFeedbackRateLimit: vi.fn(),
-}));
-
-vi.mock("@opennextjs/cloudflare", () => ({
-  getCloudflareContext: () => ({
-    env: {
-      FEEDBACK_BURST: { limit: mockFeedbackRateLimit },
-    },
-  }),
-}));
-
-// Mock global fetch so the route never hits GitHub.
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
 // Must set env before importing the route module.
 const env = process.env as Record<string, string | undefined>;
 beforeAll(() => {
   env.GITHUB_TOKEN = "test-token";
   env.GITHUB_FEEDBACK_REPO = "test/repo";
-  mockFeedbackRateLimit.mockResolvedValue({ success: true });
-  mockFetch.mockResolvedValue(
-    new Response(JSON.stringify({ number: 1 }), { status: 201 }),
-  );
 });
+
+// Mock global fetch so the route never hits GitHub.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 
 // Import after env is set so the module picks up the vars.
 const { POST } = await import("../route");
@@ -38,7 +22,7 @@ function makeRequest(body: Record<string, unknown>): Request {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "CF-Connecting-IP": `10.0.${Math.floor(ipCounter / 256)}.${ipCounter % 256}`,
+      "x-forwarded-for": `10.0.${Math.floor(ipCounter / 256)}.${ipCounter % 256}`,
     },
     body: JSON.stringify(body),
   });
@@ -46,24 +30,6 @@ function makeRequest(body: Record<string, unknown>): Request {
 
 afterEach(() => {
   vi.clearAllMocks();
-});
-
-describe("POST /api/feedback — Cloudflare rate limit", () => {
-  it("passes the edge IP to the native rate limiter", async () => {
-    await POST(makeRequest({ type: "general", description: "Great app!" }));
-    expect(mockFeedbackRateLimit).toHaveBeenCalledWith({
-      key: expect.stringMatching(/^10\.0\./),
-    });
-  });
-
-  it("rejects a request when the native rate limiter denies it", async () => {
-    mockFeedbackRateLimit.mockResolvedValueOnce({ success: false });
-
-    const res = await POST(makeRequest({ type: "general", description: "Great app!" }));
-
-    expect(res.status).toBe(429);
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
 });
 
 describe("POST /api/feedback — description validation", () => {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,6 +1,5 @@
-import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextResponse } from "next/server";
-import { RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
+import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
 
 type FeedbackType = "data_issue" | "general";
 
@@ -23,6 +22,8 @@ const MAX_DESCRIPTION_LENGTH = 2000;
 
 // Max length (in code points) of the description snippet used as an issue title.
 const TITLE_SNIPPET_MAX = 60;
+
+const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 5 });
 
 // Collapse a (possibly multi-line) description into a single-line title snippet,
 // truncating at a word boundary with an ellipsis when it exceeds the limit.
@@ -129,20 +130,8 @@ export function GET() {
 }
 
 export async function POST(req: Request) {
-  // The endpoint creates GitHub issues, so rate limiting must be shared across Worker
-  // isolates. Cloudflare-Connecting-IP is edge-provided and cannot be spoofed by the
-  // client. The binding is optional in local development and fails open like /api/chat.
-  try {
-    const ip = req.headers.get("CF-Connecting-IP");
-    const { env } = getCloudflareContext();
-    if (ip && env.FEEDBACK_BURST) {
-      const { success } = await env.FEEDBACK_BURST.limit({ key: ip });
-      if (!success) {
-        return RATE_LIMITED_RESPONSE;
-      }
-    }
-  } catch {
-    // Binding may be unavailable outside the Cloudflare runtime.
+  if (!checkRateLimit(req)) {
+    return RATE_LIMITED_RESPONSE;
   }
 
   let payload: FeedbackPayload;

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -1,20 +1,27 @@
 // Abuse guard for the (public, no-login) /api/chat endpoint, keyed off the caller's
 // Cloudflare edge IP and backed by the RATE_KV namespace.
 //
-// The Cloudflare ASKIRIS_BURST binding owns the short-window request count. This module
-// keeps the two daily TOKEN budgets because their values are only known after a model
-// request finishes and they are not expressible through the native request limiter.
+// Two axes, because they bound different things:
+//   - burst (a request COUNT per minute) bounds the RATE. It's the only check we can
+//     make BEFORE spending anything, and it caps how much a flood can overshoot the
+//     token budgets before their post-request accounting catches up.
+//   - per-IP and global daily TOKEN budgets bound the SPEND (the wallet). Token usage
+//     is only known once a request finishes, so these are checked proactively ("are
+//     we already over?") and incremented afterwards via recordTokens().
 //
 // KV has no atomic increment, so the counters are read-modify-write and thus loose
-// under concurrency. This is cost deterrence, not strict metering.
+// under concurrency — fine here, since the burst gate bounds concurrency and this is
+// deterrence, not strict metering.
 
 export const RATE_LIMIT = {
+  burstPerMinute: 6,
   perIpDailyTokens: 400_000,
   globalDailyTokens: 15_000_000,
 } as const;
 
 const BYPASS_COOKIE = "rate_bypass";
 const DAY_TTL_SECONDS = 2 * 24 * 60 * 60;
+const BURST_TTL_SECONDS = 120;
 
 // Cloudflare sets CF-Connecting-IP to the real client IP and strips any client-sent
 // copy, so it can't be spoofed at the edge. Absent off-Cloudflare (e.g. `next dev`).
@@ -47,13 +54,21 @@ function toCount(raw: string | null): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-// Proactive gate: reject if either daily token budget is already spent. Token usage is
-// added after the request finishes by recordTokens().
-export async function checkDailyTokenBudget(
+// Proactive gate: reject if the burst rate or either daily token budget is already
+// spent. Reserves the burst slot only when letting the request through.
+export async function checkRateLimit(
   kv: KVNamespace,
   ip: string,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
-  const day = Math.floor(Date.now() / 86_400_000);
+  const now = Date.now();
+  const minute = Math.floor(now / 60_000);
+  const day = Math.floor(now / 86_400_000);
+
+  const burstKey = `burst:${ip}:${minute}`;
+  const burst = toCount(await kv.get(burstKey));
+  if (burst >= RATE_LIMIT.burstPerMinute) {
+    return { ok: false, reason: "burst" };
+  }
   if (toCount(await kv.get(`tok:ip:${ip}:${day}`)) >= RATE_LIMIT.perIpDailyTokens) {
     return { ok: false, reason: "ip-daily" };
   }
@@ -61,6 +76,7 @@ export async function checkDailyTokenBudget(
     return { ok: false, reason: "global" };
   }
 
+  await kv.put(burstKey, String(burst + 1), { expirationTtl: BURST_TTL_SECONDS });
   return { ok: true };
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,28 +19,9 @@ GITHUB_FEEDBACK_ASSIGNEES = "sentacraft"
 binding = "ANALYTICS"
 dataset = "xglass_events"
 
-# Short-window request limit for the public /api/chat endpoint. The key is supplied
-# by the Worker at runtime; Cloudflare owns the counter and window.
-[[ratelimits]]
-name = "ASKIRIS_BURST"
-namespace_id = "1001"
-
-  [ratelimits.simple]
-  limit = 6
-  period = 60
-
-# Short-window request limit for the public feedback endpoint. The key is supplied
-# by the Worker at runtime; Cloudflare owns the counter and window.
-[[ratelimits]]
-name = "FEEDBACK_BURST"
-namespace_id = "1002"
-
-  [ratelimits.simple]
-  limit = 5
-  period = 60
-
-# KV counters for /api/chat's per-IP/global daily token budgets. The RATE_LIMIT_BYPASS
-# secret (dashboard / `wrangler secret put`) exempts the developer's own testing.
+# Rate-limit counters for /api/chat (per-IP burst + per-IP/global daily token
+# budgets). The RATE_LIMIT_BYPASS secret (dashboard / `wrangler secret put`) exempts
+# the developer's own testing.
 [[kv_namespaces]]
 binding = "RATE_KV"
 id = "b4eeeb3afdca4f038de649dd3ecbea5f"


### PR DESCRIPTION
Reverts #449.

## Why

The Cloudflare rate limiting binding keeps its counters **per Cloudflare location**, not globally — [the docs](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) state it plainly, along with "intentionally designed to not be used as an accurate accounting system". A caller spread across N locations gets N times the configured limit, so `/api/chat` at 6/60s was really up to 6·N. The KV limiter it replaced used a single global key, so this was not a step up in distributed protection.

Burst limiting is moving to a WAF rate limiting rule instead, which sheds the request before it reaches the Worker — costing neither an invocation nor model tokens.

## What comes back

- The KV burst gate on `/api/chat`, and `checkDailyTokenBudget` reverts to `checkRateLimit`
- The previous `/api/feedback` limiter and its tests
- `ASKIRIS_BURST` / `FEEDBACK_BURST` leave `wrangler.toml`

The daily token budgets are untouched. They were already in KV and stay there: at a 24-hour window with post-request accounting, KV's eventual consistency is noise rather than a defect.

Reverting also removes two issues #449 introduced — a silent fail-open when the binding is absent (which mattered because the burst gate was the only pre-paid limit; the token budgets only bill afterwards), and a `namespace_id` of `1001` copied from the docs example, which is account-scoped and shares counters with any other Worker using the same value.

## Verification

Restores the five files to their exact pre-#449 state (`git diff 9a0d5c1` over those paths is empty). `wrangler types` regenerated without the bindings; nothing references them.

417 unit tests (419 → 417, the two feedback binding tests go with the revert), typecheck, lint and `pnpm run build` pass.
