### PR TITLE
refactor(askiris): send eval turns through the SDK's chat transport

### DIFF
--- a/eval/promptfoo/README.md
+++ b/eval/promptfoo/README.md
@@ -31,13 +31,15 @@ the dev server**. The test-hook panel's AskIris tab shows what is actually live.
 
 ## How it's built
 
-- **`provider.mjs`** — a custom promptfoo provider. It POSTs each turn to `/api/chat`,
-  rebuilds the streamed assistant message with the AI SDK's `readUIMessageStream` (threading
-  prior turns back in for multi-turn cases), and returns two things: the ordered transcript
-  (prose + recommendation cards, for the judge) and the structured tool-call trace on
-  `metadata` (for the deterministic checks). This adapter is the only bespoke code — the
-  transport (AI-SDK UI-message SSE) and domain (a `recommendLenses` output _is_ a card deck)
-  are ours; everything else is promptfoo's.
+- **`provider.mjs`** — a custom promptfoo provider. It sends each turn to `/api/chat`
+  through the AI SDK's `DefaultChatTransport` — the same transport `useChat` hands the
+  browser, so the eval issues the request the real client builds rather than a second
+  implementation of it — rebuilds the streamed assistant message with `readUIMessageStream`
+  (threading prior turns back in for multi-turn cases), and returns two things: the ordered
+  transcript (prose + recommendation cards, for the judge) and the structured tool-call
+  trace on `metadata` (for the deterministic checks). What remains bespoke is the reading of
+  a turn, not the moving of it: the domain mapping (a `recommendLenses` output _is_ a card
+  deck) is ours; everything else is the SDK's or promptfoo's.
 - **`promptfooconfig.yaml`** — the cases and their graders, two tiers:
   - `javascript` assertions check invariants against the **tool-call trace** (did it sort by
     reach? do the picks stay in the focal band? is any pick over budget?). These read

--- a/eval/promptfoo/provider.mjs
+++ b/eval/promptfoo/provider.mjs
@@ -2,7 +2,7 @@
 // message with readUIMessageStream, return the transcript + tool-call trace for
 // the assertions. See README.md.
 import { readFileSync } from "node:fs";
-import { readUIMessageStream } from "ai";
+import { DefaultChatTransport, readUIMessageStream } from "ai";
 // The real implementation, not a copy of it: a second version of the hash would drift
 // silently and the eval would just measure the wrong thing. Node strips the types.
 import { lensRef, LENS_LINK_PREFIX } from "../../src/lib/ai/lens-ref.ts";
@@ -45,31 +45,20 @@ function formatCard(rec) {
   return `- ${rec.name} · ${focal} · ${ap} · ${rec.weightG ?? "?"}g · ${price}${reason}`;
 }
 
-// POST one turn's running history, rebuild the assistant UIMessage via the SDK.
+// The same transport the browser uses: AskIrisChat's useChat() takes the default, which
+// is this class. Going through it means the eval exercises the request the real client
+// builds — turn history, chunk protocol and all — instead of a second implementation of
+// it that can drift from the route without anything failing.
+const transport = new DefaultChatTransport({ api: ENDPOINT });
+
+// POST one turn's running history, rebuild the assistant UIMessage via the SDK. mount and
+// locale ride in `body`, exactly as the client passes them per send.
 async function postTurn(messages, mount, locale) {
-  const res = await fetch(ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages, mount, locale }),
-  });
-  const body = await res.text();
-  const chunks = [];
-  for (const line of body.split("\n")) {
-    if (line.startsWith("data: ")) {
-      try {
-        chunks.push(JSON.parse(line.slice(6)));
-      } catch {
-        // keep-alive / non-JSON — skip
-      }
-    }
-  }
-  const stream = new ReadableStream({
-    start(c) {
-      for (const x of chunks) {
-        c.enqueue(x);
-      }
-      c.close();
-    },
+  const stream = await transport.sendMessages({
+    chatId: "eval",
+    messages,
+    trigger: "submit-message",
+    body: { mount, locale },
   });
   let msg = null;
   for await (const m of readUIMessageStream({ stream, onError: () => {} })) {


### PR DESCRIPTION
Closes the two follow-ups left on the eval provider: replace the hand-written SSE parsing, and settle whether it needs an AI SDK `Chat`.

## The parsing

`postTurn` buffered the whole response, split it on newlines, sliced past `data: `, `JSON.parse`d each line, then wrapped the chunks back into a `ReadableStream` so `readUIMessageStream` could read them. That is a second implementation of a protocol the SDK owns, and it could drift from the route with nothing failing to say so.

`DefaultChatTransport.sendMessages()` returns `Promise<ReadableStream<UIMessageChunk>>` — exactly what `readUIMessageStream` consumes — so the parsing goes away.

The point is fidelity, not brevity. `AskIrisChat` calls `useChat()` with no transport, which means it gets `DefaultChatTransport`, and passes `{ mount, locale, segmentId }` per send via `body`. The eval now goes through that same class, so it issues the request the browser issues instead of an approximation of it. The extra `id` and `trigger` the transport sends are dropped by the route's non-strict schema; `createUIMessageStreamResponse` on the other end is what the transport expects.

## No `Chat` needed

`useChat` is a React hook and unusable here, and while `ai` does export a framework-agnostic `AbstractChat`, the provider does not need it. `Chat` manages client session state — the message list, status, regeneration — and the provider already threads its own `messages` array across turns. The transport alone is the piece it was missing.

## Verification

By equivalence, not inspection. Both providers — the one on `main` and this one — were run against a single stubbed `/api/chat` response covering prose containing a lens link, a `queryLenses` recall, a `recommendLenses` deck, and a `listLenses` table. `callApi`'s full return, transcript plus all thirteen `metadata` keys, is `deepEqual` across the change.

Suite 423 passing, lint clean, typecheck clean. The harness itself was throwaway and is not committed — the eval is run manually against a live dev server and has no CI coverage to add it to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)