### PR TITLE
fix(askiris): align the judge transcript with what a rubric grades

### DIFF
--- a/eval/promptfoo/provider.mjs
+++ b/eval/promptfoo/provider.mjs
@@ -32,17 +32,15 @@ const REF_TO_ID = new Map(
     .map((lens) => [lensRef(lens.id), lens.id]),
 );
 
+// One card as the judge reads it, carrying what the rubrics actually grade: the display
+// name, which is also the handle the web-searching judge audits the pick by, and the
+// reason, which is the card-quality standard's whole subject. Specs stay out — the
+// rendered card shows none of them — and so does the price, which every rubric treats as
+// a by-design reference figure rather than a claim to grade.
 function formatCard(rec) {
-  const f = rec.focalNativeMm;
-  const focal = Array.isArray(f) ? (f[0] === f[1] ? `${f[0]}mm` : `${f[0]}-${f[1]}mm`) : "?";
-  const a = rec.maxAperture;
-  const ap = Array.isArray(a) ? `F${a[0]}-${a[1]}` : `F${a}`;
-  const p = rec.price;
-  const price = p ? `${p.currency === "CNY" ? "¥" : "$"}${p.amount}` : "no price";
-  // The reason is the card's real payload (what it's good for + its trade-off), so
-  // a judge grading card quality or honest trade-offs must see it, not just specs.
+  const weight = rec.weightG != null ? ` · ${rec.weightG}g` : "";
   const reason = rec.reason?.trim() ? `\n    ${rec.reason.trim()}` : "";
-  return `- ${rec.name} · ${focal} · ${ap} · ${rec.weightG ?? "?"}g · ${price}${reason}`;
+  return `- ${rec.name}${weight}${reason}`;
 }
 
 // The same transport the browser uses: AskIrisChat's useChat() takes the default, which

--- a/eval/promptfoo/provider.mjs
+++ b/eval/promptfoo/provider.mjs
@@ -32,15 +32,14 @@ const REF_TO_ID = new Map(
     .map((lens) => [lensRef(lens.id), lens.id]),
 );
 
-// One card as the judge reads it, carrying what the rubrics actually grade: the display
-// name, which is also the handle the web-searching judge audits the pick by, and the
-// reason, which is the card-quality standard's whole subject. Specs stay out — the
-// rendered card shows none of them — and so does the price, which every rubric treats as
-// a by-design reference figure rather than a claim to grade.
+// One card as the judge reads it: the display name — also the handle the web-searching
+// judge audits a pick by — and the reason, which is the card-quality standard's whole
+// subject. The bar for adding a field here is that some rubric grades it; a spec no
+// rubric reads only invites the judge to weigh something nobody is asking about.
+// RecommendationDeck.tsx renders the card this mirrors.
 function formatCard(rec) {
-  const weight = rec.weightG != null ? ` · ${rec.weightG}g` : "";
   const reason = rec.reason?.trim() ? `\n    ${rec.reason.trim()}` : "";
-  return `- ${rec.name}${weight}${reason}`;
+  return `- ${rec.name}${reason}`;
 }
 
 // The same transport the browser uses: AskIrisChat's useChat() takes the default, which
