### PR TITLE
chore(api): record where each endpoint's rate limiting is headed

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -72,6 +72,17 @@ export async function POST(req: Request) {
   // Abuse guard for this public, no-login endpoint. Fail-open by design: with no KV
   // binding (e.g. `next dev`) or on any KV hiccup we proceed unlimited rather than
   // break the chat. See src/lib/ai/rate-limit.ts for the burst + daily-token design.
+  //
+  // TODO: move the burst half to a WAF rate limiting rule, so a flood is shed at the
+  // edge without costing a Worker invocation or a model call. Two things the rule has
+  // to carry: the bypass cookie below must appear in its match expression, since the
+  // bypass has to skip the burst gate as well; and the secret then lives in firewall
+  // config as well as in RATE_LIMIT_BYPASS, so rotating it is a two-step.
+  //
+  // The daily token budgets stay here. A WAF rule counts requests, not tokens, its
+  // counting window tops out at one hour, and it cannot count site-wide at all —
+  // complexity-based counting is Enterprise-only and reads a response header, which
+  // a streamed reply has already sent before the token count is known.
   const ip = clientIp(req);
   const cookieHeader = req.headers.get("cookie");
   // Read the anonymous visit id set by /api/track; "" for a turn before its first

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -23,6 +23,14 @@ const MAX_DESCRIPTION_LENGTH = 2000;
 // Max length (in code points) of the description snippet used as an issue title.
 const TITLE_SNIPPET_MAX = 60;
 
+// Per-isolate, so on Workers this bounds one isolate's traffic rather than a
+// caller's: the platform runs as many isolates as it likes and each gets a fresh
+// counter. It is a speed bump, not a limit.
+//
+// TODO: replace with a WAF rate limiting rule, which counts at the edge and sheds
+// the request before it reaches the Worker. Not the Workers rate limiting binding
+// — its counters are per Cloudflare location, so a caller spread across N
+// locations gets N times the limit.
 const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 5 });
 
 // Collapse a (possibly multi-line) description into a single-line title snippet,

--- a/src/app/api/lenses/route.ts
+++ b/src/app/api/lenses/route.ts
@@ -10,9 +10,6 @@ import { parseFilters } from "@/lib/url/filter-params";
 import { urlSegmentToMount } from "@/lib/mount";
 import { OPTICAL_TRAITS, type OpticalTrait } from "@/lib/types";
 import { routing } from "@/i18n/routing";
-import { createRateLimiter, rateLimitedResponse } from "@/lib/rate-limit";
-
-const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
 function computeAvailableOpticalTraits(lenses: { isCine?: boolean; opticalTraits?: OpticalTrait[] }[]): OpticalTrait[] {
   const present = new Set(
@@ -26,12 +23,11 @@ export function GET(req: Request) {
   // BFF, never external-facing. 404 in production until that lands so it is not
   // a live, full-dataset surface. (A page would call notFound(); a route
   // handler returns the 404 response directly.)
+  //
+  // TODO: this endpoint carries no rate limit. Add one together with the BFF that
+  // makes it reachable — as a WAF rate limiting rule, not in code.
   if (process.env.NODE_ENV === "production") {
     return new NextResponse(null, { status: 404 });
-  }
-
-  if (!checkRateLimit(req)) {
-    return rateLimitedResponse();
   }
 
   const { searchParams } = new URL(req.url);

--- a/src/app/api/lenses/search/route.ts
+++ b/src/app/api/lenses/search/route.ts
@@ -4,9 +4,6 @@ import { buildLensSearchIndex, searchLensIndex, type LensSearchIndex } from "@/l
 import { urlSegmentToMount } from "@/lib/mount";
 import type { Mount } from "@/lib/types";
 import { routing } from "@/i18n/routing";
-import { createRateLimiter, rateLimitedResponse } from "@/lib/rate-limit";
-
-const checkRateLimit = createRateLimiter({ windowMs: 60_000, max: 120 });
 
 const MAX_QUERY_LENGTH = 200;
 const DEFAULT_LIMIT = 8;
@@ -28,12 +25,10 @@ export function GET(req: Request) {
   // Dormant endpoint with no consumers today — search runs client-side in the
   // browser (see LensSearchDialog). Reserved for a future internal BFF, never
   // external-facing; 404 in production until then, mirroring /api/lenses.
+  // TODO: this endpoint carries no rate limit. Add one together with the BFF that
+  // makes it reachable — as a WAF rate limiting rule, not in code.
   if (process.env.NODE_ENV === "production") {
     return new NextResponse(null, { status: 404 });
-  }
-
-  if (!checkRateLimit(req)) {
-    return rateLimitedResponse();
   }
 
   const { searchParams } = new URL(req.url);


### PR DESCRIPTION
Stacked on #453 — merge that first.

Comments and TODOs only, plus the removal of two limiters that guarded nothing. No limiting behaviour changes.

## Per endpoint

| Endpoint | Reachable in prod | Now | Change |
|---|---|---|---|
| `/api/chat` | yes | KV burst + per-IP and site-wide daily token budgets | TODO: burst → WAF rule |
| `/api/feedback` | yes | in-memory limiter | labelled as per-isolate; TODO: → WAF rule |
| `/api/track` | yes | none, deliberately | — |
| `/api/telemetry` | yes | none, deliberately | — |
| `/api/lenses` | no (404) | in-memory limiter | **removed**, TODO left |
| `/api/lenses/search` | no (404) | in-memory limiter | **removed**, TODO left |

## Why the two removals

Both endpoints return 404 in production. The limiter guarded nothing while implying protection existed — and it was an in-memory `Map`, which on Workers bounds a single isolate rather than a caller. The TODO records that whatever makes them reachable has to bring a real limit with it.

`createRateLimiter` stays; `/api/feedback` is now its only caller.

## Why the daily token budgets do not move to WAF

Recorded at the call site so it is not re-derived later. A WAF rate limiting rule counts requests, not tokens; its counting window tops out at one hour, so a daily budget cannot be expressed; and it cannot count site-wide at all, since at least one counting characteristic is required. Complexity-based counting — the one mechanism that counts cost rather than requests — is Enterprise-only and reads a **response** header, which a streamed reply has already sent before the token count is known.

## Why not the Workers rate limiting binding

Its counters are per Cloudflare location, so a caller spread across N locations gets N times the limit. That was #449, reverted in #452.

## `/api/track` and `/api/telemetry`

Untouched. Both file headers already state the decision — unlimited behind Cloudflare's platform DDoS and bot protection, with size-capped and shape-validated bodies.

419 unit tests, typecheck, lint and `pnpm run build` pass.
