### PR TITLE
fix(askiris): hand lensDetails results back as refs, not raw ids

### DIFF
--- a/src/lib/ai/__tests__/tools.test.ts
+++ b/src/lib/ai/__tests__/tools.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { buildLensTools } from "../tools";
+
+const tools = buildLensTools("X", "zh", (brand) => brand);
+
+// The AI SDK types `execute` as optional and passes call options every tool here ignores.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const run = (tool: { execute?: (...args: any[]) => any }, input: unknown) =>
+  tool.execute!(input, {} as never);
+
+// Walk a tool payload for the raw catalogue id. Ids are patterned (brand-model slugs), so
+// one in context is enough for a model to guess others and cite a lens it never recalled —
+// which is the whole reason refs exist.
+function idsIn(node: unknown, path: string, found: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => idsIn(item, `${path}[${i}]`, found));
+    return;
+  }
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id") {
+      found.push(`${path}.id = ${String(value)}`);
+    }
+    idsIn(value, `${path}.${key}`, found);
+  }
+}
+
+describe("lensDetails hands the model refs, never ids", () => {
+  it("returns a ref per lens and no id anywhere in the payload", async () => {
+    // lensDetails only resolves refs the same turn already recalled, so seed the gate.
+    const recall = await run(tools.queryLenses, { type: "prime" });
+    const refs = recall.matches.slice(0, 3).map((lens: { ref: string }) => lens.ref);
+    expect(refs.length).toBeGreaterThan(0);
+
+    const details = await run(tools.lensDetails, { refs });
+
+    expect(details.lenses.map((lens: { ref?: string }) => lens.ref)).toEqual(refs);
+
+    const found: string[] = [];
+    idsIn(details, "lensDetails", found);
+    expect(found).toEqual([]);
+  });
+
+  it("still carries the long-tail specs a recall result leaves out", async () => {
+    const recall = await run(tools.queryLenses, { type: "prime" });
+    const [ref] = recall.matches.map((lens: { ref: string }) => lens.ref);
+    const details = await run(tools.lensDetails, { refs: [ref] });
+
+    // Dropping the id must not turn into dropping the payload: these are exactly what
+    // the tool exists to fetch, and none of them appears in a recall result.
+    expect(Object.keys(details.lenses[0])).toEqual(
+      expect.arrayContaining([
+        "lensConfiguration",
+        "filterMm",
+        "apertureBladeCount",
+        "focusMotor",
+        "internalFocusing",
+      ]),
+    );
+  });
+});

--- a/src/lib/ai/__tests__/tools.test.ts
+++ b/src/lib/ai/__tests__/tools.test.ts
@@ -27,6 +27,26 @@ function idsIn(node: unknown, path: string, found: string[]): void {
   }
 }
 