@@ -200,8 +199,12 @@ function digest(msg) {
       const ids = part.output.lenses.map((l) => l.id);
       const columns = Array.isArray(part.output.columns) ? part.output.columns : [];
       tables.push({ ids, columns, names: part.output.lenses.map((l) => l.name ?? null) });
+      // The caption is prose the model wrote for the reader, and LensTable renders it
+      // above the table — so the rubrics that grade prose have to see it. Cell values
+      // stay out: no rubric reads them. LensTable.tsx renders the table this mirrors.
+      const caption = part.output.caption?.trim() ? `\n${part.output.caption.trim()}` : "";
       transcript.push(
-        `[table: ${columns.join(", ")}]\n${part.output.lenses
+        `[table: ${columns.join(", ")}]${caption}\n${part.output.lenses
           .map((l) => `- ${l.name}`)
           .join("\n")}`,
       );

--- a/src/components/askiris/LensTable.tsx
+++ b/src/components/askiris/LensTable.tsx
@@ -63,6 +63,11 @@ function priceCell(price: NonNullable<ResolvedLens["price"]>, usedLabel: string)
 // has no data for it — rendered as a dash). Values run through the shared format
 // helpers; enum-like values (focus, WR, aperture ring) resolve through localized
 // labels rather than raw booleans.
+//
+// EVAL MIRROR — the table block in eval/promptfoo/provider.mjs hand-writes what the
+// judges read, and nothing keeps the two in step. It carries the caption and the lens
+// names but no cell values, because no rubric reads them; adding a column here is a
+// change to this table only until a rubric starts grading what the cells say.
 const RENDERERS: Record<LensTableColumn, (lens: ResolvedLens, l: Labels) => string | null> = {
   focalEquiv: (lens) => focalRangeDisplay(lens.focalEquivMm[0], lens.focalEquivMm[1]),
   focalNative: (lens) => focalRangeDisplay(lens.focalNativeMm[0], lens.focalNativeMm[1]),

--- a/src/components/askiris/RecommendationDeck.tsx
+++ b/src/components/askiris/RecommendationDeck.tsx
@@ -48,6 +48,11 @@ function priceParts(
 // Two rows: a header (thumbnail + name + price/weight) and the reason on its own
 // full-width row below, so the reason spans the whole card instead of a narrow
 // column beside the thumbnail — fewer wrapped lines, better use of the space.
+//
+// EVAL MIRROR — `formatCard` in eval/promptfoo/provider.mjs hand-writes what the
+// judges read for a card, and nothing keeps the two in step. Changing what this card
+// shows means deciding whether that string changes too: a field belongs there only if
+// some rubric in promptfooconfig.yaml grades it.
 function RecommendationCard({ rec }: { rec: Recommendation }) {
   const locale = useLocale();
   const weight = rec.weightG != null ? weightDisplay(rec.weightG, "g") : null;


### PR DESCRIPTION
One rule, applied in both directions: **the judge reads what a rubric grades.**

## Before / after

For a turn that recommends a lens and then tables it:

```diff
 [cards]
-- 富士 XF56mmF1.2 R · 56mm · F1.2 · 405g · ¥4999
+- 富士 XF56mmF1.2 R
     原厂人像头的标准答案，虚化过渡最好看。代价是对焦不快，抓拍小孩会吃力。

 [table: focalEquiv, aperture, weight, price]
++两支的硬指标对比
 - 富士 XF56mmF1.2 R
```

## What came out

**Focal length and aperture.** The rendered card shows neither. Every judge was reading — and the web-searching one auditing — specs no reader can see.

**Price.** It is on the card, but printing it into the transcript is what forced two rubrics to defend against it. The price guard states that a figure printed on a card or table row "is not what this checks", and the comment beside it explains why: card rows "always carry a bare reference price by design, and a judge that counts those would fail every deck." The search grader likewise says to "treat any price shown as accurate and for reference only."

**Weight.** Kept in the first pass on the grounds that no rubric had to work around it — which is not the rule. The rule is whether a rubric grades it, and none does; no case in the suite even asks about weight. When one arrives, weight comes back together with the rubric that wants it.

## What went in

**The table caption.** It is prose the model wrote for the reader, and `LensTable` renders it above the table — but the transcript dropped it silently. The rubrics that grade prose (the narration floor, the connective-prose half of the card standard) were missing a sentence the user actually reads.

Cell values stay out: no rubric reads them.

## What is left

The display name — a model designation, not an id, and the handle the web-searching judge audits a pick by — and the reason, which is the card-quality standard's whole subject.

## Not affected

`metadata` is untouched, so no deterministic assertion moves. Verified against a stubbed turn exercising all three surfaces (prose with inline lens references, a card deck, a table): `picks`, `tables` and the full `metadata` key set are byte-identical; only the transcript string differs.

## Keeping it in step

Nothing structural ties the transcript to the components it mirrors. Enforcing it in types — a view type per surface with an exhaustive `Record<keyof View, …>` serializer, the way `LensTable`'s `RENDERERS` is already exhaustive over `LensTableColumn` — was considered and judged too heavy for the project at this size. Both components now carry an `EVAL MIRROR` note stating the coupling and the rule for changing it.

## Noted, not fixed

`metadata.picks` carries `price` as a bare amount with no `condition`, so neither a judge nor a JS assertion can currently tell a new-price pick from a used listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)