### PR TITLE
fix(api): return a fresh 429 response per rate-limited request

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
+import { createRateLimiter, rateLimitedResponse } from "@/lib/rate-limit";
 
 type FeedbackType = "data_issue" | "general";
 
@@ -131,7 +131,7 @@ export function GET() {
 
 export async function POST(req: Request) {
   if (!checkRateLimit(req)) {
-    return RATE_LIMITED_RESPONSE;
+    return rateLimitedResponse();
   }
 
   let payload: FeedbackPayload;

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -10,7 +10,7 @@ import { parseFilters } from "@/lib/url/filter-params";
 import { urlSegmentToMount } from "@/lib/mount";
 import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { routing } from "@/i18n/routing";
-import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
+import { createRateLimiter, rateLimitedResponse } from "@/lib/rate-limit";
 
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
@@ -31,7 +31,7 @@ export function GET(req: Request) {
   }
 
   if (!checkRateLimit(req)) {
-    return RATE_LIMITED_RESPONSE;
+    return rateLimitedResponse();
   }
 
   const { searchParams } = new URL(req.url);

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -4,7 +4,7 @@ import { buildLensSearchIndex, searchLensIndex, type LensSearchIndex } from "@/l
 import { urlSegmentToMount } from "@/lib/mount";
 import type { Mount } from "@/lib/types";
 import { routing } from "@/i18n/routing";
-import { createRateLimiter, RATE_LIMITED_RESPONSE } from "@/lib/rate-limit";
+import { createRateLimiter, rateLimitedResponse } from "@/lib/rate-limit";
 
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
@@ -33,7 +33,7 @@ export function GET(req: Request) {
   }
 
   if (!checkRateLimit(req)) {
-    return RATE_LIMITED_RESPONSE;
+    return rateLimitedResponse();
   }
 
   const { searchParams } = new URL(req.url);

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { rateLimitedResponse } from "../rate-limit";
+
+describe("rateLimitedResponse", () => {
+  it("returns a 429 carrying the rate_limited error", async () => {
+    const res = rateLimitedResponse();
+    expect(res.status).toBe(429);
+    await expect(res.json()).resolves.toEqual({ error: "rate_limited" });
+  });
+
+  it("gives every caller its own readable body", async () => {
+    const first = rateLimitedResponse();
+    const second = rateLimitedResponse();
+
+    await expect(first.json()).resolves.toEqual({ error: "rate_limited" });
+    // A shared instance would fail here: the first read consumes the stream, and
+    // the second request's response would throw instead of returning 429.
+    await expect(second.json()).resolves.toEqual({ error: "rate_limited" });
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -37,7 +37,9 @@ export function createRateLimiter({ windowMs, max }: RateLimiterOptions) {
   };
 }
 
-export const RATE_LIMITED_RESPONSE = NextResponse.json(
-  { error: "rate_limited" },
-  { status: 429 },
-);
+// A function, not a shared constant: a Response body is a stream that can only be
+// consumed once, so returning the same instance from a second rate-limited request
+// throws on read and the caller gets a 500 instead of a 429.
+export function rateLimitedResponse(): NextResponse {
+  return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+}


### PR DESCRIPTION
`RATE_LIMITED_RESPONSE` was a module-level `NextResponse`. A `Response` body is a stream that can only be consumed once, so the **second** rate-limited request served by the same isolate returned an already-read body — the caller got a 500 instead of a 429.

It is now `rateLimitedResponse()`, called at each of the three sites (`/api/feedback`, `/api/lenses`, `/api/lenses/search`).

## Verification

The regression test asserts that two calls each yield a readable body. Against the old shared instance it fails with the real error:

```
AssertionError: promise rejected "TypeError: Body is unusable: Body has alr…" instead of resolving
Caused by: TypeError: Body is unusable: Body has already been read
```

419 unit tests (417 → 419), typecheck, lint and `pnpm run build` pass.

## Reachability

`/api/lenses` and `/api/lenses/search` return 404 in production, so only `/api/feedback` could hit this on the deployed Worker — and only when the same isolate rate-limits twice.