+// The gate and the payload are two readings of the same question — "what did this call
+// surface?" — so they have to come from one place. searchLensByName used to answer it
+// twice, hashing the id for the gate and again inside the projection for the payload.
+describe("a recall tool's gate accepts exactly what it returned", () => {
+  it.each([
+    ["queryLenses", { type: "prime" }, (out: { matches: { ref: string }[] }) => out.matches],
+    ["searchLensByName", { query: "35" }, (out: { results: { ref: string }[] }) => out.results],
+  ])("%s", async (name, input, pick) => {
+    const tools = buildLensTools("X", "zh", (brand) => brand);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refs = pick(await run((tools as any)[name], input)).map((lens) => lens.ref);
+    expect(refs.length).toBeGreaterThan(0);
+
+    // lensDetails throws on a ref the turn never recalled, so resolving every one of
+    // them is the gate asserting it holds what the payload advertised.
+    const details = await run(tools.lensDetails, { refs: refs.slice(0, 6) });
+    expect(details.lenses.map((lens: { ref: string }) => lens.ref)).toEqual(refs.slice(0, 6));
+  });
+});
+
 describe("lensDetails hands the model refs, never ids", () => {
   it("returns a ref per lens and no id anywhere in the payload", async () => {
     // lensDetails only resolves refs the same turn already recalled, so seed the gate.

--- a/src/lib/ai/recall.ts
+++ b/src/lib/ai/recall.ts
@@ -240,6 +240,17 @@ export function toRecalled(lens: ResolvedLens): RecalledLens {
   };
 }
 
+// What lensDetails hands back: the full record with the opaque handle in place of the
+// id, the same substitution toRecalled makes. Nothing renders this tool's output, so the
+// id reached the model and no one else — and an id in context is a patterned handle the
+// model can extend into lenses it never recalled.
+export type DetailedLens = Omit<ResolvedLens, "id"> & { ref: string };
+
+export function toDetailed(lens: ResolvedLens): DetailedLens {
+  const { id, ...rest } = lens;
+  return { ref: lensRef(id), ...rest };
+}
+
 // A resolved lens the model has chosen to recommend, carrying its authored reason.
 export type Recommendation = ResolvedLens & { reason: string };
 

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -8,6 +8,7 @@ import {
   recommendLenses,
   listLenses,
   resolveLens,
+  toDetailed,
   toRecalled,
   RECALL_SORT_NAMES,
   LENS_TABLE_COLUMNS,
@@ -210,7 +211,7 @@ export function buildLensTools(
             if (!lens) {
               throw new Error(`Unknown lens ref "${ref}".`);
             }
-            return resolveLens(lens, locale, tBrand);
+            return toDetailed(resolveLens(lens, locale, tBrand));
           }),
         };
       },

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -171,13 +171,17 @@ export function buildLensTools(
       }),
       execute: ({ query, limit }) => {
         const index = buildLensSearchIndex(getLensesByMount(mount, locale));
-        const results = searchLensIndex(index, query, limit ?? 8);
-        for (const lens of results) {
-          recalledRefs.add(lensRef(lens.id));
-        }
         // Same projection as a recall: a name lookup is still the model choosing between
         // lenses, so it gets refs and the fields to choose on — never the id.
-        return { results: results.map((lens) => toRecalled(resolveLens(lens, locale, tBrand))) };
+        const results = searchLensIndex(index, query, limit ?? 8).map((lens) =>
+          toRecalled(resolveLens(lens, locale, tBrand)),
+        );
+        // Refs read off the projection, the way queryLenses does it, so the gate and the
+        // payload cannot disagree about what this call surfaced.
+        for (const lens of results) {
+          recalledRefs.add(lens.ref);
+        }
+        return { results };
       },
     }),
 


### PR DESCRIPTION
Two changes at the model boundary, where the catalogue id becomes an opaque ref.

## 1. `lensDetails` returned raw ids

Every other tool replaces the catalogue id with a ref before the model sees it. `toRecalled` states the reason: ids are patterned, so one left in context lets the model reconstruct others and cite a lens it never recalled — "leaving both in context would leave the patterned one to be reconstructed, which is the failure being fixed." `lensDetails` returned `resolveLens()` untouched and put the id straight back.

**Why `execute` and not `toModelOutput`.** `recommendLenses` and `listLenses` use `toModelOutput` because their output legitimately differs between consumers: the client renders the full record, the model needs only a lean ack. `lensDetails` has no such split — it renders nothing, and the client maps it to a `"gathering"` activity label without ever reading the output. So the id was reaching the model and no one else. Projecting it away in `execute` keeps it out of the response body too, rather than shipping a field with no consumer on either end.

`ResolvedLens` keeps its `id`: the recommendation card needs it for the lens link and the thumbnail. The new `DetailedLens` projection is scoped to this one tool.

The long-tail specs the tool exists to fetch — optical construction, filter thread, aperture blades, focus motor, internal focusing — are untouched, and a test pins them so dropping the id cannot quietly turn into dropping the payload.

## 2. `searchLensByName` computed each ref twice

The gate and the payload answer the same question — what did this call surface? — so they should come from one place. `searchLensByName` hashed each id for `recalledRefs`, then hashed it again inside `toRecalled` for the result. `queryLenses` already reads `lens.ref` off the projection; the two tools are now the same shape.

No behavior change — both paths produced the same ref. The accompanying test pins the contract underneath rather than the refactor: whatever a recall tool returns, `lensDetails` must accept, since it throws on a ref the turn never recalled.

## Verification

The `lensDetails` regression test fails on `main` (`ref` comes back `undefined`) and passes here. Full suite 423 passing, lint clean, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)